### PR TITLE
Updates to cross_multiplier and dsp48_bram_vacc

### DIFF
--- a/casper_library/casper_library_accumulators.mdl
+++ b/casper_library/casper_library_accumulators.mdl
@@ -44,8 +44,8 @@ Library {
 	ViewObjType		"SimulinkTopLevel"
 	LoadSaveID		"0"
 	Extents			[1884.0, 1003.0]
-	ZoomFactor		[4.034782608695652]
-	Offset			[14.78017241379311, 13.53017241379311]
+	ZoomFactor		[4.03]
+	Offset			[14.776054590570709, 13.526054590570723]
       }
     }
   }
@@ -55,9 +55,9 @@ Library {
   ModifiedByFormat	  "%<Auto>"
   LastModifiedBy	  "dbeuser"
   ModifiedDateFormat	  "%<Auto>"
-  LastModifiedDate	  "Wed May 13 15:56:36 2015"
-  RTWModifiedTimeStamp	  353433392
-  ModelVersionFormat	  "1.%<AutoIncrement:16>"
+  LastModifiedDate	  "Fri May 22 10:43:15 2015"
+  RTWModifiedTimeStamp	  354192169
+  ModelVersionFormat	  "1.%<AutoIncrement:19>"
   ConfigurationManager	  "None"
   SampleTimeColors	  off
   SampleTimeAnnotations	  off
@@ -22130,7 +22130,7 @@ Library {
 	TiledPageScale		1
 	ShowPageBoundaries	off
 	ZoomFactor		"150"
-	SIDHighWatermark	"68"
+	SIDHighWatermark	"73"
 	Block {
 	  BlockType		  Inport
 	  Name			  "new_acc"
@@ -22345,6 +22345,37 @@ Library {
 	}
 	Block {
 	  BlockType		  Reference
+	  Name			  "Delay"
+	  SID			  "588:71"
+	  Ports			  [1, 1]
+	  Position		  [735, 209, 770, 231]
+	  ZOrder		  5
+	  LibraryVersion	  "1.2"
+	  SourceBlock		  "xbsIndex_r4/Delay"
+	  SourceType		  "Xilinx Delay Block"
+	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
+	  rst			  off
+	  infoeditControl	  "Selection of Reset will increase slice count due to use of real FFs and instead of SRLs"
+	  en			  off
+	  latency		  "1"
+	  dbl_ovrd		  off
+	  reg_retiming		  off
+	  xl_use_area		  off
+	  xl_area		  "[0,0,0,0,0,0,0]"
+	  has_advanced_control	  "0"
+	  sggui_pos		  "-7,19,416,361"
+	  block_type		  "delay"
+	  sg_icon_stat		  "35,22,1,1,white,blue,0,07b98262,right,,[ ],[ ]"
+	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 35 35 0 0 ],[0 0 22 22 0 ],[0.77 0.82 0.91"
+	  " ]);\nplot([0 35 35 0 0 ],[0 0 22 22 0 ]);\npatch([10.325 14.66 17.66 20.66 23.66 17.66 13.325 10.325 ],[14.33 14.3"
+	  "3 17.33 14.33 17.33 17.33 17.33 14.33 ],[1 1 1 ]);\npatch([13.325 17.66 14.66 10.325 13.325 ],[11.33 11.33 14.33 14"
+	  ".33 11.33 ],[0.931 0.946 0.973 ]);\npatch([10.325 14.66 17.66 13.325 10.325 ],[8.33 8.33 11.33 11.33 8.33 ],[1 1 1 "
+	  "]);\npatch([13.325 23.66 20.66 17.66 14.66 10.325 13.325 ],[5.33 5.33 8.33 5.33 8.33 8.33 5.33 ],[0.931 0.946 0.973"
+	  " ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\n\ncolor('black');disp('"
+	  "z^{-1}','texmode','on');\nfprintf('','COMMENT: end icon text');"
+	}
+	Block {
+	  BlockType		  Reference
 	  Name			  "Inverter"
 	  SID			  "588:7"
 	  Ports			  [1, 1]
@@ -22372,38 +22403,6 @@ Library {
 	  ".55 29.44 27.44 25.44 23.44 20.55 22.55 ],[4.22 4.22 6.22 4.22 6.22 6.22 4.22 ],[0.931 0.946 0.973 ]);\nfprintf('',"
 	  "'COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\n\ncolor('black');disp('not');\nfprintf('"
 	  "','COMMENT: end icon text');\n"
-	}
-	Block {
-	  BlockType		  Reference
-	  Name			  "Reinterpret"
-	  SID			  "588:8"
-	  Ports			  [1, 1]
-	  Position		  [775, 82, 825, 98]
-	  ZOrder		  -8
-	  LibraryVersion	  "1.2"
-	  SourceBlock		  "xbsIndex_r4/Reinterpret"
-	  SourceType		  "Xilinx Type Reinterpreter Block"
-	  infoedit		  "Changes signal type without altering the binary representation.   You can change the signal between si"
-	  "gned and unsigned, and relocate the binary point.<br><br>Hardware notes: In hardware this block costs nothing.<br><"
-	  "br>Example:  Suppose the input is 6 bits wide, signed, with 2 fractional bits, and the output is forced to unsigned"
-	  " with 0 fractional bits.  Then an input of -2.0 (1110.00 in binary 2's complement) becomes an output of 56 (111000 "
-	  "in binary)."
-	  force_arith_type	  on
-	  arith_type		  "Signed  (2's comp)"
-	  force_bin_pt		  on
-	  bin_pt		  "max(0, bin_pt_in - (48 - n_bits_out))"
-	  has_advanced_control	  "0"
-	  sggui_pos		  "-9,19,372,364"
-	  block_type		  "reinterpret"
-	  block_version		  "10.1.3"
-	  sg_icon_stat		  "50,16,1,1,white,blue,0,6b04d0b0,right,,[ ],[ ]"
-	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 16 16 0 ],[0.77 0.82 0.91"
-	  " ]);\nplot([0 50 50 0 0 ],[0 0 16 16 0 ]);\npatch([20.55 23.44 25.44 27.44 29.44 25.44 22.55 20.55 ],[10.22 10.22 1"
-	  "2.22 10.22 12.22 12.22 12.22 10.22 ],[1 1 1 ]);\npatch([22.55 25.44 23.44 20.55 22.55 ],[8.22 8.22 10.22 10.22 8.22"
-	  " ],[0.931 0.946 0.973 ]);\npatch([20.55 23.44 25.44 22.55 20.55 ],[6.22 6.22 8.22 8.22 6.22 ],[1 1 1 ]);\npatch([22"
-	  ".55 29.44 27.44 25.44 23.44 20.55 22.55 ],[4.22 4.22 6.22 4.22 6.22 6.22 4.22 ],[0.931 0.946 0.973 ]);\nfprintf('',"
-	  "'COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\n\ncolor('black');disp('reinterpret');\nf"
-	  "printf('','COMMENT: end icon text');\n"
 	}
 	Block {
 	  BlockType		  Reference
@@ -22576,40 +22575,6 @@ Library {
 	}
 	Block {
 	  BlockType		  Reference
-	  Name			  "Slice_p"
-	  SID			  "588:15"
-	  Ports			  [1, 1]
-	  Position		  [685, 82, 720, 98]
-	  ZOrder		  2
-	  LibraryVersion	  "1.2"
-	  SourceBlock		  "xbsIndex_r4/Slice"
-	  SourceType		  "Xilinx Bit Slice Extractor Block"
-	  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type "
-	  "is ordinarily unsigned with binary point at zero, but can be Boolean when the slice is one bit wide.<br><br>Hardwar"
-	  "e notes: In hardware this block costs nothing."
-	  nbits			  "n_bits_out"
-	  boolean_output	  off
-	  mode			  "Upper Bit Location + Width"
-	  bit1			  "0"
-	  base1			  "MSB of Input"
-	  bit0			  "0"
-	  base0			  "LSB of Input"
-	  dbl_ovrd		  off
-	  has_advanced_control	  "0"
-	  sggui_pos		  "-9,19,543,459"
-	  block_type		  "slice"
-	  block_version		  "11.4"
-	  sg_icon_stat		  "35,16,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 35 35 0 0 ],[0 0 16 16 0 ],[0.77 0.82 0.91"
-	  " ]);\nplot([0 35 35 0 0 ],[0 0 16 16 0 ]);\npatch([12.55 15.44 17.44 19.44 21.44 17.44 14.55 12.55 ],[10.22 10.22 1"
-	  "2.22 10.22 12.22 12.22 12.22 10.22 ],[1 1 1 ]);\npatch([14.55 17.44 15.44 12.55 14.55 ],[8.22 8.22 10.22 10.22 8.22"
-	  " ],[0.931 0.946 0.973 ]);\npatch([12.55 15.44 17.44 14.55 12.55 ],[6.22 6.22 8.22 8.22 6.22 ],[1 1 1 ]);\npatch([14"
-	  ".55 21.44 19.44 17.44 15.44 12.55 14.55 ],[4.22 4.22 6.22 4.22 6.22 6.22 4.22 ],[0.931 0.946 0.973 ]);\nfprintf('',"
-	  "'COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',1,'[a"
-	  ":b]');\nfprintf('','COMMENT: end icon text');\n"
-	}
-	Block {
-	  BlockType		  Reference
 	  Name			  "alumode"
 	  SID			  "588:16"
 	  Ports			  [0, 1]
@@ -22745,6 +22710,55 @@ Library {
 	  "1'=>'popup(0|P|A:B|A*B|C|P+C|A:B+C)','inp2'=>'popup(0|PCIN|P|C|PCIN>>17|P>>17)','opselect'=>'popup(C + A*B|PCIN + A"
 	  "*B|P + A*B|A * B|C + A:B|C - A:B|C|Custom)','userSelections'=>{'carry'=>'CIN','inp1'=>'P','inp2'=>'PCIN>>17','opsel"
 	  "ect'=>'C'}}}"
+	}
+	Block {
+	  BlockType		  Reference
+	  Name			  "convert"
+	  SID			  "588:70"
+	  Ports			  [1, 1]
+	  Position		  [725, 80, 770, 100]
+	  ZOrder		  4
+	  BackgroundColor	  "[0.501961, 1.000000, 0.501961]"
+	  AttributesFormatString  "N_7 ==> 4_3\ntruncate, wrap\nlatency = 4"
+	  LibraryVersion	  "1.43"
+	  LinkData {
+	    BlockName		    "Reinterpret"
+	    DialogParameters {
+	      sggui_pos		      "11,19,364,363"
+	      sg_icon_stat	      "40,18,1,1,white,blue,0,6b04d0b0,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 18 18 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 40 40 0 0 ],[0 0 18 18 0 ]);\npatch([15.55 18.44 20.44 22.44 24.44 20.44 17.55 15.55 ],[1"
+	      "1.22 11.22 13.22 11.22 13.22 13.22 13.22 11.22 ],[1 1 1 ]);\npatch([17.55 20.44 18.44 15.55 17.55 ],[9.22 9.22 "
+	      "11.22 11.22 9.22 ],[0.931 0.946 0.973 ]);\npatch([15.55 18.44 20.44 17.55 15.55 ],[7.22 7.22 9.22 9.22 7.22 ],["
+	      "1 1 1 ]);\npatch([17.55 24.44 22.44 20.44 18.44 15.55 17.55 ],[5.22 5.22 7.22 5.22 7.22 7.22 5.22 ],[0.931 0.94"
+	      "6 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\n\ncolor('bla"
+	      "ck');disp('reinterpret');\nfprintf('','COMMENT: end icon text');"
+	    }
+	    BlockName		    "adder"
+	    DialogParameters {
+	      sggui_pos		      "11,19,416,343"
+	      sg_icon_stat	      "45,113,2,1,white,blue,0,eeab5c4c,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 45 45 0 0 ],[0 0 113 113 0 ],[0.77"
+	      " 0.82 0.91 ]);\nplot([0 45 45 0 0 ],[0 0 113 113 0 ]);\npatch([8.65 17.32 23.32 29.32 35.32 23.32 14.65 8.65 ],"
+	      "[62.66 62.66 68.66 62.66 68.66 68.66 68.66 62.66 ],[1 1 1 ]);\npatch([14.65 23.32 17.32 8.65 14.65 ],[56.66 56."
+	      "66 62.66 62.66 56.66 ],[0.931 0.946 0.973 ]);\npatch([8.65 17.32 23.32 14.65 8.65 ],[50.66 50.66 56.66 56.66 50"
+	      ".66 ],[1 1 1 ]);\npatch([14.65 35.32 29.32 23.32 17.32 8.65 14.65 ],[44.66 44.66 50.66 44.66 50.66 50.66 44.66 "
+	      "],[0.931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\nc"
+	      "olor('black');port_label('input',1,'a');\ncolor('black');port_label('input',2,'b');\ncolor('black');port_label("
+	      "'output',1,'\\bf{a + b}','texmode','on');\ncolor('black');disp('z^{-4}\\newline ','texmode','on');\ncolor('blac"
+	      "k');disp(' \\newline\\bf{}','texmode','on');\nfprintf('','COMMENT: end icon text');"
+	    }
+	  }
+	  UserDataPersistent	  on
+	  UserData		  "DataTag2"
+	  SourceBlock		  "casper_library_misc/convert"
+	  SourceType		  "convert"
+	  bin_pt_in		  "7"
+	  n_bits_out		  "4"
+	  bin_pt_out		  "3"
+	  quantization		  "Truncate"
+	  overflow		  "Wrap"
+	  latency		  "4"
 	}
 	Block {
 	  BlockType		  SubSystem
@@ -23443,7 +23457,7 @@ Library {
 	  DstPort		  3
 	}
 	Line {
-	  SrcBlock		  "Reinterpret"
+	  SrcBlock		  "convert"
 	  SrcPort		  1
 	  DstBlock		  "dout"
 	  DstPort		  1
@@ -23555,7 +23569,7 @@ Library {
 	  Points		  [20, 0]
 	  Branch {
 	    Points		    [0, 40]
-	    DstBlock		    "valid"
+	    DstBlock		    "Delay"
 	    DstPort		    1
 	  }
 	  Branch {
@@ -23574,7 +23588,7 @@ Library {
 	  SrcPort		  1
 	  Points		  [19, 0]
 	  Branch {
-	    DstBlock		    "Slice_p"
+	    DstBlock		    "convert"
 	    DstPort		    1
 	  }
 	  Branch {
@@ -23584,10 +23598,20 @@ Library {
 	  }
 	}
 	Line {
-	  SrcBlock		  "Slice_p"
+	  SrcBlock		  "Delay"
 	  SrcPort		  1
-	  DstBlock		  "Reinterpret"
+	  DstBlock		  "valid"
 	  DstPort		  1
+	}
+	Annotation {
+	  SID			  "588:73"
+	  Name			  "Pulse advanced here to be ahead of data0 again."
+	  Position		  [748, 258]
+	}
+	Annotation {
+	  SID			  "588:72"
+	  Name			  "Pulse comes in behild data0.\nIt's delayed here to be in line with data 0."
+	  Position		  [103, 157]
 	}
 	Annotation {
 	  SID			  "588:35"
@@ -36054,7 +36078,7 @@ Library {
       ZOrder		      -5
       BackgroundColor	      "[0.500000, 1.000000, 0.500000]"
       UserDataPersistent      on
-      UserData		      "DataTag2"
+      UserData		      "DataTag3"
       MinAlgLoopOccurrences   off
       PropExecContextOutsideSubsystem off
       RTWSystemCode	      "Auto"
@@ -38570,7 +38594,7 @@ Library {
 	      AttributesFormatString  "both edges\nactive high"
 	      LibraryVersion	      "1.43"
 	      UserDataPersistent      on
-	      UserData		      "DataTag3"
+	      UserData		      "DataTag4"
 	      SourceBlock	      "casper_library_misc/edge_detect"
 	      SourceType	      "edge_detect"
 	      edge		      "Both"
@@ -38636,7 +38660,7 @@ Library {
 	      AttributesFormatString  "rising edges\nactive high"
 	      LibraryVersion	      "1.43"
 	      UserDataPersistent      on
-	      UserData		      "DataTag4"
+	      UserData		      "DataTag5"
 	      SourceBlock	      "casper_library_misc/edge_detect"
 	      SourceType	      "edge_detect"
 	      edge		      "Rising"
@@ -40723,7 +40747,7 @@ Library {
 	  AttributesFormatString  "rising edges\nactive high"
 	  LibraryVersion	  "1.43"
 	  UserDataPersistent	  on
-	  UserData		  "DataTag5"
+	  UserData		  "DataTag6"
 	  SourceBlock		  "casper_library_misc/edge_detect"
 	  SourceType		  "edge_detect"
 	  edge			  "Rising"
@@ -41146,7 +41170,7 @@ Library {
   }
 }
 MatData {
-  NumRecords		  6
+  NumRecords		  7
   DataRecord {
     Tag			    DataTag0
     Data		    "  %)30     .    , (   8    (     @         %    \"     $    !     0         %  0 \"P    $    6    <W1A="
@@ -41176,6 +41200,20 @@ MatData {
   }
   DataRecord {
     Tag			    DataTag2
+    Data		    "  %)30     .    4 ,   8    (     @         %    \"     $    !     0         %  0 \"P    $    6    <W1A="
+    "&4       !P87)A;65T97)S    #@   #     &    \"     T         !0    @    !     0    $         !@ $ (C5X@ .    P (   "
+    "8    (     @         %    \"     $    !     0         %  0 #0    $   !;    9&5F875L=',      &)I;E]P=%]I;@    !N7V)"
+    "I='-?;W5T    8FEN7W!T7V]U=    '%U86YT:7IA=&EO;@!O=F5R9FQO=P      ;&%T96YC>0              #@   *@    &    \"     $ "
+    "        !0    @    !     @    $         #@   #@    &    \"     0         !0    @    !    !P    $         $     <  "
+    " !L871E;F-Y  X    X    !@    @    &          4    (     0    $    !          D    (             $ .    .     8    "
+    "(    !@         %    \"     $    !     0         )    \"            !Q #@   #@    &    \"     8         !0    @   "
+    " !     0    $         \"0    @            00 X    X    !@    @    &          4    (     0    $    !          D    "
+    "(            \"$ .    .     8    (    !          %    \"     $    (     0         0    \"    %1R=6YC871E#@   #    "
+    " &    \"     0         !0    @    !    !     $         $  $ %=R87 .    .     8    (    !@         %    \"     $   "
+    " !     0         )    \"            !! "
+  }
+  DataRecord {
+    Tag			    DataTag3
     Data		    "  %)30     .    , (   8    (     @         %    \"     $    !     0         %  0 \"P    $    6    <W1A="
     "&4       !P87)A;65T97)S    #@   #     &    \"     T         !0    @    !     0    $         !@ $ 'E(LP8.    H $   "
     "8    (     @         %    \"     $    !     0         %  0 \"P    $    W    9&5F875L=',   !V96-?;&5N     &%R:71H7W"
@@ -41185,7 +41223,7 @@ MatData {
     "    (            0$ .    .     8    (    !@         %    \"     $    !     0         )    \"               "
   }
   DataRecord {
-    Tag			    DataTag3
+    Tag			    DataTag4
     Data		    "  %)30     .    J 8   8    (     @         %    \"     $    !     0         %  0 \"P    $    6    <W1A="
     "&4       !P87)A;65T97)S    #@   #     &    \"     T         !0    @    !     0    $         !@ $ \"NX:@4.    & 8  "
     " 8    (     @         %    \"     $    !     0         %  0 \"0    $    _    9&5F875L=', 961G90      <&]L87)I='D >"
@@ -41209,7 +41247,7 @@ MatData {
     "    !    'P    $         $    !\\   !;+3$@+3$@(#$@(#$@+3$@+3$@(#$@(#$@+3$@+3%=  "
   }
   DataRecord {
-    Tag			    DataTag4
+    Tag			    DataTag5
     Data		    "  %)30     .    L 8   8    (     @         %    \"     $    !     0         %  0 \"P    $    6    <W1A="
     "&4       !P87)A;65T97)S    #@   #     &    \"     T         !0    @    !     0    $         !@ $ )#IO@4.    ( 8   "
     "8    (     @         %    \"     $    !     0         %  0 \"0    $    _    9&5F875L=', 961G90      <&]L87)I='D >%"
@@ -41233,7 +41271,7 @@ MatData {
     "!          %    \"     $    ?     0         0    'P   %LM,2 M,2 @,2 @,2 M,2 M,2 M,2 M,2 M,2 M,5T "
   }
   DataRecord {
-    Tag			    DataTag5
+    Tag			    DataTag6
     Data		    "  %)30     .    L 8   8    (     @         %    \"     $    !     0         %  0 \"P    $    6    <W1A="
     "&4       !P87)A;65T97)S    #@   #     &    \"     T         !0    @    !     0    $         !@ $ )#IO@4.    ( 8   "
     "8    (     @         %    \"     $    !     0         %  0 \"0    $    _    9&5F875L=', 961G90      <&]L87)I='D >%"

--- a/casper_library/casper_library_accumulators.mdl
+++ b/casper_library/casper_library_accumulators.mdl
@@ -1,22 +1,63 @@
 Library {
   Name			  "casper_library_accumulators"
-  Version		  7.2
+  Version		  8.0
   MdlSubVersion		  0
-  SavedCharacterEncoding  "windows-1252"
+  SavedCharacterEncoding  "UTF-8"
   LibraryType		  "BlockLibrary"
   SaveDefaultBlockParams  on
   ScopeRefreshTime	  0.035000
   OverrideScopeRefreshTime on
   DisableAllScopes	  off
+  FPTRunName		  "Run 1"
+  MaxMDLFileLineLength	  120
+  Object {
+    $PropName		    "BdWindowsInfo"
+    $ObjectID		    1
+    $ClassName		    "Simulink.BDWindowsInfo"
+    Object {
+      $PropName		      "WindowsInfo"
+      $ObjectID		      2
+      $ClassName	      "Simulink.WindowInfo"
+      IsActive		      [1]
+      Location		      [0.0, 27.0, 1920.0, 1173.0]
+      Object {
+	$PropName		"ModelBrowserInfo"
+	$ObjectID		3
+	$ClassName		"Simulink.ModelBrowserInfo"
+	Visible			[0]
+	DockPosition		"Left"
+	Width			[50]
+	Height			[50]
+	Filter			[9]
+      }
+      Object {
+	$PropName		"ExplorerBarInfo"
+	$ObjectID		4
+	$ClassName		"Simulink.ExplorerBarInfo"
+	Visible			[1]
+      }
+      Object {
+	$PropName		"EditorsInfo"
+	$ObjectID		5
+	$ClassName		"Simulink.EditorInfo"
+	IsActive		[1]
+	ViewObjType		"SimulinkTopLevel"
+	LoadSaveID		"0"
+	Extents			[1884.0, 1003.0]
+	ZoomFactor		[4.034782608695652]
+	Offset			[14.78017241379311, 13.53017241379311]
+      }
+    }
+  }
   Created		  "Thu Sep 02 12:37:05 2010"
   Creator		  "mdexter"
   UpdateHistory		  "UpdateHistoryNever"
   ModifiedByFormat	  "%<Auto>"
-  LastModifiedBy	  "mdexter"
+  LastModifiedBy	  "dbeuser"
   ModifiedDateFormat	  "%<Auto>"
-  LastModifiedDate	  "Tue May 21 13:46:26 2013"
-  RTWModifiedTimeStamp	  291044784
-  ModelVersionFormat	  "1.%<AutoIncrement:7>"
+  LastModifiedDate	  "Wed May 13 15:56:36 2015"
+  RTWModifiedTimeStamp	  353433392
+  ModelVersionFormat	  "1.%<AutoIncrement:16>"
   ConfigurationManager	  "None"
   SampleTimeColors	  off
   SampleTimeAnnotations	  off
@@ -24,6 +65,7 @@ Library {
   WideLines		  off
   ShowLineDimensions	  off
   ShowPortDataTypes	  off
+  ShowDesignRanges	  off
   ShowLoopsOnError	  on
   IgnoreBidirectionalLines off
   ShowStorageClass	  off
@@ -83,14 +125,14 @@ Library {
     Type		    "Handle"
     Dimension		    1
     Simulink.ConfigSet {
-      $ObjectID		      1
-      Version		      "1.10.0"
+      $ObjectID		      6
+      Version		      "1.12.1"
       Array {
 	Type			"Handle"
 	Dimension		8
 	Simulink.SolverCC {
-	  $ObjectID		  2
-	  Version		  "1.10.0"
+	  $ObjectID		  7
+	  Version		  "1.12.1"
 	  StartTime		  "0.0"
 	  StopTime		  "10.0"
 	  AbsTol		  "auto"
@@ -108,8 +150,11 @@ Library {
 	  MaxConsecutiveMinStep	  "1"
 	  RelTol		  "1e-3"
 	  SolverMode		  "SingleTasking"
+	  EnableConcurrentExecution off
+	  ConcurrentTasks	  off
 	  Solver		  "ode45"
 	  SolverName		  "ode45"
+	  SolverJacobianMethodControl "auto"
 	  ShapePreserveControl	  "DisableAll"
 	  ZeroCrossControl	  "UseLocalSettings"
 	  ZeroCrossAlgorithm	  "Nonadaptive"
@@ -121,8 +166,8 @@ Library {
 	  InsertRTBMode		  "Whenever possible"
 	}
 	Simulink.DataIOCC {
-	  $ObjectID		  3
-	  Version		  "1.10.0"
+	  $ObjectID		  8
+	  Version		  "1.12.1"
 	  Decimation		  "1"
 	  ExternalInput		  "[t, u]"
 	  FinalStateName	  "xFinal"
@@ -132,23 +177,29 @@ Library {
 	  LoadExternalInput	  off
 	  LoadInitialState	  off
 	  SaveFinalState	  off
+	  SaveCompleteFinalSimState off
 	  SaveFormat		  "Array"
+	  SignalLoggingSaveFormat "ModelDataLogs"
 	  SaveOutput		  on
 	  SaveState		  off
 	  SignalLogging		  on
+	  DSMLogging		  on
 	  InspectSignalLogs	  off
 	  SaveTime		  on
+	  ReturnWorkspaceOutputs  off
 	  StateSaveName		  "xout"
 	  TimeSaveName		  "tout"
 	  OutputSaveName	  "yout"
 	  SignalLoggingName	  "logsout"
+	  DSMLoggingName	  "dsmout"
 	  OutputOption		  "RefineOutputTimes"
 	  OutputTimes		  "[]"
+	  ReturnWorkspaceOutputsName "out"
 	  Refine		  "1"
 	}
 	Simulink.OptimizationCC {
-	  $ObjectID		  4
-	  Version		  "1.10.0"
+	  $ObjectID		  9
+	  Version		  "1.12.1"
 	  Array {
 	    Type		    "Cell"
 	    Dimension		    8
@@ -166,13 +217,20 @@ Library {
 	  BooleanDataType	  off
 	  ConditionallyExecuteInputs on
 	  InlineParams		  off
+	  UseIntDivNetSlope	  off
+	  UseFloatMulNetSlope	  off
+	  UseSpecifiedMinMax	  off
 	  InlineInvariantSignals  off
 	  OptimizeBlockIOStorage  on
 	  BufferReuse		  on
 	  EnhancedBackFolding	  off
+	  StrengthReduction	  off
 	  ExpressionFolding	  on
+	  BooleansAsBitfields	  off
+	  BitfieldContainerType	  "uint_T"
 	  EnableMemcpy		  on
 	  MemcpyThreshold	  64
+	  PassReuseOutputArgsAs	  "Structure reference"
 	  ExpressionDepthLimit	  2147483647
 	  FoldNonRolledExpr	  on
 	  LocalBlockOutputs	  on
@@ -189,14 +247,15 @@ Library {
 	  EfficientMapNaN2IntZero on
 	  OptimizeModelRefInitCode off
 	  LifeSpan		  "inf"
+	  MaxStackSize		  "Inherit from target"
 	  BufferReusableBoundary  on
 	  SimCompilerOptimization "Off"
 	  AccelVerboseBuild	  off
-  EnforceIntegerDowncast   on
+	  ParallelExecutionInRapidAccelerator on
 	}
 	Simulink.DebuggingCC {
-	  $ObjectID		  5
-	  Version		  "1.10.0"
+	  $ObjectID		  10
+	  Version		  "1.12.1"
 	  RTPrefix		  "error"
 	  ConsistencyChecking	  "none"
 	  ArrayBoundsChecking	  "none"
@@ -219,6 +278,8 @@ Library {
 	  MinStepSizeMsg	  "warning"
 	  TimeAdjustmentMsg	  "none"
 	  MaxConsecutiveZCsMsg	  "error"
+	  MaskedZcDiagnostic	  "warning"
+	  IgnoredZcDiagnostic	  "warning"
 	  SolverPrmCheckMsg	  "none"
 	  InheritedTsInSrcMsg	  "warning"
 	  DiscreteInheritContinuousMsg "warning"
@@ -236,22 +297,27 @@ Library {
 	  ParameterUnderflowMsg	  "none"
 	  ParameterPrecisionLossMsg "warning"
 	  ParameterTunabilityLossMsg "warning"
+	  FixptConstUnderflowMsg  "none"
+	  FixptConstOverflowMsg	  "none"
+	  FixptConstPrecisionLossMsg "none"
 	  UnderSpecifiedDataTypeMsg "none"
 	  UnnecessaryDatatypeConvMsg "none"
 	  VectorMatrixConversionMsg "none"
 	  InvalidFcnCallConnMsg	  "error"
-	  FcnCallInpInsideContextMsg "Use local settings"
+	  FcnCallInpInsideContextMsg "UseLocalSettings"
 	  SignalLabelMismatchMsg  "none"
 	  UnconnectedInputMsg	  "warning"
 	  UnconnectedOutputMsg	  "warning"
 	  UnconnectedLineMsg	  "warning"
 	  SFcnCompatibilityMsg	  "none"
+	  FrameProcessingCompatibilityMsg "warning"
 	  UniqueDataStoreMsg	  "none"
 	  BusObjectLabelMismatch  "warning"
 	  RootOutportRequireBusObject "warning"
 	  AssertControl		  "UseLocalSettings"
 	  EnableOverflowDetection off
 	  ModelReferenceIOMsg	  "none"
+	  ModelReferenceMultiInstanceNormalModeStructChecksumCheck "error"
 	  ModelReferenceVersionMismatchMessage "none"
 	  ModelReferenceIOMismatchMessage "none"
 	  ModelReferenceCSMismatchMessage "none"
@@ -260,17 +326,35 @@ Library {
 	  ModelReferenceSymbolNameMessage "warning"
 	  ModelReferenceExtraNoncontSigs "error"
 	  StateNameClashWarn	  "warning"
+	  SimStateInterfaceChecksumMismatchMsg "warning"
+	  SimStateOlderReleaseMsg "error"
+	  InitInArrayFormatMsg	  "warning"
 	  StrictBusMsg		  "Warning"
+	  BusNameAdapt		  "WarnAndRepair"
+	  NonBusSignalsTreatedAsBus "none"
 	  LoggingUnavailableSignals "error"
 	  BlockIODiagnostic	  "none"
+	  SFUnusedDataAndEventsDiag "warning"
+	  SFUnexpectedBacktrackingDiag "warning"
+	  SFInvalidInputDataAccessInChartInitDiag "warning"
+	  SFNoUnconditionalDefaultTransitionDiag "warning"
+	  SFTransitionOutsideNaturalParentDiag "warning"
+	  SFUnconditionalTransitionShadowingDiag "warning"
+	  SFUndirectedBroadcastEventsDiag "warning"
+	  SFTransitionActionBeforeConditionDiag	"warning"
 	}
 	Simulink.HardwareCC {
-	  $ObjectID		  6
-	  Version		  "1.10.0"
+	  $ObjectID		  11
+	  Version		  "1.12.1"
 	  ProdBitPerChar	  8
 	  ProdBitPerShort	  16
 	  ProdBitPerInt		  32
 	  ProdBitPerLong	  32
+	  ProdBitPerFloat	  32
+	  ProdBitPerDouble	  64
+	  ProdBitPerPointer	  32
+	  ProdLargestAtomicInteger "Char"
+	  ProdLargestAtomicFloat  "None"
 	  ProdIntDivRoundTo	  "Undefined"
 	  ProdEndianess		  "Unspecified"
 	  ProdWordSize		  32
@@ -280,6 +364,11 @@ Library {
 	  TargetBitPerShort	  16
 	  TargetBitPerInt	  32
 	  TargetBitPerLong	  32
+	  TargetBitPerFloat	  32
+	  TargetBitPerDouble	  64
+	  TargetBitPerPointer	  32
+	  TargetLargestAtomicInteger "Char"
+	  TargetLargestAtomicFloat "None"
 	  TargetShiftRightIntArith on
 	  TargetIntDivRoundTo	  "Undefined"
 	  TargetEndianess	  "Unspecified"
@@ -292,27 +381,38 @@ Library {
 	  ProdEqTarget		  on
 	}
 	Simulink.ModelReferenceCC {
-	  $ObjectID		  7
-	  Version		  "1.10.0"
+	  $ObjectID		  12
+	  Version		  "1.12.1"
 	  UpdateModelReferenceTargets "IfOutOfDateOrStructuralChange"
 	  CheckModelReferenceTargetMessage "error"
+	  EnableParallelModelReferenceBuilds off
+	  ParallelModelReferenceErrorOnInvalidPool on
+	  ParallelModelReferenceMATLABWorkerInit "None"
 	  ModelReferenceNumInstancesAllowed "Multi"
+	  PropagateVarSize	  "Infer from blocks in model"
 	  ModelReferencePassRootInputsByReference on
 	  ModelReferenceMinAlgLoopOccurrences off
+	  PropagateSignalLabelsOutOfModel off
+	  SupportModelReferenceSimTargetCustomCode off
 	}
 	Simulink.SFSimCC {
-	  $ObjectID		  8
-	  Version		  "1.10.0"
+	  $ObjectID		  13
+	  Version		  "1.12.1"
 	  SFSimEnableDebug	  on
 	  SFSimOverflowDetection  on
 	  SFSimEcho		  on
+	  SimBlas		  on
+	  SimCtrlC		  on
+	  SimExtrinsic		  on
+	  SimIntegrity		  on
 	  SimUseLocalCustomCode	  off
+	  SimParseCustomCode	  on
 	  SimBuildMode		  "sf_incremental_build"
 	}
 	Simulink.RTWCC {
 	  $BackupClass		  "Simulink.RTWCC"
-	  $ObjectID		  9
-	  Version		  "1.10.0"
+	  $ObjectID		  14
+	  Version		  "1.12.1"
 	  Array {
 	    Type		    "Cell"
 	    Dimension		    7
@@ -329,6 +429,7 @@ Library {
 	  GenCodeOnly		  off
 	  MakeCommand		  "make_rtw"
 	  GenerateMakefile	  on
+	  PackageGeneratedCodeAndArtifacts off
 	  TemplateMakefile	  "grt_default_tmf"
 	  GenerateReport	  off
 	  SaveLog		  off
@@ -345,6 +446,13 @@ Library {
 	  RTWUseSimCustomCode	  off
 	  IncludeHyperlinkInReport off
 	  LaunchReport		  off
+	  PortableWordSizes	  off
+	  GenerateErtSFunction	  off
+	  CreateSILPILBlock	  "None"
+	  CodeExecutionProfiling  off
+	  CodeExecutionProfileVariable "executionProfile"
+	  CodeProfilingSaveOptions "SummaryOnly"
+	  CodeProfilingInstrumentation off
 	  TargetLang		  "C"
 	  IncludeBusHierarchyInRTWFileBlockHierarchyMap	off
 	  IncludeERTFirstTime	  off
@@ -354,13 +462,18 @@ Library {
 	  GenerateTraceReportSf	  off
 	  GenerateTraceReportEml  off
 	  GenerateCodeInfo	  off
+	  GenerateWebview	  off
+	  GenerateCodeMetricsReport off
+	  GenerateCodeReplacementReport	off
 	  RTWCompilerOptimization "Off"
+	  CheckMdlBeforeBuild	  "Off"
+	  CustomRebuildMode	  "OnUpdate"
 	  Array {
 	    Type		    "Handle"
 	    Dimension		    2
 	    Simulink.CodeAppCC {
-	      $ObjectID		      10
-	      Version		      "1.10.0"
+	      $ObjectID		      15
+	      Version		      "1.12.1"
 	      Array {
 		Type			"Cell"
 		Dimension		21
@@ -396,15 +509,18 @@ Library {
 	      PreserveName	      off
 	      PreserveNameWithParent  off
 	      ShowEliminatedStatement off
+	      OperatorAnnotations     off
 	      IncAutoGenComments      off
 	      SimulinkDataObjDesc     off
 	      SFDataObjDesc	      off
+	      MATLABFcnDesc	      off
 	      IncDataTypeInIds	      off
 	      MangleLength	      1
 	      CustomSymbolStrGlobalVar "$R$N$M"
 	      CustomSymbolStrType     "$N$R$M"
 	      CustomSymbolStrField    "$N$M"
 	      CustomSymbolStrFcn      "$R$N$M$F"
+	      CustomSymbolStrFcnArg   "rt$I$N$M"
 	      CustomSymbolStrBlkIO    "rtb_$N$M"
 	      CustomSymbolStrTmpVar   "$N$M"
 	      CustomSymbolStrMacro    "$R$N$M"
@@ -412,16 +528,19 @@ Library {
 	      ParamNamingRule	      "None"
 	      SignalNamingRule	      "None"
 	      InsertBlockDesc	      off
+	      InsertPolySpaceComments off
 	      SimulinkBlockComments   on
+	      MATLABSourceComments    off
 	      EnableCustomComments    off
+	      InternalIdentifier      "Classic"
 	      InlinedPrmAccess	      "Literals"
 	      ReqsInCode	      off
 	      UseSimReservedNames     off
 	    }
 	    Simulink.GRTTargetCC {
 	      $BackupClass	      "Simulink.TargetCC"
-	      $ObjectID		      11
-	      Version		      "1.10.0"
+	      $ObjectID		      16
+	      Version		      "1.12.1"
 	      Array {
 		Type			"Cell"
 		Dimension		16
@@ -446,7 +565,7 @@ Library {
 	      TargetFcnLib	      "ansi_tfl_table_tmw.mat"
 	      TargetLibSuffix	      ""
 	      TargetPreCompLibLocation ""
-	      TargetFunctionLibrary   "ANSI_C"
+	      CodeReplacementLibrary  "ANSI_C"
 	      UtilityFuncGeneration   "Auto"
 	      ERTMultiwordTypeDef     "System defined"
 	      ERTMultiwordLength      256
@@ -456,9 +575,13 @@ Library {
 	      GenerateTestInterfaces  off
 	      IsPILTarget	      off
 	      ModelReferenceCompliant on
+	      ParMdlRefBuildCompliant on
 	      CompOptLevelCompliant   on
+	      ConcurrentExecutionCompliant on
 	      IncludeMdlTerminateFcn  on
+	      GeneratePreprocessorConditionals "Disable all"
 	      CombineOutputUpdateFcns off
+	      CombineSignalStateStructs	off
 	      SuppressErrorStatus     off
 	      ERTFirstTimeCompliant   off
 	      IncludeFileDelimiter    "Auto"
@@ -472,12 +595,13 @@ Library {
 	      PurelyIntegerCode	      off
 	      SupportContinuousTime   on
 	      SupportNonInlinedSFcns  on
+	      SupportVariableSizeSignals off
 	      EnableShiftOperators    on
 	      ParenthesesLevel	      "Nominal"
-	      PortableWordSizes	      off
 	      ModelStepFunctionPrototypeControlCompliant off
 	      CPPClassGenCompliant    off
 	      AutosarCompliant	      off
+	      GRTInterface	      on
 	      UseMalloc		      off
 	      ExtMode		      off
 	      ExtModeStaticAlloc      off
@@ -489,6 +613,7 @@ Library {
 	      RTWCAPISignals	      off
 	      RTWCAPIParams	      off
 	      RTWCAPIStates	      off
+	      RTWCAPIRootIO	      off
 	      GenerateASAP2	      off
 	    }
 	    PropName		    "Components"
@@ -498,10 +623,11 @@ Library {
       }
       Name		      "Configuration"
       CurrentDlgPage	      "Solver"
-      ConfigPrmDlgPosition    " [ 400, 210, 1280, 840 ] "
+      ConfigPrmDlgPosition     [ 400, 210, 1280, 840 ] 
     }
     PropName		    "ConfigurationSets"
   }
+  ExplicitPartitioning	  off
   BlockDefaults {
     ForegroundColor	    "black"
     BackgroundColor	    "white"
@@ -512,7 +638,8 @@ Library {
     FontWeight		    "normal"
     FontAngle		    "normal"
     ShowName		    on
-    Orientation		    "right"
+    BlockRotation	    0
+    BlockMirror		    off
   }
   AnnotationDefaults {
     HorizontalAlignment	    "center"
@@ -524,12 +651,32 @@ Library {
     FontSize		    10
     FontWeight		    "normal"
     FontAngle		    "normal"
+    UseDisplayTextAsClickCallback off
   }
   LineDefaults {
     FontName		    "Arial"
     FontSize		    9
     FontWeight		    "normal"
     FontAngle		    "normal"
+  }
+  MaskDefaults {
+    SelfModifiable	    "off"
+    IconFrame		    "on"
+    IconOpaque		    "on"
+    RunInitForIconRedraw    "off"
+    IconRotate		    "none"
+    PortRotate		    "default"
+    IconUnits		    "autoscale"
+  }
+  MaskParameterDefaults {
+    Evaluate		    "on"
+    Tunable		    "on"
+    NeverSave		    "off"
+    Internal		    "off"
+    ReadOnly		    "off"
+    Enabled		    "on"
+    Visible		    "on"
+    ToolTip		    "on"
   }
   BlockParameterDefaults {
     Block {
@@ -543,23 +690,23 @@ Library {
       LockScale		      off
       SampleTime	      "inf"
       FramePeriod	      "inf"
-  OutDataTypeMode   "Inherit from 'Constant value'"
-  OutDataType   "fixdt(1,16,0)"
-  ConRadixGroup   "Use specified scaling"
-  OutScaling   "[]"
+      PreserveConstantTs      off
     }
     Block {
       BlockType		      From
+      GotoTag		      "A"
       IconDisplay	      "Tag"
       TagVisibility	      "local"
     }
     Block {
       BlockType		      Goto
       IconDisplay	      "Tag"
+      TagVisibility	      "local"
     }
     Block {
       BlockType		      Inport
       Port		      "1"
+      OutputFunctionCall      off
       OutMin		      "[]"
       OutMax		      "[]"
       OutDataTypeStr	      "Inherit: auto"
@@ -571,13 +718,8 @@ Library {
       SignalType	      "auto"
       SamplingMode	      "auto"
       LatchByDelayingOutsideSignal off
-      LatchByCopyingInsideSignal off
+      LatchInputForFeedbackSignals off
       Interpolate	      on
-  DataType   "auto"
-  OutDataType   "fixdt(1,16,0)"
-  OutScaling   "[]"
-  UseBusObject   off
-  BusObject   "BusObject"
     }
     Block {
       BlockType		      Outport
@@ -595,11 +737,6 @@ Library {
       SourceOfInitialOutputValue "Dialog"
       OutputWhenDisabled      "held"
       InitialOutput	      "[]"
-  DataType   "auto"
-  OutDataType   "fixdt(1,16,0)"
-  OutScaling   "[]"
-  UseBusObject   off
-  BusObject   "BusObject"
     }
     Block {
       BlockType		      Scope
@@ -612,6 +749,7 @@ Library {
       YMax		      "5"
       SaveToWorkspace	      off
       SaveName		      "ScopeData"
+      DataFormat	      "Array"
       LimitDataPoints	      on
       MaxDataPoints	      "5000"
       Decimation	      "1"
@@ -635,7 +773,11 @@ Library {
       RTWMemSecDataParameters "Inherit from model"
       SimViewingDevice	      off
       DataTypeOverride	      "UseLocalSettings"
+      DataTypeOverrideAppliesTo	"AllNumericTypes"
       MinMaxOverflowLogging   "UseLocalSettings"
+      SFBlockType	      "NONE"
+      Variant		      off
+      GeneratePreprocessorConditionals off
     }
     Block {
       BlockType		      Terminator
@@ -643,8 +785,8 @@ Library {
   }
   System {
     Name		    "casper_library_accumulators"
-    Location		    [475, 77, 1011, 378]
-    Open		    off
+    Location		    [0, 27, 1920, 1200]
+    Open		    on
     ModelBrowserVisibility  off
     ModelBrowserWidth	    200
     ScreenColor		    "white"
@@ -655,13 +797,16 @@ Library {
     TiledPaperMargins	    [0.500000, 0.500000, 0.500000, 0.500000]
     TiledPageScale	    1
     ShowPageBoundaries	    off
-    ZoomFactor		    "100"
+    ZoomFactor		    "403"
     ReportName		    "simulink-default.rpt"
+    SIDHighWatermark	    "1148"
     Block {
       BlockType		      SubSystem
       Name		      "addr_bram_vacc"
+      SID		      "1"
       Ports		      [2, 3]
       Position		      [190, 176, 265, 234]
+      ZOrder		      -1
       BackgroundColor	      "[0.500000, 1.000000, 0.500000]"
       UserDataPersistent      on
       UserData		      "DataTag0"
@@ -670,28 +815,62 @@ Library {
       RTWSystemCode	      "Auto"
       FunctionWithSeparateData off
       Opaque		      off
+      RequestExecContextInheritance off
       MaskHideContents	      off
-      MaskType		      "simple_bram_vacc"
-      MaskDescription	      "This simple vector accumulator is based on a shift register. It outputs its previous accu"
-      "mulated vector after a new_acc pulse is received."
-      MaskPromptString	      "Vector length:|Output type:|Bit width (output):|Binary point (output):"
-      MaskStyleString	      "edit,popup(Signed|Unsigned),edit,edit"
-      MaskVariables	      "vec_len=@1;arith_type=&2;n_bits=@3;bin_pt=@4;"
-      MaskTunableValueString  "on,on,on,on"
-      MaskCallbackString      "|||"
-      MaskEnableString	      "on,on,on,on"
-      MaskVisibilityString    "on,on,on,on"
-      MaskToolTipString	      "on,on,on,on"
-      MaskInitialization      "simple_bram_vacc_init(gcb, ...\n    'vec_len', vec_len, ...\n    'arith_type', arith_ty"
-      "pe, ...\n    'n_bits', n_bits, ...\n    'bin_pt', bin_pt);"
-      MaskIconFrame	      on
-      MaskIconOpaque	      on
-      MaskIconRotate	      "none"
-      MaskIconUnits	      "autoscale"
-      MaskValueString	      "16|Signed|32|0"
+      Object {
+	$PropName		"MaskObject"
+	$ObjectID		17
+	$ClassName		"Simulink.Mask"
+	Type			"simple_bram_vacc"
+	Description		"This simple vector accumulator is based on a shift register. It outputs its previous accumulated vector"
+	" after a new_acc pulse is received."
+	Initialization		"simple_bram_vacc_init(gcb, ...\n    'vec_len', vec_len, ...\n    'arith_type', arith_type, ...\n    "
+	"'n_bits', n_bits, ...\n    'bin_pt', bin_pt);"
+	Array {
+	  Type			  "Simulink.MaskParameter"
+	  Dimension		  4
+	  Object {
+	    $ObjectID		    18
+	    Type		    "edit"
+	    Name		    "vec_len"
+	    Prompt		    "Vector length:"
+	    Value		    "16"
+	  }
+	  Object {
+	    $ObjectID		    19
+	    Type		    "popup"
+	    Array {
+	      Type		      "Cell"
+	      Dimension		      2
+	      Cell		      "Signed"
+	      Cell		      "Unsigned"
+	      PropName		      "TypeOptions"
+	    }
+	    Name		    "arith_type"
+	    Prompt		    "Output type:"
+	    Value		    "Signed"
+	    Evaluate		    "off"
+	  }
+	  Object {
+	    $ObjectID		    20
+	    Type		    "edit"
+	    Name		    "n_bits"
+	    Prompt		    "Bit width (output):"
+	    Value		    "32"
+	  }
+	  Object {
+	    $ObjectID		    21
+	    Type		    "edit"
+	    Name		    "bin_pt"
+	    Prompt		    "Binary point (output):"
+	    Value		    "0"
+	  }
+	  PropName		  "Parameters"
+	}
+      }
       System {
 	Name			"addr_bram_vacc"
-	Location		[818, 299, 1586, 756]
+	Location		[784, 180, 1600, 872]
 	Open			off
 	ModelBrowserVisibility	off
 	ModelBrowserWidth	200
@@ -707,22 +886,29 @@ Library {
 	Block {
 	  BlockType		  Inport
 	  Name			  "new_acc"
+	  SID			  "2"
 	  Position		  [15, 183, 45, 197]
+	  ZOrder		  -1
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Inport
 	  Name			  "din"
+	  SID			  "3"
 	  Position		  [15, 148, 45, 162]
+	  ZOrder		  -2
 	  Port			  "2"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "Adder"
+	  SID			  "4"
 	  Ports			  [2, 1]
 	  Position		  [230, 127, 285, 238]
+	  ZOrder		  -3
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/AddSub"
 	  SourceType		  "Xilinx Adder/Subtracter Block"
 	  mode			  "Addition"
@@ -747,20 +933,26 @@ Library {
 	  sggui_pos		  "0,0,419,344"
 	  block_type		  "addsub"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "55,111,1,1,white,blue,0,89752214,right"
-	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 ],[0 0 111 111 ],[0.77 0.82 0.91])"
-	  ";\npatch([13 4 17 4 13 28 32 36 52 40 28 19 32 19 28 40 52 36 32 28 13 ],[34 43 56 69 78 78 74 78 78 66 78 69 56 43"
-	  " 34 46 34 34 38 34 34 ],[0.98 0.96 0.92]);\nplot([0 55 55 0 0 ],[0 0 111 111 0 ]);\nfprintf('','COMMENT: end icon g"
-	  "raphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('input',1,'a');\ncolor('black');port"
-	  "_label('input',2,'b');\ncolor('black');port_label('output',1,'\\bf{a + b}','texmode','on');\ncolor('black');disp('\\"
-	  "newline\\bf{}\\newlinez^{-2}','texmode','on');\nfprintf('','COMMENT: end icon text');\n"
+	  sg_icon_stat		  "55,111,2,1,white,blue,0,dcac4ee3,right,,[ ],[ ]"
+	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 0 ],[0 0 111 111 0 ],[0.77 0.82 0."
+	  "91 ]);\nplot([0 55 55 0 0 ],[0 0 111 111 0 ]);\npatch([11.425 21.54 28.54 35.54 42.54 28.54 18.425 11.425 ],[62.77 "
+	  "62.77 69.77 62.77 69.77 69.77 69.77 62.77 ],[1 1 1 ]);\npatch([18.425 28.54 21.54 11.425 18.425 ],[55.77 55.77 62.7"
+	  "7 62.77 55.77 ],[0.931 0.946 0.973 ]);\npatch([11.425 21.54 28.54 18.425 11.425 ],[48.77 48.77 55.77 55.77 48.77 ],"
+	  "[1 1 1 ]);\npatch([18.425 42.54 35.54 28.54 21.54 11.425 18.425 ],[41.77 41.77 48.77 41.77 48.77 48.77 41.77 ],[0.9"
+	  "31 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('blac"
+	  "k');port_label('input',1,'a');\ncolor('black');port_label('input',2,'b');\ncolor('black');port_label('output',1,'\\"
+	  "bf{a + b}','texmode','on');\ncolor('black');disp('z^{-2}\\newline ','texmode','on');\ncolor('black');disp(' \\newli"
+	  "ne\\bf{}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "Constant"
+	  SID			  "5"
 	  Ports			  [0, 1]
 	  Position		  [110, 222, 140, 238]
+	  ZOrder		  -4
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Constant"
 	  SourceType		  "Xilinx Constant Block Block"
 	  const			  "0"
@@ -785,13 +977,14 @@ Library {
 	  sggui_pos		  "-1,-1,-1,-1"
 	  block_type		  "constant"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "30,16,1,1,white,blue,0,72d575a1,right"
-	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 1 1 0 ],[0 0 1 1 ],[0.77 0.82 0.91]);\npat"
-	  "ch([0.366667 0.266667 0.4 0.266667 0.366667 0.5 0.533333 0.566667 0.733333 0.6 0.5 0.433333 0.566667 0.433333 0.5 0"
-	  ".6 0.733333 0.566667 0.533333 0.5 0.366667 ],[0.125 0.3125 0.5625 0.8125 1 1 0.9375 1 1 0.75 0.9375 0.8125 0.5625 0"
-	  ".3125 0.1875 0.375 0.125 0.125 0.1875 0.125 0.125 ],[0.98 0.96 0.92]);\nplot([0 1 1 0 0 ],[0 0 1 1 0 ]);\nfprintf('"
-	  "','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'0'"
-	  ");\nfprintf('','COMMENT: end icon text');\n"
+	  sg_icon_stat		  "30,16,0,1,white,blue,0,bf4ddd8b,right,,[ ],[ ]"
+	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 16 16 0 ],[0.77 0.82 0.91"
+	  " ]);\nplot([0 30 30 0 0 ],[0 0 16 16 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[10.22 10.22 1"
+	  "2.22 10.22 12.22 12.22 12.22 10.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[8.22 8.22 10.22 10.22 8.22"
+	  " ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[6.22 6.22 8.22 8.22 6.22 ],[1 1 1 ]);\npatch([12"
+	  ".55 19.44 17.44 15.44 13.44 10.55 12.55 ],[4.22 4.22 6.22 4.22 6.22 6.22 4.22 ],[0.931 0.946 0.973 ]);\nfprintf('',"
+	  "'COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'0');"
+	  "\nfprintf('','COMMENT: end icon text');"
 	  sg_list_contents	  "{'table'=>{'carry'=>'popup(0|1|CIN|~SIGN(P or PCIN)|~SIGN(A*B or A:B)|~SIGND(A*B or A:B))','inp"
 	  "1'=>'popup(0|P|A:B|A*B|C|P+C|A:B+C)','inp2'=>'popup(0|PCIN|P|C|PCIN>>17|P>>17)','opselect'=>'popup(C + A*B|PCIN + A"
 	  "*B|P + A*B|A * B|C + A:B|C - A:B|C|Custom)','userSelections'=>{'carry'=>'CIN','inp1'=>'P','inp2'=>'PCIN>>17','opsel"
@@ -800,9 +993,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Counter"
+	  SID			  "6"
 	  Ports			  [1, 1]
 	  Position		  [160, 61, 195, 79]
+	  ZOrder		  -5
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Counter"
 	  SourceType		  "Xilinx Counter Block"
 	  infoedit		  "Hardware notes: Free running counters are the least expensive in hardware.  A count limited counter is"
@@ -830,19 +1026,24 @@ Library {
 	  sggui_pos		  "20,20,348,619"
 	  block_type		  "counter"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "35,18,1,1,white,blue,0,300e9576,right"
-	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 35 35 0 ],[0 0 18 18 ],[0.77 0.82 0.91]);\n"
-	  "patch([13 10 14 10 13 18 19 20 25 21 17 14 18 14 17 21 25 20 19 18 13 ],[2 5 9 13 16 16 15 16 16 12 16 13 9 5 2 6 2"
-	  " 2 3 2 2 ],[0.98 0.96 0.92]);\nplot([0 35 35 0 0 ],[0 0 18 18 0 ]);\nfprintf('','COMMENT: end icon graphics');\nfpr"
-	  "intf('','COMMENT: begin icon text');\ncolor('black');port_label('input',1,'rst');\ncolor('black');port_label('outpu"
-	  "t',1,'out');\nfprintf('','COMMENT: end icon text');\n"
+	  sg_icon_stat		  "35,18,1,1,white,blue,0,803eba70,right,,[ ],[ ]"
+	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 35 35 0 0 ],[0 0 18 18 0 ],[0.77 0.82 0.91"
+	  " ]);\nplot([0 35 35 0 0 ],[0 0 18 18 0 ]);\npatch([12.55 15.44 17.44 19.44 21.44 17.44 14.55 12.55 ],[11.22 11.22 1"
+	  "3.22 11.22 13.22 13.22 13.22 11.22 ],[1 1 1 ]);\npatch([14.55 17.44 15.44 12.55 14.55 ],[9.22 9.22 11.22 11.22 9.22"
+	  " ],[0.931 0.946 0.973 ]);\npatch([12.55 15.44 17.44 14.55 12.55 ],[7.22 7.22 9.22 9.22 7.22 ],[1 1 1 ]);\npatch([14"
+	  ".55 21.44 19.44 17.44 15.44 12.55 14.55 ],[5.22 5.22 7.22 5.22 7.22 7.22 5.22 ],[0.931 0.946 0.973 ]);\nfprintf('',"
+	  "'COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('input',1,'rst')"
+	  ";\n\ncolor('black');disp('{\\fontsize{14}\\bf++}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay1"
+	  SID			  "7"
 	  Ports			  [1, 1]
 	  Position		  [390, 12, 420, 28]
+	  ZOrder		  -6
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -870,9 +1071,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay2"
+	  SID			  "8"
 	  Ports			  [1, 1]
 	  Position		  [390, 102, 420, 118]
+	  ZOrder		  -7
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -900,9 +1104,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay4"
+	  SID			  "9"
 	  Ports			  [1, 1]
 	  Position		  [80, 62, 110, 78]
+	  ZOrder		  -8
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -930,9 +1137,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay8"
+	  SID			  "10"
 	  Ports			  [1, 1]
 	  Position		  [160, 147, 190, 163]
+	  ZOrder		  -9
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -960,9 +1170,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Mux"
+	  SID			  "11"
 	  Ports			  [3, 1]
 	  Position		  [160, 177, 185, 243]
+	  ZOrder		  -10
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Mux"
 	  SourceType		  "Xilinx Bus Multiplexer Block"
 	  inputs		  "2"
@@ -994,37 +1207,51 @@ Library {
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "delay_bram"
+	  SID			  "12"
 	  Ports			  [1, 1]
 	  Position		  [315, 165, 355, 205]
+	  ZOrder		  -11
 	  BackgroundColor	  "gray"
 	  MinAlgLoopOccurrences	  off
 	  PropExecContextOutsideSubsystem off
 	  RTWSystemCode		  "Auto"
 	  FunctionWithSeparateData off
 	  Opaque		  off
+	  RequestExecContextInheritance	off
 	  MaskHideContents	  off
-	  MaskType		  "delay_bram"
-	  MaskDescription	  "A delay block that uses BRAM for its storage."
-	  MaskHelp		  "eval('xlWeb(''http://casper.berkeley.edu/wiki/Delay_bram'')')"
-	  MaskPromptString	  "Delay By:|BRAM Latency"
-	  MaskStyleString	  "edit,edit"
-	  MaskVariables		  "DelayLen=@1;bram_latency=@2;"
-	  MaskTunableValueString  "on,on"
-	  MaskCallbackString	  "|"
-	  MaskEnableString	  "on,on"
-	  MaskVisibilityString	  "on,on"
-	  MaskToolTipString	  "on,on"
-	  MaskInitialization	  "if (DelayLen <= bram_latency)\n	error('delay value must be greater than BRAM Latency');\nend\n"
-	  "BitWidth = max(ceil(log2(DelayLen)), 2);"
-	  MaskSelfModifiable	  on
-	  MaskIconFrame		  on
-	  MaskIconOpaque	  on
-	  MaskIconRotate	  "none"
-	  MaskIconUnits		  "autoscale"
-	  MaskValueString	  "vec_len - 2 - 2|2"
+	  Object {
+	    $PropName		    "MaskObject"
+	    $ObjectID		    22
+	    $ClassName		    "Simulink.Mask"
+	    Type		    "delay_bram"
+	    Description		    "A delay block that uses BRAM for its storage."
+	    Help		    "eval('xlWeb(''http://casper.berkeley.edu/wiki/Delay_bram'')')"
+	    Initialization	    "if (DelayLen <= bram_latency)\n	error('delay value must be greater than BRAM Latency');\nend\n"
+	    "BitWidth = max(ceil(log2(DelayLen)), 2);"
+	    SelfModifiable	    "on"
+	    Array {
+	      Type		      "Simulink.MaskParameter"
+	      Dimension		      2
+	      Object {
+		$ObjectID		23
+		Type			"edit"
+		Name			"DelayLen"
+		Prompt			"Delay By:"
+		Value			"vec_len - 2 - 2"
+	      }
+	      Object {
+		$ObjectID		24
+		Type			"edit"
+		Name			"bram_latency"
+		Prompt			"BRAM Latency"
+		Value			"2"
+	      }
+	      PropName		      "Parameters"
+	    }
+	  }
 	  System {
 	    Name		    "delay_bram"
-	    Location		    [137, 87, 917, 538]
+	    Location		    [103, 45, 931, 731]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -1037,17 +1264,23 @@ Library {
 	    TiledPageScale	    1
 	    ShowPageBoundaries	    off
 	    ZoomFactor		    "100"
+	    SIDHighWatermark	    "5"
 	    Block {
 	      BlockType		      Inport
 	      Name		      "In1"
+	      SID		      "12:1"
 	      Position		      [285, 128, 315, 142]
+	      ZOrder		      -1
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Constant2"
+	      SID		      "12:2"
 	      Ports		      [0, 1]
 	      Position		      [320, 143, 355, 167]
+	      ZOrder		      -2
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Constant"
 	      SourceType	      "Xilinx Constant Block Block"
 	      const		      "1"
@@ -1084,8 +1317,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Counter"
+	      SID		      "12:3"
 	      Ports		      [0, 1]
 	      Position		      [310, 70, 350, 110]
+	      ZOrder		      -3
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Counter"
 	      SourceType	      "Xilinx Counter Block"
 	      infoedit		      "Hardware notes: Free running counters are the least expensive in hardware.  A count limited co"
@@ -1113,18 +1349,23 @@ Library {
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "counter"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,40,1,1,white,blue,0,a170c862,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 1 1 0 ],[0 0 1 1 ],[0.77 0.82 0.91"
-	      "]);\npatch([0.25 0.075 0.3 0.075 0.25 0.525 0.6 0.675 0.95 0.725 0.5 0.35 0.6 0.35 0.5 0.725 0.95 0.675 0.6 0.5"
-	      "25 0.25 ],[0.1 0.275 0.5 0.725 0.9 0.9 0.825 0.9 0.9 0.675 0.9 0.75 0.5 0.25 0.1 0.325 0.1 0.1 0.175 0.1 0.1 ],"
-	      "[0.98 0.96 0.92]);\nplot([0 1 1 0 0 ],[0 0 1 1 0 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','CO"
-	      "MMENT: begin icon text');\ncolor('black');port_label('output',1,'out');\nfprintf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "40,40,0,1,white,blue,0,4b061529,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 40 40 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 40 40 0 0 ],[0 0 40 40 0 ]);\npatch([8.875 16.1 21.1 26.1 31.1 21.1 13.875 8.875 ],[25.55"
+	      " 25.55 30.55 25.55 30.55 30.55 30.55 25.55 ],[1 1 1 ]);\npatch([13.875 21.1 16.1 8.875 13.875 ],[20.55 20.55 25"
+	      ".55 25.55 20.55 ],[0.931 0.946 0.973 ]);\npatch([8.875 16.1 21.1 13.875 8.875 ],[15.55 15.55 20.55 20.55 15.55 "
+	      "],[1 1 1 ]);\npatch([13.875 31.1 26.1 21.1 16.1 8.875 13.875 ],[10.55 10.55 15.55 10.55 15.55 15.55 10.55 ],[0."
+	      "931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolo"
+	      "r('black');disp('{\\fontsize{14}\\bf\\lceil++\\rceil}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Single Port RAM"
+	      SID		      "12:4"
 	      Ports		      [3, 1]
 	      Position		      [370, 108, 435, 162]
+	      ZOrder		      -4
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Single Port RAM"
 	      SourceType	      "Xilinx Single Port Random Access Memory Block"
 	      depth		      "2^BitWidth"
@@ -1137,27 +1378,29 @@ Library {
 	      latency		      "bram_latency"
 	      dbl_ovrd		      off
 	      optimize		      "Area"
-	      use_rpm		      off
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "spram"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "65,54,1,1,white,blue,0,e5f9a5f3,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 1 1 0 ],[0 0 1 1 ],[0.77 0.82 0.91"
-	      "]);\npatch([0.276923 0.138462 0.338462 0.138462 0.276923 0.492308 0.553846 0.615385 0.846154 0.661538 0.476923 "
-	      "0.353846 0.569231 0.353846 0.476923 0.661538 0.846154 0.615385 0.553846 0.492308 0.276923 ],[0.111111 0.277778 "
-	      "0.518519 0.759259 0.925926 0.925926 0.851852 0.925926 0.925926 0.703704 0.925926 0.777778 0.518519 0.259259 0.1"
-	      "11111 0.333333 0.111111 0.111111 0.185185 0.111111 0.111111 ],[0.98 0.96 0.92]);\nplot([0 1 1 0 0 ],[0 0 1 1 0 "
-	      "]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_la"
-	      "bel('input',1,'addr');\ncolor('black');port_label('input',2,'data');\ncolor('black');port_label('input',3,'we')"
-	      ";\ncolor('black');disp('z^{-2}','texmode','on');\nfprintf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "65,54,3,1,white,blue,0,558c5cad,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 65 65 0 0 ],[0 0 54 54 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 65 65 0 0 ],[0 0 54 54 0 ]);\npatch([16.425 26.54 33.54 40.54 47.54 33.54 23.425 16.425 ]"
+	      ",[34.77 34.77 41.77 34.77 41.77 41.77 41.77 34.77 ],[1 1 1 ]);\npatch([23.425 33.54 26.54 16.425 23.425 ],[27.7"
+	      "7 27.77 34.77 34.77 27.77 ],[0.931 0.946 0.973 ]);\npatch([16.425 26.54 33.54 23.425 16.425 ],[20.77 20.77 27.7"
+	      "7 27.77 20.77 ],[1 1 1 ]);\npatch([23.425 47.54 40.54 33.54 26.54 16.425 23.425 ],[13.77 13.77 20.77 13.77 20.7"
+	      "7 20.77 13.77 ],[0.931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin i"
+	      "con text');\ncolor('black');port_label('input',1,'addr');\ncolor('black');port_label('input',2,'data');\ncolor("
+	      "'black');port_label('input',3,'we');\n\ncolor('black');disp('z^{-2}','texmode','on');\nfprintf('','COMMENT: end"
+	      " icon text');"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "Out1"
+	      SID		      "12:5"
 	      Position		      [455, 128, 485, 142]
+	      ZOrder		      -5
 	      IconDisplay	      "Port number"
 	    }
 	    Line {
@@ -1189,34 +1432,39 @@ Library {
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "pulse_ext"
+	  SID			  "13"
 	  Ports			  [1, 1]
 	  Position		  [70, 181, 105, 199]
+	  ZOrder		  -12
 	  MinAlgLoopOccurrences	  off
 	  PropExecContextOutsideSubsystem off
 	  RTWSystemCode		  "Auto"
 	  FunctionWithSeparateData off
 	  Opaque		  off
+	  RequestExecContextInheritance	off
 	  MaskHideContents	  off
-	  MaskType		  "pulse_ext"
-	  MaskDescription	  "Extends a boolean signal to be high for the specified number of clocks after\nthe last high inpu"
-	  "t."
-	  MaskHelp		  "eval('xlWeb(''http://casper.berkeley.edu/wiki/Pulse_ext'')')"
-	  MaskPromptString	  "Length of Pulse"
-	  MaskStyleString	  "edit"
-	  MaskVariables		  "pulse_len=@1;"
-	  MaskTunableValueString  "on"
-	  MaskEnableString	  "on"
-	  MaskVisibilityString	  "on"
-	  MaskToolTipString	  "on"
-	  MaskInitialization	  "bits = ceil(log2(pulse_len+1));"
-	  MaskIconFrame		  on
-	  MaskIconOpaque	  on
-	  MaskIconRotate	  "none"
-	  MaskIconUnits		  "autoscale"
-	  MaskValueString	  "vec_len"
+	  Object {
+	    $PropName		    "MaskObject"
+	    $ObjectID		    25
+	    $ClassName		    "Simulink.Mask"
+	    Type		    "pulse_ext"
+	    Description		    "Extends a boolean signal to be high for the specified number of clocks after\nthe last high inp"
+	    "ut."
+	    Help		    "eval('xlWeb(''http://casper.berkeley.edu/wiki/Pulse_ext'')')"
+	    Initialization	    "bits = ceil(log2(pulse_len+1));"
+	    Object {
+	      $PropName		      "Parameters"
+	      $ObjectID		      26
+	      $ClassName	      "Simulink.MaskParameter"
+	      Type		      "edit"
+	      Name		      "pulse_len"
+	      Prompt		      "Length of Pulse"
+	      Value		      "vec_len"
+	    }
+	  }
 	  System {
 	    Name		    "pulse_ext"
-	    Location		    [690, 701, 1252, 951]
+	    Location		    [656, 582, 1266, 1067]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -1232,14 +1480,19 @@ Library {
 	    Block {
 	      BlockType		      Inport
 	      Name		      "in"
+	      SID		      "14"
 	      Position		      [20, 43, 50, 57]
+	      ZOrder		      -1
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Constant5"
+	      SID		      "15"
 	      Ports		      [0, 1]
 	      Position		      [145, 109, 215, 141]
+	      ZOrder		      -2
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Constant"
 	      SourceType	      "Xilinx Constant Block Block"
 	      const		      "pulse_len"
@@ -1264,19 +1517,23 @@ Library {
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "constant"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "70,32,1,1,white,blue,0,636e1b21,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 1 1 0 ],[0 0 1 1 ],[0.77 0.82 0.91"
-	      "]);\npatch([0.371429 0.3 0.4 0.3 0.371429 0.485714 0.514286 0.542857 0.671429 0.571429 0.471429 0.4 0.5 0.4 0.4"
-	      "71429 0.571429 0.671429 0.542857 0.514286 0.485714 0.371429 ],[0.09375 0.25 0.46875 0.6875 0.84375 0.84375 0.78"
-	      "125 0.84375 0.84375 0.625 0.84375 0.6875 0.46875 0.25 0.09375 0.3125 0.09375 0.09375 0.15625 0.09375 0.09375 ],"
-	      "[0.98 0.96 0.92]);\nplot([0 1 1 0 0 ],[0 0 1 1 0 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','CO"
-	      "MMENT: begin icon text');\ncolor('black');port_label('output',1,'16');\nfprintf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "70,32,0,1,white,blue,0,eafdfd08,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 70 70 0 0 ],[0 0 32 32 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 70 70 0 0 ],[0 0 32 32 0 ]);\npatch([26.1 31.88 35.88 39.88 43.88 35.88 30.1 26.1 ],[20.4"
+	      "4 20.44 24.44 20.44 24.44 24.44 24.44 20.44 ],[1 1 1 ]);\npatch([30.1 35.88 31.88 26.1 30.1 ],[16.44 16.44 20.4"
+	      "4 20.44 16.44 ],[0.931 0.946 0.973 ]);\npatch([26.1 31.88 35.88 30.1 26.1 ],[12.44 12.44 16.44 16.44 12.44 ],[1"
+	      " 1 1 ]);\npatch([30.1 43.88 39.88 35.88 31.88 26.1 30.1 ],[8.44 8.44 12.44 8.44 12.44 12.44 8.44 ],[0.931 0.946"
+	      " 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');"
+	      "port_label('output',1,'16');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Counter3"
+	      SID		      "16"
 	      Ports		      [2, 1]
 	      Position		      [165, 35, 215, 90]
+	      ZOrder		      -3
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Counter"
 	      SourceType	      "Xilinx Counter Block"
 	      infoedit		      "Hardware notes: Free running counters are the least expensive in hardware.  A count limited co"
@@ -1304,20 +1561,24 @@ Library {
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "counter"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "50,55,1,1,white,blue,0,46c73e85,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 1 1 0 ],[0 0 1 1 ],[0.77 0.82 0.91"
-	      "]);\npatch([0.22 0.06 0.3 0.06 0.22 0.48 0.56 0.64 0.92 0.7 0.48 0.32 0.56 0.32 0.48 0.7 0.92 0.64 0.56 0.48 0."
-	      "22 ],[0.145455 0.290909 0.509091 0.727273 0.872727 0.872727 0.8 0.872727 0.872727 0.672727 0.872727 0.727273 0."
-	      "509091 0.290909 0.145455 0.345455 0.145455 0.145455 0.218182 0.145455 0.145455 ],[0.98 0.96 0.92]);\nplot([0 1 "
-	      "1 0 0 ],[0 0 1 1 0 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncol"
-	      "or('black');port_label('input',1,'rst');\ncolor('black');port_label('input',2,'en');\ncolor('black');port_label"
-	      "('output',1,'out');\nfprintf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "50,55,2,1,white,blue,0,ae3608d6,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 55 55 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 50 50 0 0 ],[0 0 55 55 0 ]);\npatch([9.425 19.54 26.54 33.54 40.54 26.54 16.425 9.425 ],["
+	      "34.77 34.77 41.77 34.77 41.77 41.77 41.77 34.77 ],[1 1 1 ]);\npatch([16.425 26.54 19.54 9.425 16.425 ],[27.77 2"
+	      "7.77 34.77 34.77 27.77 ],[0.931 0.946 0.973 ]);\npatch([9.425 19.54 26.54 16.425 9.425 ],[20.77 20.77 27.77 27."
+	      "77 20.77 ],[1 1 1 ]);\npatch([16.425 40.54 33.54 26.54 19.54 9.425 16.425 ],[13.77 13.77 20.77 13.77 20.77 20.7"
+	      "7 13.77 ],[0.931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon te"
+	      "xt');\ncolor('black');port_label('input',1,'rst');\ncolor('black');port_label('input',2,'en');\n\ncolor('black'"
+	      ");disp('{\\fontsize{14}\\bf++}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Relational5"
+	      SID		      "17"
 	      Ports		      [2, 1]
 	      Position		      [240, 93, 285, 137]
+	      ZOrder		      -4
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Relational"
 	      SourceType	      "Xilinx Arithmetic Relational Operator Block"
 	      mode		      "a!=b"
@@ -1343,18 +1604,21 @@ Library {
 	    Block {
 	      BlockType		      SubSystem
 	      Name		      "posedge"
+	      SID		      "18"
 	      Tag		      "Rising Edge Detector"
 	      Ports		      [1, 1]
 	      Position		      [85, 37, 130, 63]
+	      ZOrder		      -5
 	      MinAlgLoopOccurrences   off
 	      PropExecContextOutsideSubsystem off
 	      RTWSystemCode	      "Auto"
 	      FunctionWithSeparateData off
 	      Opaque		      off
+	      RequestExecContextInheritance off
 	      MaskHideContents	      off
 	      System {
 		Name			"posedge"
-		Location		[2, 82, 1014, 732]
+		Location		[12, 45, 1072, 930]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -1370,14 +1634,19 @@ Library {
 		Block {
 		  BlockType		  Inport
 		  Name			  "In"
+		  SID			  "19"
 		  Position		  [25, 43, 55, 57]
+		  ZOrder		  -1
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Delay"
+		  SID			  "20"
 		  Ports			  [1, 1]
 		  Position		  [75, 27, 120, 73]
+		  ZOrder		  -2
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Delay"
 		  SourceType		  "Xilinx Delay Block"
 		  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -1405,8 +1674,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter"
+		  SID			  "21"
 		  Ports			  [1, 1]
 		  Position		  [150, 33, 200, 67]
+		  ZOrder		  -3
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -1431,8 +1703,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical"
+		  SID			  "22"
 		  Ports			  [2, 1]
 		  Position		  [225, 29, 285, 116]
+		  ZOrder		  -4
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -1463,7 +1738,9 @@ Library {
 		Block {
 		  BlockType		  Outport
 		  Name			  "Out"
+		  SID			  "23"
 		  Position		  [305, 63, 335, 77]
+		  ZOrder		  -5
 		  IconDisplay		  "Port number"
 		}
 		Line {
@@ -1505,7 +1782,9 @@ Library {
 	    Block {
 	      BlockType		      Outport
 	      Name		      "out"
+	      SID		      "24"
 	      Position		      [325, 108, 355, 122]
+	      ZOrder		      -6
 	      IconDisplay	      "Port number"
 	    }
 	    Line {
@@ -1554,20 +1833,26 @@ Library {
 	Block {
 	  BlockType		  Outport
 	  Name			  "addr"
+	  SID			  "25"
 	  Position		  [495, 63, 525, 77]
+	  ZOrder		  -13
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Outport
 	  Name			  "dout"
+	  SID			  "26"
 	  Position		  [495, 103, 525, 117]
+	  ZOrder		  -14
 	  Port			  "2"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Outport
 	  Name			  "we"
+	  SID			  "27"
 	  Position		  [495, 13, 525, 27]
+	  ZOrder		  -15
 	  Port			  "3"
 	  IconDisplay		  "Port number"
 	}
@@ -1672,8 +1957,10 @@ Library {
     Block {
       BlockType		      SubSystem
       Name		      "dram_vacc"
+      SID		      "28"
       Ports		      [4, 4]
       Position		      [180, 17, 275, 118]
+      ZOrder		      -2
       BackgroundColor	      "[1.000000, 0.501961, 0.501961]"
       AttributesFormatString  "Vector Length: 18432"
       MinAlgLoopOccurrences   off
@@ -1681,30 +1968,58 @@ Library {
       RTWSystemCode	      "Auto"
       FunctionWithSeparateData off
       Opaque		      off
+      RequestExecContextInheritance off
       MaskHideContents	      off
-      MaskType		      "dram_vacc"
-      MaskDescription	      "A vector accumulator for very large vector lengths using the BEE2's DRAM."
-      MaskHelp		      "eval('xlWeb(''http://casper.berkeley.edu/wiki/Dram_vacc'')')"
-      MaskPromptString	      "Vector length??(# cycles)|Use DIMM number|Simulation (disables startup delay)"
-      MaskStyleString	      "edit,popup(1|2|3|4),checkbox"
-      MaskVariables	      "acc_length=@1;dimm_sel=@2;sim_sel=@3;"
-      MaskTunableValueString  "on,on,on"
-      MaskCallbackString      "||"
-      MaskEnableString	      "on,on,on"
-      MaskVisibilityString    "on,on,on"
-      MaskToolTipString	      "on,on,on"
-      MaskInitialization      "valid_length = 36;\nset_param([gcb,'/dram'],'dimm',num2str(dimm_sel))\nif (sim_sel)\n  "
-      "  fprintf('DRAM_VACC in SIMULATION-ONLY mode\\n\\n')\n    set_param([gcb,'/startup_delay'],'const','400')\nelse "
-      "\n    set_param([gcb,'/startup_delay'],'const','(2^28-1)')\nend\nfmtstr = sprintf('Vector Length: %d', acc_lengt"
-      "h);\nset_param(gcb, 'AttributesFormatString', fmtstr);\n"
-      MaskIconFrame	      on
-      MaskIconOpaque	      on
-      MaskIconRotate	      "none"
-      MaskIconUnits	      "autoscale"
-      MaskValueString	      "18432|1|off"
+      Object {
+	$PropName		"MaskObject"
+	$ObjectID		27
+	$ClassName		"Simulink.Mask"
+	Type			"dram_vacc"
+	Description		"A vector accumulator for very large vector lengths using the BEE2's DRAM."
+	Help			"eval('xlWeb(''http://casper.berkeley.edu/wiki/Dram_vacc'')')"
+	Initialization		"valid_length = 36;\nset_param([gcb,'/dram'],'dimm',num2str(dimm_sel))\nif (sim_sel)\n    fprintf('DR"
+	"AM_VACC in SIMULATION-ONLY mode\\n\\n')\n    set_param([gcb,'/startup_delay'],'const','400')\nelse \n    set_param([g"
+	"cb,'/startup_delay'],'const','(2^28-1)')\nend\nfmtstr = sprintf('Vector Length: %d', acc_length);\nset_param(gcb, 'At"
+	"tributesFormatString', fmtstr);\n"
+	Array {
+	  Type			  "Simulink.MaskParameter"
+	  Dimension		  3
+	  Object {
+	    $ObjectID		    28
+	    Type		    "edit"
+	    Name		    "acc_length"
+	    Prompt		    "Vector length??(# cycles)"
+	    Value		    "18432"
+	  }
+	  Object {
+	    $ObjectID		    29
+	    Type		    "popup"
+	    Array {
+	      Type		      "Cell"
+	      Dimension		      4
+	      Cell		      "1"
+	      Cell		      "2"
+	      Cell		      "3"
+	      Cell		      "4"
+	      PropName		      "TypeOptions"
+	    }
+	    Name		    "dimm_sel"
+	    Prompt		    "Use DIMM number"
+	    Value		    "1"
+	  }
+	  Object {
+	    $ObjectID		    30
+	    Type		    "checkbox"
+	    Name		    "sim_sel"
+	    Prompt		    "Simulation (disables startup delay)"
+	    Value		    "off"
+	  }
+	  PropName		  "Parameters"
+	}
+      }
       System {
 	Name			"dram_vacc"
-	Location		[32, 125, 1172, 755]
+	Location		[12, 45, 1200, 910]
 	Open			off
 	ModelBrowserVisibility	off
 	ModelBrowserWidth	200
@@ -1720,45 +2035,56 @@ Library {
 	Block {
 	  BlockType		  Inport
 	  Name			  "new_acc"
+	  SID			  "29"
 	  Position		  [15, 168, 45, 182]
+	  ZOrder		  -1
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Inport
 	  Name			  "data_in"
+	  SID			  "30"
 	  Position		  [15, 208, 45, 222]
+	  ZOrder		  -2
 	  Port			  "2"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Inport
 	  Name			  "valid_data"
+	  SID			  "31"
 	  Position		  [20, 273, 50, 287]
+	  ZOrder		  -3
 	  Port			  "3"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Inport
 	  Name			  "ack_RB"
+	  SID			  "32"
 	  Position		  [2195, 288, 2225, 302]
+	  ZOrder		  -4
 	  Port			  "4"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "Adder"
+	  SID			  "33"
 	  Ports			  [6, 6]
 	  Position		  [755, 163, 940, 357]
+	  ZOrder		  -5
 	  BackgroundColor	  "yellow"
 	  MinAlgLoopOccurrences	  off
 	  PropExecContextOutsideSubsystem off
 	  RTWSystemCode		  "Auto"
 	  FunctionWithSeparateData off
 	  Opaque		  off
+	  RequestExecContextInheritance	off
 	  MaskHideContents	  off
 	  System {
 	    Name		    "Adder"
-	    Location		    [2, 74, 1126, 724]
+	    Location		    [12, 45, 1184, 930]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -1774,49 +2100,64 @@ Library {
 	    Block {
 	      BlockType		      Inport
 	      Name		      "FIFO_data"
+	      SID		      "34"
 	      Position		      [65, 223, 95, 237]
+	      ZOrder		      -1
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "valid_FIFO_data"
+	      SID		      "35"
 	      Position		      [860, 468, 890, 482]
+	      ZOrder		      -2
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "dram_data"
+	      SID		      "36"
 	      Position		      [45, 538, 75, 552]
+	      ZOrder		      -3
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "valid_dram_data"
+	      SID		      "37"
 	      Position		      [855, 528, 885, 542]
+	      ZOrder		      -4
 	      Port		      "4"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "ctrl_ready"
+	      SID		      "38"
 	      Position		      [65, 133, 95, 147]
+	      ZOrder		      -5
 	      Port		      "5"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "output_fifo_empty"
+	      SID		      "39"
 	      Position		      [80, 848, 110, 862]
+	      ZOrder		      -6
 	      Port		      "6"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "AddSub4"
+	      SID		      "40"
 	      Ports		      [3, 1]
 	      Position		      [895, 173, 945, 207]
+	      ZOrder		      -7
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/AddSub"
 	      SourceType	      "Xilinx Adder/Subtracter Block"
 	      mode		      "Addition"
@@ -1856,8 +2197,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "AddSub5"
+	      SID		      "41"
 	      Ports		      [3, 1]
 	      Position		      [895, 223, 945, 257]
+	      ZOrder		      -8
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/AddSub"
 	      SourceType	      "Xilinx Adder/Subtracter Block"
 	      mode		      "Addition"
@@ -1897,8 +2241,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "AddSub6"
+	      SID		      "42"
 	      Ports		      [3, 1]
 	      Position		      [895, 273, 945, 307]
+	      ZOrder		      -9
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/AddSub"
 	      SourceType	      "Xilinx Adder/Subtracter Block"
 	      mode		      "Addition"
@@ -1938,8 +2285,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "AddSub7"
+	      SID		      "43"
 	      Ports		      [3, 1]
 	      Position		      [895, 323, 945, 357]
+	      ZOrder		      -10
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/AddSub"
 	      SourceType	      "Xilinx Adder/Subtracter Block"
 	      mode		      "Addition"
@@ -1979,8 +2329,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Concat1"
+	      SID		      "44"
 	      Ports		      [2, 1]
 	      Position		      [1160, 256, 1205, 294]
+	      ZOrder		      -11
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Concat"
 	      SourceType	      "Xilinx Bus Concatenator Block"
 	      infoedit		      "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary poi"
@@ -2004,8 +2357,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Concat1v1"
+	      SID		      "45"
 	      Ports		      [2, 1]
 	      Position		      [1005, 190, 1045, 230]
+	      ZOrder		      -12
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Concat"
 	      SourceType	      "Xilinx Bus Concatenator Block"
 	      infoedit		      "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary poi"
@@ -2029,8 +2385,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Concat4"
+	      SID		      "46"
 	      Ports		      [2, 1]
 	      Position		      [1005, 290, 1045, 330]
+	      ZOrder		      -13
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Concat"
 	      SourceType	      "Xilinx Bus Concatenator Block"
 	      infoedit		      "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary poi"
@@ -2054,8 +2413,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Constant"
+	      SID		      "47"
 	      Ports		      [0, 1]
 	      Position		      [585, 357, 625, 383]
+	      ZOrder		      -14
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Constant"
 	      SourceType	      "Xilinx Constant Block Block"
 	      const		      "0"
@@ -2092,8 +2454,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Convert"
+	      SID		      "48"
 	      Ports		      [1, 1]
 	      Position		      [1035, 535, 1060, 555]
+	      ZOrder		      -15
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -2129,8 +2494,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Convert1"
+	      SID		      "49"
 	      Ports		      [1, 1]
 	      Position		      [1015, 465, 1040, 485]
+	      ZOrder		      -16
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -2166,8 +2534,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Convert2"
+	      SID		      "50"
 	      Ports		      [1, 1]
 	      Position		      [175, 130, 200, 150]
+	      ZOrder		      -17
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -2203,8 +2574,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay1"
+	      SID		      "51"
 	      Ports		      [2, 1]
 	      Position		      [1295, 467, 1335, 503]
+	      ZOrder		      -18
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -2234,50 +2608,62 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From"
+	      SID		      "52"
 	      Position		      [1705, 446, 1745, 464]
+	      ZOrder		      -19
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "Data"
 	    }
 	    Block {
 	      BlockType		      From
 	      Name		      "From1"
+	      SID		      "53"
 	      Position		      [1705, 551, 1745, 569]
+	      ZOrder		      -20
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "ctrl_ready"
 	    }
 	    Block {
 	      BlockType		      From
 	      Name		      "From2"
+	      SID		      "54"
 	      Position		      [1705, 511, 1745, 529]
+	      ZOrder		      -21
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "sync_ctrl"
 	    }
 	    Block {
 	      BlockType		      Goto
 	      Name		      "Goto"
+	      SID		      "55"
 	      Position		      [1245, 265, 1295, 285]
+	      ZOrder		      -22
 	      GotoTag		      "Data"
-	      TagVisibility	      "local"
 	    }
 	    Block {
 	      BlockType		      Goto
 	      Name		      "Goto1"
+	      SID		      "56"
 	      Position		      [350, 175, 395, 195]
+	      ZOrder		      -23
 	      GotoTag		      "ctrl_ready"
-	      TagVisibility	      "local"
 	    }
 	    Block {
 	      BlockType		      Goto
 	      Name		      "Goto2"
+	      SID		      "57"
 	      Position		      [780, 865, 830, 885]
+	      ZOrder		      -24
 	      GotoTag		      "sync_ctrl"
-	      TagVisibility	      "local"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical1"
+	      SID		      "58"
 	      Ports		      [2, 1]
 	      Position		      [1155, 573, 1180, 602]
+	      ZOrder		      -25
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "OR"
@@ -2308,9 +2694,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical3"
+	      SID		      "59"
 	      Ports		      [2, 1]
 	      Position		      [995, 528, 1020, 557]
+	      ZOrder		      -26
 	      NamePlacement	      "alternate"
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -2341,8 +2730,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical4"
+	      SID		      "60"
 	      Ports		      [2, 1]
 	      Position		      [1155, 483, 1180, 512]
+	      ZOrder		      -27
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "OR"
@@ -2373,8 +2765,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Mux"
+	      SID		      "61"
 	      Ports		      [3, 1]
 	      Position		      [705, 382, 730, 448]
+	      ZOrder		      -28
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Mux"
 	      SourceType	      "Xilinx Bus Multiplexer Block"
 	      inputs		      "2"
@@ -2407,8 +2802,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Mux1"
+	      SID		      "62"
 	      Ports		      [3, 1]
 	      Position		      [705, 472, 730, 538]
+	      ZOrder		      -29
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Mux"
 	      SourceType	      "Xilinx Bus Multiplexer Block"
 	      inputs		      "2"
@@ -2441,8 +2839,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Mux2"
+	      SID		      "63"
 	      Ports		      [3, 1]
 	      Position		      [705, 562, 730, 628]
+	      ZOrder		      -30
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Mux"
 	      SourceType	      "Xilinx Bus Multiplexer Block"
 	      inputs		      "2"
@@ -2475,8 +2876,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Mux3"
+	      SID		      "64"
 	      Ports		      [3, 1]
 	      Position		      [705, 647, 730, 713]
+	      ZOrder		      -31
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Mux"
 	      SourceType	      "Xilinx Bus Multiplexer Block"
 	      inputs		      "2"
@@ -2509,8 +2913,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret"
+	      SID		      "65"
 	      Ports		      [1, 1]
 	      Position		      [705, 172, 740, 188]
+	      ZOrder		      -32
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -2538,8 +2945,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret1"
+	      SID		      "66"
 	      Ports		      [1, 1]
 	      Position		      [705, 222, 740, 238]
+	      ZOrder		      -33
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -2567,8 +2977,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret10"
+	      SID		      "67"
 	      Ports		      [1, 1]
 	      Position		      [965, 292, 985, 308]
+	      ZOrder		      -34
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -2596,8 +3009,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret11"
+	      SID		      "68"
 	      Ports		      [1, 1]
 	      Position		      [965, 312, 985, 328]
+	      ZOrder		      -35
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -2625,8 +3041,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret2"
+	      SID		      "69"
 	      Ports		      [1, 1]
 	      Position		      [705, 272, 740, 288]
+	      ZOrder		      -36
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -2654,8 +3073,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret3"
+	      SID		      "70"
 	      Ports		      [1, 1]
 	      Position		      [705, 322, 740, 338]
+	      ZOrder		      -37
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -2683,8 +3105,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret4"
+	      SID		      "71"
 	      Ports		      [1, 1]
 	      Position		      [600, 407, 635, 423]
+	      ZOrder		      -38
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -2712,8 +3137,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret5"
+	      SID		      "72"
 	      Ports		      [1, 1]
 	      Position		      [600, 497, 635, 513]
+	      ZOrder		      -39
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -2741,8 +3169,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret6"
+	      SID		      "73"
 	      Ports		      [1, 1]
 	      Position		      [600, 587, 635, 603]
+	      ZOrder		      -40
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -2770,8 +3201,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret7"
+	      SID		      "74"
 	      Ports		      [1, 1]
 	      Position		      [600, 672, 635, 688]
+	      ZOrder		      -41
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -2799,8 +3233,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret8"
+	      SID		      "75"
 	      Ports		      [1, 1]
 	      Position		      [965, 192, 985, 208]
+	      ZOrder		      -42
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -2828,8 +3265,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret9"
+	      SID		      "76"
 	      Ports		      [1, 1]
 	      Position		      [965, 212, 985, 228]
+	      ZOrder		      -43
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -2857,8 +3297,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice1"
+	      SID		      "77"
 	      Ports		      [1, 1]
 	      Position		      [170, 221, 220, 239]
+	      ZOrder		      -44
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -2888,8 +3331,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice15"
+	      SID		      "78"
 	      Ports		      [1, 1]
 	      Position		      [615, 171, 665, 189]
+	      ZOrder		      -45
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -2919,8 +3365,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice16"
+	      SID		      "79"
 	      Ports		      [1, 1]
 	      Position		      [615, 222, 665, 238]
+	      ZOrder		      -46
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -2950,8 +3399,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice17"
+	      SID		      "80"
 	      Ports		      [1, 1]
 	      Position		      [615, 272, 665, 288]
+	      ZOrder		      -47
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -2981,8 +3433,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice18"
+	      SID		      "81"
 	      Ports		      [1, 1]
 	      Position		      [615, 321, 665, 339]
+	      ZOrder		      -48
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -3012,8 +3467,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice2"
+	      SID		      "82"
 	      Ports		      [1, 1]
 	      Position		      [520, 406, 570, 424]
+	      ZOrder		      -49
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -3043,8 +3501,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice3"
+	      SID		      "83"
 	      Ports		      [1, 1]
 	      Position		      [520, 497, 570, 513]
+	      ZOrder		      -50
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -3074,8 +3535,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice4"
+	      SID		      "84"
 	      Ports		      [1, 1]
 	      Position		      [520, 587, 570, 603]
+	      ZOrder		      -51
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -3105,8 +3569,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice5"
+	      SID		      "85"
 	      Ports		      [1, 1]
 	      Position		      [520, 671, 570, 689]
+	      ZOrder		      -52
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -3136,8 +3603,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "and1"
+	      SID		      "86"
 	      Ports		      [2, 1]
 	      Position		      [1325, 649, 1345, 696]
+	      ZOrder		      -53
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "OR"
@@ -3168,8 +3638,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "and2"
+	      SID		      "87"
 	      Ports		      [2, 1]
 	      Position		      [1100, 462, 1120, 513]
+	      ZOrder		      -54
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -3200,8 +3673,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "and3"
+	      SID		      "88"
 	      Ports		      [2, 1]
 	      Position		      [1420, 472, 1440, 523]
+	      ZOrder		      -55
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -3232,8 +3708,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "and4"
+	      SID		      "89"
 	      Ports		      [2, 1]
 	      Position		      [1420, 552, 1440, 603]
+	      ZOrder		      -56
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -3264,8 +3743,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "and5"
+	      SID		      "90"
 	      Ports		      [2, 1]
 	      Position		      [1420, 637, 1440, 688]
+	      ZOrder		      -57
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -3296,8 +3778,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "cast2"
+	      SID		      "91"
 	      Ports		      [1, 1]
 	      Position		      [1060, 200, 1090, 220]
+	      ZOrder		      -58
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -3333,8 +3818,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "cast3"
+	      SID		      "92"
 	      Ports		      [1, 1]
 	      Position		      [1060, 300, 1090, 320]
+	      ZOrder		      -59
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -3370,17 +3858,20 @@ Library {
 	    Block {
 	      BlockType		      SubSystem
 	      Name		      "even_ctrl"
+	      SID		      "93"
 	      Ports		      [4, 3]
 	      Position		      [1790, 436, 1965, 579]
+	      ZOrder		      -60
 	      MinAlgLoopOccurrences   off
 	      PropExecContextOutsideSubsystem off
 	      RTWSystemCode	      "Auto"
 	      FunctionWithSeparateData off
 	      Opaque		      off
+	      RequestExecContextInheritance off
 	      MaskHideContents	      off
 	      System {
 		Name			"even_ctrl"
-		Location		[2, 175, 1126, 824]
+		Location		[12, 56, 1184, 940]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -3396,35 +3887,46 @@ Library {
 		Block {
 		  BlockType		  Inport
 		  Name			  "Data"
+		  SID			  "94"
 		  Position		  [65, 118, 95, 132]
+		  ZOrder		  -1
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "valid_in"
+		  SID			  "95"
 		  Position		  [40, 513, 70, 527]
+		  ZOrder		  -2
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "sync_indicator"
+		  SID			  "96"
 		  Position		  [45, 649, 80, 661]
+		  ZOrder		  -3
 		  Port			  "3"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "ctrl_ready"
+		  SID			  "97"
 		  Position		  [65, 418, 95, 432]
+		  ZOrder		  -4
 		  Port			  "4"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Constant"
+		  SID			  "98"
 		  Ports			  [0, 1]
 		  Position		  [470, 658, 505, 672]
+		  ZOrder		  -5
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "2^18-1"
@@ -3461,8 +3963,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Constant1"
+		  SID			  "99"
 		  Ports			  [0, 1]
 		  Position		  [470, 683, 505, 697]
+		  ZOrder		  -6
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "0"
@@ -3499,8 +4004,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Convert1"
+		  SID			  "100"
 		  Ports			  [1, 1]
 		  Position		  [475, 630, 500, 650]
+		  ZOrder		  -7
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Convert"
 		  SourceType		  "Xilinx Type Converter Block"
 		  infoedit		  "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do not."
@@ -3535,8 +4043,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Convert2"
+		  SID			  "101"
 		  Ports			  [1, 1]
 		  Position		  [420, 820, 445, 840]
+		  ZOrder		  -8
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Convert"
 		  SourceType		  "Xilinx Type Converter Block"
 		  infoedit		  "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do not."
@@ -3571,106 +4082,133 @@ Library {
 		Block {
 		  BlockType		  From
 		  Name			  "From0"
+		  SID			  "102"
 		  Position		  [290, 326, 345, 344]
+		  ZOrder		  -9
 		  CloseFcn		  "tagdialog Close"
 		  GotoTag		  "State0"
 		}
 		Block {
 		  BlockType		  From
 		  Name			  "From1"
+		  SID			  "103"
 		  Position		  [690, 331, 745, 349]
+		  ZOrder		  -10
 		  CloseFcn		  "tagdialog Close"
 		  GotoTag		  "State0"
 		}
 		Block {
 		  BlockType		  From
 		  Name			  "From2"
+		  SID			  "104"
 		  Position		  [690, 416, 745, 434]
+		  ZOrder		  -11
 		  CloseFcn		  "tagdialog Close"
 		  GotoTag		  "State1"
 		}
 		Block {
 		  BlockType		  From
 		  Name			  "From3"
+		  SID			  "105"
 		  Position		  [40, 686, 95, 704]
+		  ZOrder		  -12
 		  CloseFcn		  "tagdialog Close"
 		  GotoTag		  "State0"
 		}
 		Block {
 		  BlockType		  From
 		  Name			  "From4"
+		  SID			  "106"
 		  Position		  [250, 821, 305, 839]
+		  ZOrder		  -13
 		  CloseFcn		  "tagdialog Close"
 		  GotoTag		  "valid_out"
 		}
 		Block {
 		  BlockType		  From
 		  Name			  "From5"
+		  SID			  "107"
 		  Position		  [225, 201, 280, 219]
+		  ZOrder		  -14
 		  CloseFcn		  "tagdialog Close"
 		  GotoTag		  "ctrl_ready"
 		}
 		Block {
 		  BlockType		  From
 		  Name			  "From6"
+		  SID			  "108"
 		  Position		  [385, 291, 440, 309]
+		  ZOrder		  -15
 		  CloseFcn		  "tagdialog Close"
 		  GotoTag		  "ctrl_ready"
 		}
 		Block {
 		  BlockType		  From
 		  Name			  "From7"
+		  SID			  "109"
 		  Position		  [935, 381, 990, 399]
+		  ZOrder		  -16
 		  CloseFcn		  "tagdialog Close"
 		  GotoTag		  "ctrl_ready"
 		}
 		Block {
 		  BlockType		  From
 		  Name			  "From8"
+		  SID			  "110"
 		  Position		  [465, 716, 520, 734]
+		  ZOrder		  -17
 		  CloseFcn		  "tagdialog Close"
 		  GotoTag		  "ctrl_ready"
 		}
 		Block {
 		  BlockType		  From
 		  Name			  "From9"
+		  SID			  "111"
 		  Position		  [200, 726, 255, 744]
+		  ZOrder		  -18
 		  CloseFcn		  "tagdialog Close"
 		  GotoTag		  "ctrl_ready"
 		}
 		Block {
 		  BlockType		  Goto
 		  Name			  "Goto"
+		  SID			  "112"
 		  Position		  [540, 846, 600, 864]
+		  ZOrder		  -19
 		  GotoTag		  "State1"
-		  TagVisibility		  "local"
 		}
 		Block {
 		  BlockType		  Goto
 		  Name			  "Goto1"
+		  SID			  "113"
 		  Position		  [540, 791, 600, 809]
+		  ZOrder		  -20
 		  GotoTag		  "State0"
-		  TagVisibility		  "local"
 		}
 		Block {
 		  BlockType		  Goto
 		  Name			  "Goto2"
+		  SID			  "114"
 		  Position		  [145, 416, 205, 434]
+		  ZOrder		  -21
 		  GotoTag		  "ctrl_ready"
-		  TagVisibility		  "local"
 		}
 		Block {
 		  BlockType		  Goto
 		  Name			  "Goto3"
+		  SID			  "115"
 		  Position		  [1095, 451, 1155, 469]
+		  ZOrder		  -22
 		  GotoTag		  "valid_out"
-		  TagVisibility		  "local"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter1"
+		  SID			  "116"
 		  Ports			  [1, 1]
 		  Position		  [445, 353, 470, 367]
+		  ZOrder		  -23
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -3695,9 +4233,12 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter2"
+		  SID			  "117"
 		  Ports			  [1, 1]
 		  Position		  [360, 410, 380, 450]
-		  Orientation		  "up"
+		  ZOrder		  -24
+		  BlockRotation		  270
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -3722,8 +4263,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter3"
+		  SID			  "118"
 		  Ports			  [1, 1]
 		  Position		  [485, 792, 510, 808]
+		  ZOrder		  -25
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -3748,8 +4292,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical"
+		  SID			  "119"
 		  Ports			  [3, 1]
 		  Position		  [410, 333, 430, 387]
+		  ZOrder		  -26
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -3780,8 +4327,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical1"
+		  SID			  "120"
 		  Ports			  [3, 1]
 		  Position		  [790, 329, 820, 381]
+		  ZOrder		  -27
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -3812,8 +4362,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical2"
+		  SID			  "121"
 		  Ports			  [2, 1]
 		  Position		  [485, 320, 505, 375]
+		  ZOrder		  -28
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -3844,8 +4397,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical3"
+		  SID			  "122"
 		  Ports			  [2, 1]
 		  Position		  [860, 386, 890, 439]
+		  ZOrder		  -29
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "OR"
@@ -3876,8 +4432,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical4"
+		  SID			  "123"
 		  Ports			  [3, 1]
 		  Position		  [170, 648, 190, 702]
+		  ZOrder		  -30
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -3908,8 +4467,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical5"
+		  SID			  "124"
 		  Ports			  [2, 1]
 		  Position		  [245, 512, 265, 543]
+		  ZOrder		  -31
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "OR"
@@ -3940,8 +4502,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical6"
+		  SID			  "125"
 		  Ports			  [2, 1]
 		  Position		  [1025, 376, 1055, 429]
+		  ZOrder		  -32
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -3972,8 +4537,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Mux"
+		  SID			  "126"
 		  Ports			  [4, 1]
 		  Position		  [570, 628, 615, 727]
+		  ZOrder		  -33
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Mux"
 		  SourceType		  "Xilinx Bus Multiplexer Block"
 		  inputs		  "2"
@@ -4006,8 +4574,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Register5"
+		  SID			  "127"
 		  Ports			  [2, 1]
 		  Position		  [300, 612, 355, 668]
+		  ZOrder		  -34
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Register"
 		  SourceType		  "Xilinx Register Block"
 		  init			  "0"
@@ -4033,8 +4604,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "dreg0"
+		  SID			  "128"
 		  Ports			  [2, 1]
 		  Position		  [565, 84, 625, 251]
+		  ZOrder		  -35
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Register"
 		  SourceType		  "Xilinx Register Block"
 		  init			  "0"
@@ -4060,8 +4634,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "dreg1"
+		  SID			  "129"
 		  Ports			  [2, 1]
 		  Position		  [300, 84, 360, 251]
+		  ZOrder		  -36
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Register"
 		  SourceType		  "Xilinx Register Block"
 		  init			  "0"
@@ -4087,8 +4664,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "state"
+		  SID			  "130"
 		  Ports			  [1, 1]
 		  Position		  [345, 805, 400, 855]
+		  ZOrder		  -37
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Counter"
 		  SourceType		  "Xilinx Counter Block"
 		  infoedit		  "Hardware notes: Free running counters are the least expensive in hardware.  A count limited counter i"
@@ -4116,18 +4696,24 @@ Library {
 		  sggui_pos		  "-1,-1,-1,-1"
 		  block_type		  "counter"
 		  block_version		  "9.2.01"
-		  sg_icon_stat		  "55,50,1,1,white,blue,0,1018756c,right"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 60 60 ],[0.77 0.82 0.91]);"
-		  "\npatch([14 4 18 4 14 30 34 38 55 42 29 20 35 20 29 42 55 38 34 30 14 ],[6 16 30 44 54 54 50 54 54 41 54 45 30 15 "
-		  "6 19 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 60 60 0 ]);\nfprintf('','COMMENT: end icon graphics"
-		  "');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('input',1,'en');\ncolor('black');port_labe"
-		  "l('output',1,'out');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_icon_stat		  "55,50,1,1,white,blue,0,b089e9c5,right,,[ ],[ ]"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 0 ],[0 0 50 50 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 55 55 0 0 ],[0 0 50 50 0 ]);\npatch([11.425 21.54 28.54 35.54 42.54 28.54 18.425 11.425 ],[32.77 32"
+		  ".77 39.77 32.77 39.77 39.77 39.77 32.77 ],[1 1 1 ]);\npatch([18.425 28.54 21.54 11.425 18.425 ],[25.77 25.77 32.77"
+		  " 32.77 25.77 ],[0.931 0.946 0.973 ]);\npatch([11.425 21.54 28.54 18.425 11.425 ],[18.77 18.77 25.77 25.77 18.77 ],"
+		  "[1 1 1 ]);\npatch([18.425 42.54 35.54 28.54 21.54 11.425 18.425 ],[11.77 11.77 18.77 11.77 18.77 18.77 11.77 ],[0."
+		  "931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('bl"
+		  "ack');port_label('input',1,'en');\n\ncolor('black');disp('{\\fontsize{14}\\bf++}','texmode','on');\nfprintf('','CO"
+		  "MMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "vreg0"
+		  SID			  "131"
 		  Ports			  [2, 1]
 		  Position		  [565, 517, 620, 573]
+		  ZOrder		  -38
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Register"
 		  SourceType		  "Xilinx Register Block"
 		  init			  "0"
@@ -4153,8 +4739,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "vreg1"
+		  SID			  "132"
 		  Ports			  [2, 1]
 		  Position		  [300, 517, 355, 573]
+		  ZOrder		  -39
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Register"
 		  SourceType		  "Xilinx Register Block"
 		  init			  "0"
@@ -4180,74 +4769,65 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period dreg00"
+		  SID			  "133"
 		  Ports			  []
 		  Position		  [612, 59, 638, 84]
+		  ZOrder		  -40
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period vreg00"
+		  SID			  "134"
 		  Ports			  []
 		  Position		  [607, 492, 633, 517]
+		  ZOrder		  -41
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period vreg10"
+		  SID			  "135"
 		  Ports			  []
 		  Position		  [342, 492, 368, 517]
+		  ZOrder		  -42
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "output"
+		  SID			  "136"
 		  Position		  [885, 163, 915, 177]
+		  ZOrder		  -43
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "valid_out"
+		  SID			  "137"
 		  Position		  [1110, 398, 1140, 412]
+		  ZOrder		  -44
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "wr_be"
+		  SID			  "138"
 		  Position		  [710, 673, 740, 687]
+		  ZOrder		  -45
 		  Port			  "3"
 		  IconDisplay		  "Port number"
 		}
@@ -4542,19 +5122,23 @@ Library {
 		  }
 		}
 		Annotation {
+		  SID			  "139"
 		  Name			  "\n"
 		  Position		  [202, 753]
 		}
 		Annotation {
+		  SID			  "140"
 		  Name			  "If we are at state0\nand we have the first bunch of data\nbut not the second one,\nwe disable the first "
 		  "regiester till we\nget the second valid  data."
 		  Position		  [177, 335]
 		}
 		Annotation {
+		  SID			  "141"
 		  Name			  "When the ctrl_ready is low\nwe should disable everything \nand mask the critical outputs"
 		  Position		  [124, 472]
 		}
 		Annotation {
+		  SID			  "142"
 		  Name			  "If you are in State1 \nyou are gauranteed to have\nvalid output at reg0"
 		  Position		  [759, 483]
 		}
@@ -4563,18 +5147,21 @@ Library {
 	    Block {
 	      BlockType		      SubSystem
 	      Name		      "initializer"
+	      SID		      "143"
 	      Ports		      [5, 6]
 	      Position		      [315, 769, 485, 881]
+	      ZOrder		      -61
 	      BackgroundColor	      "[1.000000, 0.501961, 0.501961]"
 	      MinAlgLoopOccurrences   off
 	      PropExecContextOutsideSubsystem off
 	      RTWSystemCode	      "Auto"
 	      FunctionWithSeparateData off
 	      Opaque		      off
+	      RequestExecContextInheritance off
 	      MaskHideContents	      off
 	      System {
 		Name			"initializer"
-		Location		[0, 87, 1124, 717]
+		Location		[12, 45, 1184, 910]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -4590,42 +5177,55 @@ Library {
 		Block {
 		  BlockType		  Inport
 		  Name			  "sync"
+		  SID			  "144"
 		  Position		  [165, 163, 195, 177]
+		  ZOrder		  -1
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "valid_fifo_data"
+		  SID			  "145"
 		  Position		  [650, 483, 680, 497]
+		  ZOrder		  -2
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "ctrl_ready"
+		  SID			  "146"
 		  Position		  [165, 498, 195, 512]
+		  ZOrder		  -3
 		  Port			  "3"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "valid_output"
+		  SID			  "147"
 		  Position		  [890, 918, 920, 932]
+		  ZOrder		  -4
 		  Port			  "4"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "output_fifo_empty"
+		  SID			  "148"
 		  Position		  [165, 418, 195, 432]
+		  ZOrder		  -5
 		  Port			  "5"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Constant1"
+		  SID			  "149"
 		  Ports			  [0, 1]
 		  Position		  [1290, 329, 1315, 351]
+		  ZOrder		  -6
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "34"
@@ -4662,8 +5262,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Constant2"
+		  SID			  "150"
 		  Ports			  [0, 1]
 		  Position		  [540, 599, 565, 621]
+		  ZOrder		  -7
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "7"
@@ -4700,8 +5303,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Constant3"
+		  SID			  "151"
 		  Ports			  [0, 1]
 		  Position		  [525, 764, 550, 786]
+		  ZOrder		  -8
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "14"
@@ -4738,8 +5344,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Constant4"
+		  SID			  "152"
 		  Ports			  [0, 1]
 		  Position		  [1090, 947, 1130, 973]
+		  ZOrder		  -9
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "acc_length-2"
@@ -4764,18 +5373,23 @@ Library {
 		  sggui_pos		  "-1,-1,-1,-1"
 		  block_type		  "constant"
 		  block_version		  "9.2.01"
-		  sg_icon_stat		  "40,26,0,1,white,blue,0,944cc4c1,right"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 ],[0 0 26 26 ],[0.77 0.82 0.91]);"
-		  "\npatch([20 16 22 16 20 27 29 31 38 32 26 22 28 22 26 32 38 31 29 27 20 ],[3 7 13 19 23 23 21 23 23 17 23 19 13 7 "
-		  "3 9 3 3 5 3 3 ],[0.98 0.96 0.92]);\nplot([0 55 55 0 0 ],[0 0 26 26 0 ]);\nfprintf('','COMMENT: end icon graphics')"
-		  ";\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'18430');\nfprintf('','COMMENT: e"
-		  "nd icon text');\n"
+		  sg_icon_stat		  "40,26,0,1,white,blue,0,2f779e4a,right,,[ ],[ ]"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 26 26 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 40 40 0 0 ],[0 0 26 26 0 ]);\npatch([13.325 17.66 20.66 23.66 26.66 20.66 16.325 13.325 ],[16.33 16"
+		  ".33 19.33 16.33 19.33 19.33 19.33 16.33 ],[1 1 1 ]);\npatch([16.325 20.66 17.66 13.325 16.325 ],[13.33 13.33 16.33"
+		  " 16.33 13.33 ],[0.931 0.946 0.973 ]);\npatch([13.325 17.66 20.66 16.325 13.325 ],[10.33 10.33 13.33 13.33 10.33 ],"
+		  "[1 1 1 ]);\npatch([16.325 26.66 23.66 20.66 17.66 13.325 16.325 ],[7.33 7.33 10.33 7.33 10.33 10.33 7.33 ],[0.931 "
+		  "0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black'"
+		  ");port_label('output',1,'18430');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Constant5"
+		  SID			  "153"
 		  Ports			  [0, 1]
 		  Position		  [90, 334, 115, 356]
+		  ZOrder		  -10
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "0"
@@ -4812,8 +5426,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Constant6"
+		  SID			  "154"
 		  Ports			  [0, 1]
 		  Position		  [555, 529, 580, 551]
+		  ZOrder		  -11
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "4"
@@ -4850,9 +5467,13 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Convert1"
+		  SID			  "155"
 		  Ports			  [1, 1]
 		  Position		  [1175, 810, 1195, 840]
-		  Orientation		  "down"
+		  ZOrder		  -12
+		  BlockRotation		  270
+		  BlockMirror		  on
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Convert"
 		  SourceType		  "Xilinx Type Converter Block"
 		  infoedit		  "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do not."
@@ -4887,8 +5508,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Convert3"
+		  SID			  "156"
 		  Ports			  [1, 1]
 		  Position		  [1535, 750, 1560, 770]
+		  ZOrder		  -13
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Convert"
 		  SourceType		  "Xilinx Type Converter Block"
 		  infoedit		  "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do not."
@@ -4923,8 +5547,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Counter1"
+		  SID			  "157"
 		  Ports			  [2, 1]
 		  Position		  [1230, 273, 1260, 362]
+		  ZOrder		  -14
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Counter"
 		  SourceType		  "Xilinx Counter Block"
 		  infoedit		  "Hardware notes: Free running counters are the least expensive in hardware.  A count limited counter i"
@@ -4965,8 +5592,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Counter2"
+		  SID			  "158"
 		  Ports			  [2, 1]
 		  Position		  [530, 628, 565, 692]
+		  ZOrder		  -15
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Counter"
 		  SourceType		  "Xilinx Counter Block"
 		  infoedit		  "Hardware notes: Free running counters are the least expensive in hardware.  A count limited counter i"
@@ -5007,8 +5637,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Counter3"
+		  SID			  "159"
 		  Ports			  [2, 1]
 		  Position		  [1130, 858, 1165, 922]
+		  ZOrder		  -16
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Counter"
 		  SourceType		  "Xilinx Counter Block"
 		  infoedit		  "Hardware notes: Free running counters are the least expensive in hardware.  A count limited counter i"
@@ -5049,8 +5682,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter1"
+		  SID			  "160"
 		  Ports			  [1, 1]
 		  Position		  [1730, 177, 1760, 193]
+		  ZOrder		  -17
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -5075,8 +5711,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter2"
+		  SID			  "161"
 		  Ports			  [1, 1]
 		  Position		  [860, 497, 890, 513]
+		  ZOrder		  -18
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -5101,9 +5740,12 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter3"
+		  SID			  "162"
 		  Ports			  [1, 1]
 		  Position		  [415, 745, 435, 775]
-		  Orientation		  "up"
+		  ZOrder		  -19
+		  BlockRotation		  270
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -5128,8 +5770,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter4"
+		  SID			  "163"
 		  Ports			  [1, 1]
 		  Position		  [1465, 752, 1495, 768]
+		  ZOrder		  -20
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -5154,8 +5799,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical"
+		  SID			  "164"
 		  Ports			  [3, 1]
 		  Position		  [1485, 319, 1510, 351]
+		  ZOrder		  -21
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -5186,8 +5834,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical1"
+		  SID			  "165"
 		  Ports			  [2, 1]
 		  Position		  [1675, 168, 1700, 197]
+		  ZOrder		  -22
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "OR"
@@ -5218,8 +5869,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical10"
+		  SID			  "166"
 		  Ports			  [2, 1]
 		  Position		  [465, 362, 490, 393]
+		  ZOrder		  -23
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "NOR"
@@ -5250,8 +5904,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical11"
+		  SID			  "167"
 		  Ports			  [2, 1]
 		  Position		  [285, 352, 310, 383]
+		  ZOrder		  -24
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "OR"
@@ -5282,8 +5939,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical12"
+		  SID			  "168"
 		  Ports			  [2, 1]
 		  Position		  [105, 377, 130, 408]
+		  ZOrder		  -25
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -5314,8 +5974,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical13"
+		  SID			  "169"
 		  Ports			  [2, 1]
 		  Position		  [1340, 773, 1365, 802]
+		  ZOrder		  -26
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -5346,8 +6009,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical2"
+		  SID			  "170"
 		  Ports			  [2, 1]
 		  Position		  [1125, 298, 1150, 342]
+		  ZOrder		  -27
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -5378,8 +6044,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical3"
+		  SID			  "171"
 		  Ports			  [2, 1]
 		  Position		  [1055, 558, 1080, 587]
+		  ZOrder		  -28
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -5410,8 +6079,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical5"
+		  SID			  "172"
 		  Ports			  [3, 1]
 		  Position		  [465, 675, 490, 705]
+		  ZOrder		  -29
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -5442,8 +6114,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical6"
+		  SID			  "173"
 		  Ports			  [2, 1]
 		  Position		  [1060, 418, 1085, 447]
+		  ZOrder		  -30
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -5474,8 +6149,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical7"
+		  SID			  "174"
 		  Ports			  [3, 1]
 		  Position		  [940, 484, 965, 526]
+		  ZOrder		  -31
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -5506,8 +6184,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical8"
+		  SID			  "175"
 		  Ports			  [2, 1]
 		  Position		  [1055, 638, 1080, 667]
+		  ZOrder		  -32
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -5538,8 +6219,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical9"
+		  SID			  "176"
 		  Ports			  [2, 1]
 		  Position		  [1055, 888, 1080, 917]
+		  ZOrder		  -33
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -5570,8 +6254,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Relational1"
+		  SID			  "177"
 		  Ports			  [2, 1]
 		  Position		  [1360, 308, 1410, 352]
+		  ZOrder		  -34
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Relational"
 		  SourceType		  "Xilinx Arithmetic Relational Operator Block"
 		  mode			  "a>=b"
@@ -5598,8 +6285,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Relational2"
+		  SID			  "178"
 		  Ports			  [3, 1]
 		  Position		  [655, 638, 705, 682]
+		  ZOrder		  -35
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Relational"
 		  SourceType		  "Xilinx Arithmetic Relational Operator Block"
 		  mode			  "a<=b"
@@ -5626,8 +6316,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Relational3"
+		  SID			  "179"
 		  Ports			  [3, 1]
 		  Position		  [625, 768, 675, 812]
+		  ZOrder		  -36
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Relational"
 		  SourceType		  "Xilinx Arithmetic Relational Operator Block"
 		  mode			  "a<=b"
@@ -5654,8 +6347,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Relational4"
+		  SID			  "180"
 		  Ports			  [3, 1]
 		  Position		  [1245, 883, 1295, 927]
+		  ZOrder		  -37
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Relational"
 		  SourceType		  "Xilinx Arithmetic Relational Operator Block"
 		  mode			  "a=b"
@@ -5682,8 +6378,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Relational5"
+		  SID			  "181"
 		  Ports			  [3, 1]
 		  Position		  [660, 543, 710, 587]
+		  ZOrder		  -38
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Relational"
 		  SourceType		  "Xilinx Arithmetic Relational Operator Block"
 		  mode			  "a<=b"
@@ -5710,8 +6409,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Slice19"
+		  SID			  "182"
 		  Ports			  [1, 1]
 		  Position		  [1360, 271, 1405, 289]
+		  ZOrder		  -39
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -5741,17 +6443,20 @@ Library {
 		Block {
 		  BlockType		  SubSystem
 		  Name			  "posedge"
+		  SID			  "183"
 		  Ports			  [1, 1]
 		  Position		  [1080, 158, 1125, 182]
+		  ZOrder		  -40
 		  MinAlgLoopOccurrences	  off
 		  PropExecContextOutsideSubsystem off
 		  RTWSystemCode		  "Auto"
 		  FunctionWithSeparateData off
 		  Opaque		  off
+		  RequestExecContextInheritance	off
 		  MaskHideContents	  off
 		  System {
 		    Name		    "posedge"
-		    Location		    [72, 372, 493, 522]
+		    Location		    [38, 253, 507, 638]
 		    Open		    off
 		    ModelBrowserVisibility  off
 		    ModelBrowserWidth	    200
@@ -5767,14 +6472,19 @@ Library {
 		    Block {
 		    BlockType		    Inport
 		    Name		    "in"
+		    SID			    "184"
 		    Position		    [25, 43, 55, 57]
+		    ZOrder		    -1
 		    IconDisplay		    "Port number"
 		    }
 		    Block {
 		    BlockType		    Reference
 		    Name		    "Delay"
+		    SID			    "185"
 		    Ports		    [1, 1]
 		    Position		    [85, 27, 130, 73]
+		    ZOrder		    -2
+		    LibraryVersion	    "1.2"
 		    SourceBlock		    "xbsIndex_r4/Delay"
 		    SourceType		    "Xilinx Delay Block"
 		    infoedit		    "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -5802,8 +6512,11 @@ Library {
 		    Block {
 		    BlockType		    Reference
 		    Name		    "Inverter2"
+		    SID			    "186"
 		    Ports		    [1, 1]
 		    Position		    [155, 33, 205, 67]
+		    ZOrder		    -3
+		    LibraryVersion	    "1.2"
 		    SourceBlock		    "xbsIndex_r4/Inverter"
 		    SourceType		    "Xilinx Inverter Block"
 		    infoedit		    "Bitwise logical negation (one's complement) operator."
@@ -5828,8 +6541,11 @@ Library {
 		    Block {
 		    BlockType		    Reference
 		    Name		    "Logical"
+		    SID			    "187"
 		    Ports		    [2, 1]
 		    Position		    [240, 31, 320, 109]
+		    ZOrder		    -4
+		    LibraryVersion	    "1.2"
 		    SourceBlock		    "xbsIndex_r4/Logical"
 		    SourceType		    "Xilinx Logical Block Block"
 		    logical_function	    "AND"
@@ -5860,7 +6576,9 @@ Library {
 		    Block {
 		    BlockType		    Outport
 		    Name		    "out"
+		    SID			    "188"
 		    Position		    [350, 63, 380, 77]
+		    ZOrder		    -5
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
@@ -5901,17 +6619,20 @@ Library {
 		Block {
 		  BlockType		  SubSystem
 		  Name			  "posedge1"
+		  SID			  "189"
 		  Ports			  [1, 1]
 		  Position		  [435, 633, 480, 657]
+		  ZOrder		  -41
 		  MinAlgLoopOccurrences	  off
 		  PropExecContextOutsideSubsystem off
 		  RTWSystemCode		  "Auto"
 		  FunctionWithSeparateData off
 		  Opaque		  off
+		  RequestExecContextInheritance	off
 		  MaskHideContents	  off
 		  System {
 		    Name		    "posedge1"
-		    Location		    [72, 372, 493, 522]
+		    Location		    [38, 253, 507, 638]
 		    Open		    off
 		    ModelBrowserVisibility  off
 		    ModelBrowserWidth	    200
@@ -5927,14 +6648,19 @@ Library {
 		    Block {
 		    BlockType		    Inport
 		    Name		    "in"
+		    SID			    "190"
 		    Position		    [25, 43, 55, 57]
+		    ZOrder		    -1
 		    IconDisplay		    "Port number"
 		    }
 		    Block {
 		    BlockType		    Reference
 		    Name		    "Delay"
+		    SID			    "191"
 		    Ports		    [1, 1]
 		    Position		    [85, 27, 130, 73]
+		    ZOrder		    -2
+		    LibraryVersion	    "1.2"
 		    SourceBlock		    "xbsIndex_r4/Delay"
 		    SourceType		    "Xilinx Delay Block"
 		    infoedit		    "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -5962,8 +6688,11 @@ Library {
 		    Block {
 		    BlockType		    Reference
 		    Name		    "Inverter2"
+		    SID			    "192"
 		    Ports		    [1, 1]
 		    Position		    [155, 33, 205, 67]
+		    ZOrder		    -3
+		    LibraryVersion	    "1.2"
 		    SourceBlock		    "xbsIndex_r4/Inverter"
 		    SourceType		    "Xilinx Inverter Block"
 		    infoedit		    "Bitwise logical negation (one's complement) operator."
@@ -5988,8 +6717,11 @@ Library {
 		    Block {
 		    BlockType		    Reference
 		    Name		    "Logical"
+		    SID			    "193"
 		    Ports		    [2, 1]
 		    Position		    [240, 31, 320, 109]
+		    ZOrder		    -4
+		    LibraryVersion	    "1.2"
 		    SourceBlock		    "xbsIndex_r4/Logical"
 		    SourceType		    "Xilinx Logical Block Block"
 		    logical_function	    "AND"
@@ -6020,7 +6752,9 @@ Library {
 		    Block {
 		    BlockType		    Outport
 		    Name		    "out"
+		    SID			    "194"
 		    Position		    [350, 63, 380, 77]
+		    ZOrder		    -5
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
@@ -6061,17 +6795,20 @@ Library {
 		Block {
 		  BlockType		  SubSystem
 		  Name			  "posedge2"
+		  SID			  "195"
 		  Ports			  [1, 1]
 		  Position		  [740, 648, 785, 672]
+		  ZOrder		  -42
 		  MinAlgLoopOccurrences	  off
 		  PropExecContextOutsideSubsystem off
 		  RTWSystemCode		  "Auto"
 		  FunctionWithSeparateData off
 		  Opaque		  off
+		  RequestExecContextInheritance	off
 		  MaskHideContents	  off
 		  System {
 		    Name		    "posedge2"
-		    Location		    [72, 372, 493, 522]
+		    Location		    [38, 253, 507, 638]
 		    Open		    off
 		    ModelBrowserVisibility  off
 		    ModelBrowserWidth	    200
@@ -6087,14 +6824,19 @@ Library {
 		    Block {
 		    BlockType		    Inport
 		    Name		    "in"
+		    SID			    "196"
 		    Position		    [25, 43, 55, 57]
+		    ZOrder		    -1
 		    IconDisplay		    "Port number"
 		    }
 		    Block {
 		    BlockType		    Reference
 		    Name		    "Delay"
+		    SID			    "197"
 		    Ports		    [1, 1]
 		    Position		    [85, 27, 130, 73]
+		    ZOrder		    -2
+		    LibraryVersion	    "1.2"
 		    SourceBlock		    "xbsIndex_r4/Delay"
 		    SourceType		    "Xilinx Delay Block"
 		    infoedit		    "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -6122,8 +6864,11 @@ Library {
 		    Block {
 		    BlockType		    Reference
 		    Name		    "Inverter2"
+		    SID			    "198"
 		    Ports		    [1, 1]
 		    Position		    [155, 33, 205, 67]
+		    ZOrder		    -3
+		    LibraryVersion	    "1.2"
 		    SourceBlock		    "xbsIndex_r4/Inverter"
 		    SourceType		    "Xilinx Inverter Block"
 		    infoedit		    "Bitwise logical negation (one's complement) operator."
@@ -6148,8 +6893,11 @@ Library {
 		    Block {
 		    BlockType		    Reference
 		    Name		    "Logical"
+		    SID			    "199"
 		    Ports		    [2, 1]
 		    Position		    [240, 31, 320, 109]
+		    ZOrder		    -4
+		    LibraryVersion	    "1.2"
 		    SourceBlock		    "xbsIndex_r4/Logical"
 		    SourceType		    "Xilinx Logical Block Block"
 		    logical_function	    "AND"
@@ -6180,7 +6928,9 @@ Library {
 		    Block {
 		    BlockType		    Outport
 		    Name		    "out"
+		    SID			    "200"
 		    Position		    [350, 63, 380, 77]
+		    ZOrder		    -5
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
@@ -6221,17 +6971,20 @@ Library {
 		Block {
 		  BlockType		  SubSystem
 		  Name			  "posedge3"
+		  SID			  "201"
 		  Ports			  [1, 1]
 		  Position		  [735, 778, 780, 802]
+		  ZOrder		  -43
 		  MinAlgLoopOccurrences	  off
 		  PropExecContextOutsideSubsystem off
 		  RTWSystemCode		  "Auto"
 		  FunctionWithSeparateData off
 		  Opaque		  off
+		  RequestExecContextInheritance	off
 		  MaskHideContents	  off
 		  System {
 		    Name		    "posedge3"
-		    Location		    [72, 372, 493, 522]
+		    Location		    [38, 253, 507, 638]
 		    Open		    off
 		    ModelBrowserVisibility  off
 		    ModelBrowserWidth	    200
@@ -6247,14 +7000,19 @@ Library {
 		    Block {
 		    BlockType		    Inport
 		    Name		    "in"
+		    SID			    "202"
 		    Position		    [25, 43, 55, 57]
+		    ZOrder		    -1
 		    IconDisplay		    "Port number"
 		    }
 		    Block {
 		    BlockType		    Reference
 		    Name		    "Delay"
+		    SID			    "203"
 		    Ports		    [1, 1]
 		    Position		    [85, 27, 130, 73]
+		    ZOrder		    -2
+		    LibraryVersion	    "1.2"
 		    SourceBlock		    "xbsIndex_r4/Delay"
 		    SourceType		    "Xilinx Delay Block"
 		    infoedit		    "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -6282,8 +7040,11 @@ Library {
 		    Block {
 		    BlockType		    Reference
 		    Name		    "Inverter2"
+		    SID			    "204"
 		    Ports		    [1, 1]
 		    Position		    [155, 33, 205, 67]
+		    ZOrder		    -3
+		    LibraryVersion	    "1.2"
 		    SourceBlock		    "xbsIndex_r4/Inverter"
 		    SourceType		    "Xilinx Inverter Block"
 		    infoedit		    "Bitwise logical negation (one's complement) operator."
@@ -6308,8 +7069,11 @@ Library {
 		    Block {
 		    BlockType		    Reference
 		    Name		    "Logical"
+		    SID			    "205"
 		    Ports		    [2, 1]
 		    Position		    [240, 31, 320, 109]
+		    ZOrder		    -4
+		    LibraryVersion	    "1.2"
 		    SourceBlock		    "xbsIndex_r4/Logical"
 		    SourceType		    "Xilinx Logical Block Block"
 		    logical_function	    "AND"
@@ -6340,7 +7104,9 @@ Library {
 		    Block {
 		    BlockType		    Outport
 		    Name		    "out"
+		    SID			    "206"
 		    Position		    [350, 63, 380, 77]
+		    ZOrder		    -5
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
@@ -6381,17 +7147,20 @@ Library {
 		Block {
 		  BlockType		  SubSystem
 		  Name			  "posedge4"
+		  SID			  "207"
 		  Ports			  [1, 1]
 		  Position		  [240, 308, 285, 332]
+		  ZOrder		  -44
 		  MinAlgLoopOccurrences	  off
 		  PropExecContextOutsideSubsystem off
 		  RTWSystemCode		  "Auto"
 		  FunctionWithSeparateData off
 		  Opaque		  off
+		  RequestExecContextInheritance	off
 		  MaskHideContents	  off
 		  System {
 		    Name		    "posedge4"
-		    Location		    [72, 372, 493, 522]
+		    Location		    [38, 253, 507, 638]
 		    Open		    off
 		    ModelBrowserVisibility  off
 		    ModelBrowserWidth	    200
@@ -6407,14 +7176,19 @@ Library {
 		    Block {
 		    BlockType		    Inport
 		    Name		    "in"
+		    SID			    "208"
 		    Position		    [25, 43, 55, 57]
+		    ZOrder		    -1
 		    IconDisplay		    "Port number"
 		    }
 		    Block {
 		    BlockType		    Reference
 		    Name		    "Delay"
+		    SID			    "209"
 		    Ports		    [1, 1]
 		    Position		    [85, 27, 130, 73]
+		    ZOrder		    -2
+		    LibraryVersion	    "1.2"
 		    SourceBlock		    "xbsIndex_r4/Delay"
 		    SourceType		    "Xilinx Delay Block"
 		    infoedit		    "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -6442,8 +7216,11 @@ Library {
 		    Block {
 		    BlockType		    Reference
 		    Name		    "Inverter2"
+		    SID			    "210"
 		    Ports		    [1, 1]
 		    Position		    [155, 33, 205, 67]
+		    ZOrder		    -3
+		    LibraryVersion	    "1.2"
 		    SourceBlock		    "xbsIndex_r4/Inverter"
 		    SourceType		    "Xilinx Inverter Block"
 		    infoedit		    "Bitwise logical negation (one's complement) operator."
@@ -6468,8 +7245,11 @@ Library {
 		    Block {
 		    BlockType		    Reference
 		    Name		    "Logical"
+		    SID			    "211"
 		    Ports		    [2, 1]
 		    Position		    [240, 31, 320, 109]
+		    ZOrder		    -4
+		    LibraryVersion	    "1.2"
 		    SourceBlock		    "xbsIndex_r4/Logical"
 		    SourceType		    "Xilinx Logical Block Block"
 		    logical_function	    "AND"
@@ -6500,7 +7280,9 @@ Library {
 		    Block {
 		    BlockType		    Outport
 		    Name		    "out"
+		    SID			    "212"
 		    Position		    [350, 63, 380, 77]
+		    ZOrder		    -5
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
@@ -6541,17 +7323,20 @@ Library {
 		Block {
 		  BlockType		  SubSystem
 		  Name			  "posedge5"
+		  SID			  "213"
 		  Ports			  [1, 1]
 		  Position		  [740, 553, 785, 577]
+		  ZOrder		  -45
 		  MinAlgLoopOccurrences	  off
 		  PropExecContextOutsideSubsystem off
 		  RTWSystemCode		  "Auto"
 		  FunctionWithSeparateData off
 		  Opaque		  off
+		  RequestExecContextInheritance	off
 		  MaskHideContents	  off
 		  System {
 		    Name		    "posedge5"
-		    Location		    [72, 372, 493, 522]
+		    Location		    [38, 253, 507, 638]
 		    Open		    off
 		    ModelBrowserVisibility  off
 		    ModelBrowserWidth	    200
@@ -6567,14 +7352,19 @@ Library {
 		    Block {
 		    BlockType		    Inport
 		    Name		    "in"
+		    SID			    "214"
 		    Position		    [25, 43, 55, 57]
+		    ZOrder		    -1
 		    IconDisplay		    "Port number"
 		    }
 		    Block {
 		    BlockType		    Reference
 		    Name		    "Delay"
+		    SID			    "215"
 		    Ports		    [1, 1]
 		    Position		    [85, 27, 130, 73]
+		    ZOrder		    -2
+		    LibraryVersion	    "1.2"
 		    SourceBlock		    "xbsIndex_r4/Delay"
 		    SourceType		    "Xilinx Delay Block"
 		    infoedit		    "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -6602,8 +7392,11 @@ Library {
 		    Block {
 		    BlockType		    Reference
 		    Name		    "Inverter2"
+		    SID			    "216"
 		    Ports		    [1, 1]
 		    Position		    [155, 33, 205, 67]
+		    ZOrder		    -3
+		    LibraryVersion	    "1.2"
 		    SourceBlock		    "xbsIndex_r4/Inverter"
 		    SourceType		    "Xilinx Inverter Block"
 		    infoedit		    "Bitwise logical negation (one's complement) operator."
@@ -6628,8 +7421,11 @@ Library {
 		    Block {
 		    BlockType		    Reference
 		    Name		    "Logical"
+		    SID			    "217"
 		    Ports		    [2, 1]
 		    Position		    [240, 31, 320, 109]
+		    ZOrder		    -4
+		    LibraryVersion	    "1.2"
 		    SourceBlock		    "xbsIndex_r4/Logical"
 		    SourceType		    "Xilinx Logical Block Block"
 		    logical_function	    "AND"
@@ -6660,7 +7456,9 @@ Library {
 		    Block {
 		    BlockType		    Outport
 		    Name		    "out"
+		    SID			    "218"
 		    Position		    [350, 63, 380, 77]
+		    ZOrder		    -5
 		    IconDisplay		    "Port number"
 		    }
 		    Line {
@@ -6701,8 +7499,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "reg1"
+		  SID			  "219"
 		  Ports			  [3, 1]
 		  Position		  [1555, 295, 1600, 365]
+		  ZOrder		  -46
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Register"
 		  SourceType		  "Xilinx Register Block"
 		  init			  "0"
@@ -6729,8 +7530,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "reg2"
+		  SID			  "220"
 		  Ports			  [3, 1]
 		  Position		  [850, 755, 895, 825]
+		  ZOrder		  -47
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Register"
 		  SourceType		  "Xilinx Register Block"
 		  init			  "0"
@@ -6757,8 +7561,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "reg3"
+		  SID			  "221"
 		  Ports			  [2, 1]
 		  Position		  [445, 194, 490, 241]
+		  ZOrder		  -48
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Register"
 		  SourceType		  "Xilinx Register Block"
 		  init			  "0"
@@ -6784,8 +7591,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "reg4"
+		  SID			  "222"
 		  Ports			  [3, 1]
 		  Position		  [1405, 737, 1440, 783]
+		  ZOrder		  -49
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Register"
 		  SourceType		  "Xilinx Register Block"
 		  init			  "0"
@@ -6812,8 +7622,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "reg5"
+		  SID			  "223"
 		  Ports			  [3, 1]
 		  Position		  [335, 294, 375, 346]
+		  ZOrder		  -50
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Register"
 		  SourceType		  "Xilinx Register Block"
 		  init			  "0"
@@ -6840,8 +7653,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "reg6"
+		  SID			  "224"
 		  Ports			  [2, 1]
 		  Position		  [170, 331, 210, 384]
+		  ZOrder		  -51
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Register"
 		  SourceType		  "Xilinx Register Block"
 		  init			  "1"
@@ -6867,257 +7683,209 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical0"
+		  SID			  "225"
 		  Ports			  []
 		  Position		  [1497, 294, 1523, 319]
+		  ZOrder		  -52
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Relational10"
+		  SID			  "226"
 		  Ports			  []
 		  Position		  [1397, 283, 1423, 308]
+		  ZOrder		  -53
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Relational20"
+		  SID			  "227"
 		  Ports			  []
 		  Position		  [692, 613, 718, 638]
+		  ZOrder		  -54
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Relational30"
+		  SID			  "228"
 		  Ports			  []
 		  Position		  [662, 743, 688, 768]
+		  ZOrder		  -55
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Relational40"
+		  SID			  "229"
 		  Ports			  []
 		  Position		  [1282, 858, 1308, 883]
+		  ZOrder		  -56
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Relational50"
+		  SID			  "230"
 		  Ports			  []
 		  Position		  [697, 518, 723, 543]
+		  ZOrder		  -57
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period reg10"
+		  SID			  "231"
 		  Ports			  []
 		  Position		  [1587, 270, 1613, 295]
+		  ZOrder		  -58
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period reg20"
+		  SID			  "232"
 		  Ports			  []
 		  Position		  [882, 730, 908, 755]
+		  ZOrder		  -59
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period reg30"
+		  SID			  "233"
 		  Ports			  []
 		  Position		  [477, 169, 503, 194]
+		  ZOrder		  -60
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period reg40"
+		  SID			  "234"
 		  Ports			  []
 		  Position		  [1427, 712, 1453, 737]
+		  ZOrder		  -61
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period reg50"
+		  SID			  "235"
 		  Ports			  []
 		  Position		  [362, 269, 388, 294]
+		  ZOrder		  -62
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period reg60"
+		  SID			  "236"
 		  Ports			  []
 		  Position		  [197, 306, 223, 331]
+		  ZOrder		  -63
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "mask_regular_valid"
+		  SID			  "237"
 		  Position		  [1820, 178, 1850, 192]
+		  ZOrder		  -64
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "fake_valid"
+		  SID			  "238"
 		  Position		  [1850, 393, 1880, 407]
+		  ZOrder		  -65
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "sync_out"
+		  SID			  "239"
 		  Position		  [1130, 648, 1160, 662]
+		  ZOrder		  -66
 		  Port			  "3"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "mask_dram_data"
+		  SID			  "240"
 		  Position		  [1605, 753, 1635, 767]
+		  ZOrder		  -67
 		  Port			  "4"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "speciall_dram_ack"
+		  SID			  "241"
 		  Position		  [560, 373, 590, 387]
+		  ZOrder		  -68
 		  Port			  "5"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "sync_ctrl"
+		  SID			  "242"
 		  Position		  [1125, 568, 1155, 582]
+		  ZOrder		  -69
 		  Port			  "6"
 		  IconDisplay		  "Port number"
 		}
@@ -7702,19 +8470,23 @@ Library {
 		  DstPort		  1
 		}
 		Annotation {
+		  SID			  "243"
 		  Name			  "I removed one \"and\" \nfrom here temp"
 		  Position		  [1167, 269]
 		}
 		Annotation {
+		  SID			  "244"
 		  Name			  "If this register is equal to 1 I am \nin the initialization interval"
 		  Position		  [1815, 251]
 		}
 		Annotation {
+		  SID			  "245"
 		  Name			  "If sync is high I have to mask regular valid for a period of time\nwithin this period I will provide 36 "
 		  "fake valid dram datas to the adder and there after I'm back to \nregular process. "
 		  Position		  [1264, 43]
 		}
 		Annotation {
+		  SID			  "246"
 		  Name			  "Goes high when DRAM \nbuffer is empty"
 		  Position		  [350, 287]
 		}
@@ -7723,8 +8495,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "slice_sync"
+	      SID		      "247"
 	      Ports		      [1, 1]
 	      Position		      [160, 301, 210, 319]
+	      ZOrder		      -62
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -7754,131 +8529,118 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "warn period AddSub40"
+	      SID		      "248"
 	      Ports		      []
 	      Position		      [932, 148, 958, 173]
+	      ZOrder		      -63
 	      ShowName		      off
+	      LibraryVersion	      "1.213"
 	      SourceBlock	      "xbsReplacements_r4/Warning"
-	      SourceType	      ""
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
+	      SourceType	      "Unknown"
 	      period		      "1"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "warn period AddSub50"
+	      SID		      "249"
 	      Ports		      []
 	      Position		      [932, 198, 958, 223]
+	      ZOrder		      -64
 	      ShowName		      off
+	      LibraryVersion	      "1.213"
 	      SourceBlock	      "xbsReplacements_r4/Warning"
-	      SourceType	      ""
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
+	      SourceType	      "Unknown"
 	      period		      "1"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "warn period AddSub60"
+	      SID		      "250"
 	      Ports		      []
 	      Position		      [932, 248, 958, 273]
+	      ZOrder		      -65
 	      ShowName		      off
+	      LibraryVersion	      "1.213"
 	      SourceBlock	      "xbsReplacements_r4/Warning"
-	      SourceType	      ""
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
+	      SourceType	      "Unknown"
 	      period		      "1"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "warn period AddSub70"
+	      SID		      "251"
 	      Ports		      []
 	      Position		      [932, 298, 958, 323]
+	      ZOrder		      -66
 	      ShowName		      off
+	      LibraryVersion	      "1.213"
 	      SourceBlock	      "xbsReplacements_r4/Warning"
-	      SourceType	      ""
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
+	      SourceType	      "Unknown"
 	      period		      "1"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "warn period Delay10"
+	      SID		      "252"
 	      Ports		      []
 	      Position		      [1322, 442, 1348, 467]
+	      ZOrder		      -67
 	      ShowName		      off
+	      LibraryVersion	      "1.213"
 	      SourceBlock	      "xbsReplacements_r4/Warning"
-	      SourceType	      ""
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
+	      SourceType	      "Unknown"
 	      period		      "1"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "output"
+	      SID		      "253"
 	      Position		      [2010, 458, 2040, 472]
+	      ZOrder		      -68
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "valid_output"
+	      SID		      "254"
 	      Position		      [2015, 503, 2045, 517]
+	      ZOrder		      -69
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "sync"
+	      SID		      "255"
 	      Position		      [790, 808, 820, 822]
+	      ZOrder		      -70
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "ack_dram_data"
+	      SID		      "256"
 	      Position		      [1570, 658, 1600, 672]
+	      ZOrder		      -71
 	      Port		      "4"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "ack_FIFO_data"
+	      SID		      "257"
 	      Position		      [1565, 573, 1595, 587]
+	      ZOrder		      -72
 	      Port		      "5"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "wr_be"
+	      SID		      "258"
 	      Position		      [2015, 548, 2045, 562]
+	      ZOrder		      -73
 	      Port		      "6"
 	      IconDisplay	      "Port number"
 	    }
@@ -8495,10 +9257,12 @@ Library {
 	      DstPort		      3
 	    }
 	    Annotation {
+	      SID		      "259"
 	      Name		      "When mask_dram_data is equal to one \nI am passing zeros instead of dram data."
 	      Position		      [400, 733]
 	    }
 	    Annotation {
+	      SID		      "260"
 	      Name		      "Initializer Tasks:\n1-wait a few cycles for the piple line to emtpy \nits valid data's\n2-Initiali"
 	      "zer the controller by sending a sync to it\nvalid should be low\n3-After we are sure controller is initialized "
 	      "we have to \ncontinue with the following:\nI-mask dram data for one full spectrum\nII-provide 36 fake valids fo"
@@ -8506,11 +9270,13 @@ Library {
 	      Position		      [144, 657]
 	    }
 	    Annotation {
+	      SID		      "261"
 	      Name		      "sync is delayed one less than data,\ntherefore we can tag sync to current data rather than \none b"
 	      "efore the data"
 	      Position		      [274, 79]
 	    }
 	    Annotation {
+	      SID		      "262"
 	      Position		      [1084, 565]
 	    }
 	  }
@@ -8518,8 +9284,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "C1"
+	  SID			  "263"
 	  Ports			  [0, 1]
 	  Position		  [1735, 140, 1760, 150]
+	  ZOrder		  -6
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Constant"
 	  SourceType		  "Xilinx Constant Block Block"
 	  const			  "0"
@@ -8556,8 +9325,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Concat"
+	  SID			  "264"
 	  Ports			  [2, 1]
 	  Position		  [155, 165, 185, 205]
+	  ZOrder		  -7
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Concat"
 	  SourceType		  "Xilinx Bus Concatenator Block"
 	  infoedit		  "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary point at ze"
@@ -8581,8 +9353,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Constant1"
+	  SID			  "265"
 	  Ports			  [0, 1]
 	  Position		  [180, 266, 220, 284]
+	  ZOrder		  -8
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Constant"
 	  SourceType		  "Xilinx Constant Block Block"
 	  const			  "0"
@@ -8619,10 +9394,14 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Convert1"
+	  SID			  "266"
 	  Ports			  [1, 1]
 	  Position		  [2135, 330, 2155, 360]
-	  Orientation		  "down"
+	  ZOrder		  -9
+	  BlockRotation		  270
+	  BlockMirror		  on
 	  NamePlacement		  "alternate"
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Convert"
 	  SourceType		  "Xilinx Type Converter Block"
 	  infoedit		  "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do not."
@@ -8657,8 +9436,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Convert2"
+	  SID			  "267"
 	  Ports			  [1, 1]
 	  Position		  [80, 165, 105, 185]
+	  ZOrder		  -10
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Convert"
 	  SourceType		  "Xilinx Type Converter Block"
 	  infoedit		  "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do not."
@@ -8693,9 +9475,13 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Convert3"
+	  SID			  "268"
 	  Ports			  [1, 1]
 	  Position		  [1925, 510, 1945, 540]
-	  Orientation		  "down"
+	  ZOrder		  -11
+	  BlockRotation		  270
+	  BlockMirror		  on
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Convert"
 	  SourceType		  "Xilinx Type Converter Block"
 	  infoedit		  "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do not."
@@ -8730,8 +9516,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Convert4"
+	  SID			  "269"
 	  Ports			  [1, 1]
 	  Position		  [2255, 285, 2280, 305]
+	  ZOrder		  -12
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Convert"
 	  SourceType		  "Xilinx Type Converter Block"
 	  infoedit		  "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do not."
@@ -8766,8 +9555,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Counter"
+	  SID			  "270"
 	  Ports			  [0, 1]
 	  Position		  [360, 328, 395, 362]
+	  ZOrder		  -13
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Counter"
 	  SourceType		  "Xilinx Counter Block"
 	  infoedit		  "Hardware notes: Free running counters are the least expensive in hardware.  A count limited counter is"
@@ -8807,8 +9599,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay1"
+	  SID			  "271"
 	  Ports			  [2, 1]
 	  Position		  [1235, 182, 1275, 218]
+	  ZOrder		  -14
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -8836,8 +9631,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay2"
+	  SID			  "272"
 	  Ports			  [2, 1]
 	  Position		  [1235, 287, 1275, 323]
+	  ZOrder		  -15
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -8865,8 +9663,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Inverter2"
+	  SID			  "273"
 	  Ports			  [1, 1]
 	  Position		  [2235, 469, 2270, 491]
+	  ZOrder		  -16
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Inverter"
 	  SourceType		  "Xilinx Inverter Block"
 	  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -8891,8 +9692,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Inverter3"
+	  SID			  "274"
 	  Ports			  [1, 1]
 	  Position		  [2050, 278, 2075, 292]
+	  ZOrder		  -17
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Inverter"
 	  SourceType		  "Xilinx Inverter Block"
 	  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -8917,8 +9721,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Inverter4"
+	  SID			  "275"
 	  Ports			  [1, 1]
 	  Position		  [485, 232, 515, 248]
+	  ZOrder		  -18
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Inverter"
 	  SourceType		  "Xilinx Inverter Block"
 	  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -8943,8 +9750,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Logical"
+	  SID			  "276"
 	  Ports			  [2, 1]
 	  Position		  [2105, 273, 2130, 317]
+	  ZOrder		  -19
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Logical"
 	  SourceType		  "Xilinx Logical Block Block"
 	  logical_function	  "AND"
@@ -8975,8 +9785,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Logical1"
+	  SID			  "277"
 	  Ports			  [2, 1]
 	  Position		  [580, 234, 615, 256]
+	  ZOrder		  -20
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Logical"
 	  SourceType		  "Xilinx Logical Block Block"
 	  logical_function	  "AND"
@@ -9007,8 +9820,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Logical2"
+	  SID			  "278"
 	  Ports			  [2, 1]
 	  Position		  [1435, 337, 1455, 368]
+	  ZOrder		  -21
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Logical"
 	  SourceType		  "Xilinx Logical Block Block"
 	  logical_function	  "OR"
@@ -9039,8 +9855,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Logical3"
+	  SID			  "279"
 	  Ports			  [2, 1]
 	  Position		  [80, 85, 100, 105]
+	  ZOrder		  -22
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Logical"
 	  SourceType		  "Xilinx Logical Block Block"
 	  logical_function	  "AND"
@@ -9071,8 +9890,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Logical7"
+	  SID			  "280"
 	  Ports			  [2, 1]
 	  Position		  [180, 96, 200, 129]
+	  ZOrder		  -23
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Logical"
 	  SourceType		  "Xilinx Logical Block Block"
 	  logical_function	  "OR"
@@ -9103,8 +9925,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Logical8"
+	  SID			  "281"
 	  Ports			  [2, 1]
 	  Position		  [225, 196, 245, 229]
+	  ZOrder		  -24
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Logical"
 	  SourceType		  "Xilinx Logical Block Block"
 	  logical_function	  "AND"
@@ -9135,18 +9960,21 @@ Library {
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "RB_reg"
+	  SID			  "282"
 	  Ports			  [6, 4]
 	  Position		  [2325, 159, 2450, 341]
+	  ZOrder		  -25
 	  BackgroundColor	  "yellow"
 	  MinAlgLoopOccurrences	  off
 	  PropExecContextOutsideSubsystem off
 	  RTWSystemCode		  "Auto"
 	  FunctionWithSeparateData off
 	  Opaque		  off
+	  RequestExecContextInheritance	off
 	  MaskHideContents	  off
 	  System {
 	    Name		    "RB_reg"
-	    Location		    [2, 74, 1142, 740]
+	    Location		    [12, 45, 1200, 946]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -9162,49 +9990,64 @@ Library {
 	    Block {
 	      BlockType		      Inport
 	      Name		      "dram_data"
+	      SID		      "283"
 	      Position		      [120, 118, 150, 132]
+	      ZOrder		      -1
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "rd_tag"
+	      SID		      "284"
 	      Position		      [20, 228, 50, 242]
+	      ZOrder		      -2
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "rd_valid"
+	      SID		      "285"
 	      Position		      [15, 313, 45, 327]
+	      ZOrder		      -3
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "dram_rd_ack"
+	      SID		      "286"
 	      Position		      [20, 428, 50, 442]
+	      ZOrder		      -4
 	      Port		      "4"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "ack_RB"
+	      SID		      "287"
 	      Position		      [80, 488, 110, 502]
+	      ZOrder		      -5
 	      Port		      "5"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "RB_active"
+	      SID		      "288"
 	      Position		      [80, 558, 110, 572]
+	      ZOrder		      -6
 	      Port		      "6"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Concat"
+	      SID		      "289"
 	      Ports		      [2, 1]
 	      Position		      [430, 97, 480, 148]
+	      ZOrder		      -7
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Concat"
 	      SourceType	      "Xilinx Bus Concatenator Block"
 	      infoedit		      "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary poi"
@@ -9228,8 +10071,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Convert1"
+	      SID		      "290"
 	      Ports		      [1, 1]
 	      Position		      [185, 555, 205, 575]
+	      ZOrder		      -8
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -9265,8 +10111,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Convert2"
+	      SID		      "291"
 	      Ports		      [1, 1]
 	      Position		      [835, 205, 855, 225]
+	      ZOrder		      -9
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -9302,8 +10151,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Convert4"
+	      SID		      "292"
 	      Ports		      [1, 1]
 	      Position		      [180, 310, 200, 330]
+	      ZOrder		      -10
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -9339,8 +10191,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Convert5"
+	      SID		      "293"
 	      Ports		      [1, 1]
 	      Position		      [120, 425, 140, 445]
+	      ZOrder		      -11
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -9376,8 +10231,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay"
+	      SID		      "294"
 	      Ports		      [1, 1]
 	      Position		      [325, 205, 365, 245]
+	      ZOrder		      -12
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -9406,8 +10264,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Inverter2"
+	      SID		      "295"
 	      Ports		      [1, 1]
 	      Position		      [785, 204, 820, 226]
+	      ZOrder		      -13
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Inverter"
 	      SourceType	      "Xilinx Inverter Block"
 	      infoedit		      "Bitwise logical negation (one's complement) operator."
@@ -9432,8 +10293,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical1"
+	      SID		      "296"
 	      Ports		      [2, 1]
 	      Position		      [245, 252, 275, 308]
+	      ZOrder		      -14
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -9464,8 +10328,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical2"
+	      SID		      "297"
 	      Ports		      [4, 1]
 	      Position		      [335, 329, 365, 386]
+	      ZOrder		      -15
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -9496,8 +10363,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical3"
+	      SID		      "298"
 	      Ports		      [2, 1]
 	      Position		      [880, 208, 905, 237]
+	      ZOrder		      -16
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -9528,8 +10398,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical4"
+	      SID		      "299"
 	      Ports		      [2, 1]
 	      Position		      [615, 373, 640, 402]
+	      ZOrder		      -17
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "OR"
@@ -9560,8 +10433,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Register"
+	      SID		      "300"
 	      Ports		      [3, 1]
 	      Position		      [700, 306, 745, 354]
+	      ZOrder		      -18
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Register"
 	      SourceType	      "Xilinx Register Block"
 	      init		      "0"
@@ -9588,8 +10464,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret"
+	      SID		      "301"
 	      Ports		      [1, 1]
 	      Position		      [750, 204, 765, 226]
+	      ZOrder		      -19
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -9617,8 +10496,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice"
+	      SID		      "302"
 	      Ports		      [1, 1]
 	      Position		      [280, 76, 325, 104]
+	      ZOrder		      -20
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -9648,8 +10530,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice1"
+	      SID		      "303"
 	      Ports		      [1, 1]
 	      Position		      [280, 136, 325, 164]
+	      ZOrder		      -21
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -9679,8 +10564,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice2"
+	      SID		      "304"
 	      Ports		      [1, 1]
 	      Position		      [120, 221, 165, 249]
+	      ZOrder		      -22
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -9710,8 +10598,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice3"
+	      SID		      "305"
 	      Ports		      [1, 1]
 	      Position		      [105, 366, 150, 394]
+	      ZOrder		      -23
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -9741,31 +10632,56 @@ Library {
 	    Block {
 	      BlockType		      SubSystem
 	      Name		      "Trickle_FWFT"
+	      SID		      "306"
 	      Ports		      [4, 4]
 	      Position		      [645, 109, 730, 231]
+	      ZOrder		      -24
 	      BackgroundColor	      "yellow"
 	      MinAlgLoopOccurrences   off
 	      PropExecContextOutsideSubsystem off
 	      RTWSystemCode	      "Auto"
 	      FunctionWithSeparateData off
 	      Opaque		      off
+	      RequestExecContextInheritance off
 	      MaskHideContents	      off
-	      MaskPromptString	      "Depth"
-	      MaskStyleString	      "popup(16|32|64|128|256|512|1K|2K|4K|8K|16K|32K|64K)"
-	      MaskVariables	      "depth=&1;"
-	      MaskTunableValueString  "off"
-	      MaskEnableString	      "on"
-	      MaskVisibilityString    "on"
-	      MaskToolTipString	      "on"
-	      MaskInitialization      "cursys = gcb ; \nset_param([cursys, '/FIFO'], 'depth', depth);\n"
-	      MaskIconFrame	      on
-	      MaskIconOpaque	      on
-	      MaskIconRotate	      "none"
-	      MaskIconUnits	      "autoscale"
-	      MaskValueString	      "16"
+	      Object {
+		$PropName		"MaskObject"
+		$ObjectID		31
+		$ClassName		"Simulink.Mask"
+		Initialization		"cursys = gcb ; \nset_param([cursys, '/FIFO'], 'depth', depth);\n"
+		Object {
+		  $PropName		  "Parameters"
+		  $ObjectID		  32
+		  $ClassName		  "Simulink.MaskParameter"
+		  Type			  "popup"
+		  Array {
+		    Type		    "Cell"
+		    Dimension		    13
+		    Cell		    "16"
+		    Cell		    "32"
+		    Cell		    "64"
+		    Cell		    "128"
+		    Cell		    "256"
+		    Cell		    "512"
+		    Cell		    "1K"
+		    Cell		    "2K"
+		    Cell		    "4K"
+		    Cell		    "8K"
+		    Cell		    "16K"
+		    Cell		    "32K"
+		    Cell		    "64K"
+		    PropName		    "TypeOptions"
+		  }
+		  Name			  "depth"
+		  Prompt		  "Depth"
+		  Value			  "16"
+		  Evaluate		  "off"
+		  Tunable		  "off"
+		}
+	      }
 	      System {
 		Name			"Trickle_FWFT"
-		Location		[2, 74, 1014, 699]
+		Location		[12, 45, 1072, 905]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -9781,36 +10697,47 @@ Library {
 		Block {
 		  BlockType		  Inport
 		  Name			  "din"
+		  SID			  "307"
 		  Position		  [80, 178, 110, 192]
+		  ZOrder		  -1
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "we"
+		  SID			  "308"
 		  Position		  [40, 198, 70, 212]
+		  ZOrder		  -2
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "ack"
+		  SID			  "309"
 		  Position		  [60, 223, 90, 237]
+		  ZOrder		  -3
 		  Port			  "3"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "reset"
+		  SID			  "310"
 		  Position		  [20, 313, 50, 327]
+		  ZOrder		  -4
 		  Port			  "4"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Convert"
+		  SID			  "311"
 		  Ports			  [1, 1]
 		  Position		  [360, 136, 385, 154]
-		  Orientation		  "left"
+		  ZOrder		  -5
+		  BlockMirror		  on
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Convert"
 		  SourceType		  "Xilinx Type Converter Block"
 		  infoedit		  "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do not."
@@ -9845,8 +10772,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Convert3"
+		  SID			  "312"
 		  Ports			  [1, 1]
 		  Position		  [825, 206, 855, 224]
+		  ZOrder		  -6
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Convert"
 		  SourceType		  "Xilinx Type Converter Block"
 		  infoedit		  "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do not."
@@ -9881,11 +10811,17 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "FIFO"
+		  SID			  "313"
 		  Ports			  [4, 4]
 		  Position		  [370, 110, 400, 135]
+		  ZOrder		  -7
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/FIFO"
 		  SourceType		  "Xilinx FIFO Block Block"
+		  mem_type		  "Block RAM"
 		  performance_options	  "Standard_FIFO"
+		  infoedit1		  "Available only for V4, V5, V6, V7, K7, A7 and Zynq devices."
+		  embedded_registers	  off
 		  depth			  "16"
 		  percent_nbits		  "1"
 		  rst			  on
@@ -9897,7 +10833,6 @@ Library {
 		  use_almost_full	  off
 		  almost_full_thresh	  "14"
 		  dbl_ovrd		  off
-		  mem_type		  "Block RAM"
 		  xl_use_area		  off
 		  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 		  explicit_period	  "on"
@@ -9921,8 +10856,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter3"
+		  SID			  "314"
 		  Ports			  [1, 1]
 		  Position		  [765, 207, 805, 223]
+		  ZOrder		  -8
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -9947,8 +10885,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical2"
+		  SID			  "315"
 		  Ports			  [2, 1]
 		  Position		  [225, 213, 250, 237]
+		  ZOrder		  -9
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "OR"
@@ -9979,8 +10920,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "not_valid"
+		  SID			  "316"
 		  Ports			  [3, 1]
 		  Position		  [540, 196, 585, 234]
+		  ZOrder		  -10
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Register"
 		  SourceType		  "Xilinx Register Block"
 		  init			  "1"
@@ -10007,81 +10951,74 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Convert0"
+		  SID			  "317"
 		  Ports			  []
 		  Position		  [372, 111, 398, 136]
+		  ZOrder		  -11
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical20"
+		  SID			  "318"
 		  Ports			  []
 		  Position		  [237, 188, 263, 213]
+		  ZOrder		  -12
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period not_valid0"
+		  SID			  "319"
 		  Ports			  []
 		  Position		  [572, 171, 598, 196]
+		  ZOrder		  -13
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "data_out"
+		  SID			  "320"
 		  Position		  [770, 178, 800, 192]
+		  ZOrder		  -14
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "valid"
+		  SID			  "321"
 		  Position		  [900, 208, 930, 222]
+		  ZOrder		  -15
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "full"
+		  SID			  "322"
 		  Position		  [465, 238, 495, 252]
+		  ZOrder		  -16
 		  Port			  "3"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "%full"
+		  SID			  "323"
 		  Position		  [440, 213, 470, 227]
+		  ZOrder		  -17
 		  Port			  "4"
 		  IconDisplay		  "Port number"
 		}
@@ -10198,6 +11135,7 @@ Library {
 		  DstPort		  1
 		}
 		Annotation {
+		  SID			  "324"
 		  Name			  "We needed a FIFO which brings the valid data automatically to the output. \nThe regular XILINX Fifos are"
 		  " not FWFT (First Word Fall Through). \nWe tried to make one but it was really hard to make one agreeing with the e"
 		  "xact specs.\nThis module which we have named it Trickle_FWFT Fifo works very similiarly with minor \ndifferences w"
@@ -10205,6 +11143,7 @@ Library {
 		  Position		  [462, 64]
 		}
 		Annotation {
+		  SID			  "325"
 		  Name			  "The real depth of this module is depth+1. \nThe valid signal will go high with one cycle delay."
 		  Position		  [451, 355]
 		}
@@ -10213,17 +11152,20 @@ Library {
 	    Block {
 	      BlockType		      SubSystem
 	      Name		      "posedge"
+	      SID		      "326"
 	      Ports		      [1, 1]
 	      Position		      [275, 553, 320, 577]
+	      ZOrder		      -25
 	      MinAlgLoopOccurrences   off
 	      PropExecContextOutsideSubsystem off
 	      RTWSystemCode	      "Auto"
 	      FunctionWithSeparateData off
 	      Opaque		      off
+	      RequestExecContextInheritance off
 	      MaskHideContents	      off
 	      System {
 		Name			"posedge"
-		Location		[72, 372, 493, 522]
+		Location		[38, 253, 507, 638]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -10239,14 +11181,19 @@ Library {
 		Block {
 		  BlockType		  Inport
 		  Name			  "in"
+		  SID			  "327"
 		  Position		  [25, 43, 55, 57]
+		  ZOrder		  -1
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Delay"
+		  SID			  "328"
 		  Ports			  [1, 1]
 		  Position		  [85, 27, 130, 73]
+		  ZOrder		  -2
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Delay"
 		  SourceType		  "Xilinx Delay Block"
 		  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -10274,8 +11221,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter2"
+		  SID			  "329"
 		  Ports			  [1, 1]
 		  Position		  [155, 33, 205, 67]
+		  ZOrder		  -3
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -10300,8 +11250,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical"
+		  SID			  "330"
 		  Ports			  [2, 1]
 		  Position		  [240, 31, 320, 109]
+		  ZOrder		  -4
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -10332,7 +11285,9 @@ Library {
 		Block {
 		  BlockType		  Outport
 		  Name			  "out"
+		  SID			  "331"
 		  Position		  [350, 63, 380, 77]
+		  ZOrder		  -5
 		  IconDisplay		  "Port number"
 		}
 		Line {
@@ -10373,99 +11328,87 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "warn period Logical10"
+	      SID		      "332"
 	      Ports		      []
 	      Position		      [262, 227, 288, 252]
+	      ZOrder		      -26
 	      ShowName		      off
+	      LibraryVersion	      "1.213"
 	      SourceBlock	      "xbsReplacements_r4/Warning"
-	      SourceType	      ""
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
+	      SourceType	      "Unknown"
 	      period		      "1"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "warn period Logical20"
+	      SID		      "333"
 	      Ports		      []
 	      Position		      [352, 304, 378, 329]
+	      ZOrder		      -27
 	      ShowName		      off
+	      LibraryVersion	      "1.213"
 	      SourceBlock	      "xbsReplacements_r4/Warning"
-	      SourceType	      ""
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
+	      SourceType	      "Unknown"
 	      period		      "1"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "warn period Logical30"
+	      SID		      "334"
 	      Ports		      []
 	      Position		      [892, 183, 918, 208]
+	      ZOrder		      -28
 	      ShowName		      off
+	      LibraryVersion	      "1.213"
 	      SourceBlock	      "xbsReplacements_r4/Warning"
-	      SourceType	      ""
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
+	      SourceType	      "Unknown"
 	      period		      "1"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "warn period Logical40"
+	      SID		      "335"
 	      Ports		      []
 	      Position		      [627, 348, 653, 373]
+	      ZOrder		      -29
 	      ShowName		      off
+	      LibraryVersion	      "1.213"
 	      SourceBlock	      "xbsReplacements_r4/Warning"
-	      SourceType	      ""
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
+	      SourceType	      "Unknown"
 	      period		      "1"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "dout"
+	      SID		      "336"
 	      Position		      [940, 118, 970, 132]
+	      ZOrder		      -30
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "valid"
+	      SID		      "337"
 	      Position		      [940, 148, 970, 162]
+	      ZOrder		      -31
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "ack_dram"
+	      SID		      "338"
 	      Position		      [440, 218, 470, 232]
+	      ZOrder		      -32
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "en_addr_gen"
+	      SID		      "339"
 	      Position		      [960, 218, 990, 232]
+	      ZOrder		      -33
 	      Port		      "4"
 	      IconDisplay	      "Port number"
 	    }
@@ -10709,6 +11652,7 @@ Library {
 	      }
 	    }
 	    Annotation {
+	      SID		      "340"
 	      Name		      "if this is high it means data is a RB data"
 	      Position		      [159, 203]
 	    }
@@ -10717,8 +11661,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Register"
+	  SID			  "341"
 	  Ports			  [2, 1]
 	  Position		  [505, 343, 530, 372]
+	  ZOrder		  -26
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Register"
 	  SourceType		  "Xilinx Register Block"
 	  init			  "0"
@@ -10744,9 +11691,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Register5"
+	  SID			  "342"
 	  Ports			  [2, 1]
 	  Position		  [130, 88, 165, 117]
+	  ZOrder		  -27
 	  NamePlacement		  "alternate"
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Register"
 	  SourceType		  "Xilinx Register Block"
 	  init			  "0"
@@ -10772,9 +11722,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Register6"
+	  SID			  "343"
 	  Ports			  [2, 1]
 	  Position		  [270, 168, 305, 197]
+	  ZOrder		  -28
 	  NamePlacement		  "alternate"
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Register"
 	  SourceType		  "Xilinx Register Block"
 	  init			  "0"
@@ -10800,9 +11753,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Register7"
+	  SID			  "344"
 	  Ports			  [2, 1]
 	  Position		  [270, 208, 305, 237]
+	  ZOrder		  -29
 	  NamePlacement		  "alternate"
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Register"
 	  SourceType		  "Xilinx Register Block"
 	  init			  "0"
@@ -10828,8 +11784,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Relational"
+	  SID			  "345"
 	  Ports			  [2, 1]
 	  Position		  [445, 338, 475, 367]
+	  ZOrder		  -30
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Relational"
 	  SourceType		  "Xilinx Arithmetic Relational Operator Block"
 	  mode			  "a=b"
@@ -10855,8 +11814,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Slice"
+	  SID			  "346"
 	  Ports			  [1, 1]
 	  Position		  [2010, 277, 2035, 293]
+	  ZOrder		  -31
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Slice"
 	  SourceType		  "Xilinx Bit Slice Extractor Block"
 	  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type "
@@ -10886,31 +11848,56 @@ Library {
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "Trickle_FWFT"
+	  SID			  "347"
 	  Ports			  [4, 4]
 	  Position		  [370, 164, 455, 286]
+	  ZOrder		  -32
 	  BackgroundColor	  "yellow"
 	  MinAlgLoopOccurrences	  off
 	  PropExecContextOutsideSubsystem off
 	  RTWSystemCode		  "Auto"
 	  FunctionWithSeparateData off
 	  Opaque		  off
+	  RequestExecContextInheritance	off
 	  MaskHideContents	  off
-	  MaskPromptString	  "Depth"
-	  MaskStyleString	  "popup(16|32|64|128|256|512|1K|2K|4K|8K|16K|32K|64K)"
-	  MaskVariables		  "depth=&1;"
-	  MaskTunableValueString  "off"
-	  MaskEnableString	  "on"
-	  MaskVisibilityString	  "on"
-	  MaskToolTipString	  "on"
-	  MaskInitialization	  "cursys = gcb ; \nset_param([cursys, '/FIFO'], 'depth', depth);\n"
-	  MaskIconFrame		  on
-	  MaskIconOpaque	  on
-	  MaskIconRotate	  "none"
-	  MaskIconUnits		  "autoscale"
-	  MaskValueString	  "512"
+	  Object {
+	    $PropName		    "MaskObject"
+	    $ObjectID		    33
+	    $ClassName		    "Simulink.Mask"
+	    Initialization	    "cursys = gcb ; \nset_param([cursys, '/FIFO'], 'depth', depth);\n"
+	    Object {
+	      $PropName		      "Parameters"
+	      $ObjectID		      34
+	      $ClassName	      "Simulink.MaskParameter"
+	      Type		      "popup"
+	      Array {
+		Type			"Cell"
+		Dimension		13
+		Cell			"16"
+		Cell			"32"
+		Cell			"64"
+		Cell			"128"
+		Cell			"256"
+		Cell			"512"
+		Cell			"1K"
+		Cell			"2K"
+		Cell			"4K"
+		Cell			"8K"
+		Cell			"16K"
+		Cell			"32K"
+		Cell			"64K"
+		PropName		"TypeOptions"
+	      }
+	      Name		      "depth"
+	      Prompt		      "Depth"
+	      Value		      "512"
+	      Evaluate		      "off"
+	      Tunable		      "off"
+	    }
+	  }
 	  System {
 	    Name		    "Trickle_FWFT"
-	    Location		    [2, 74, 1014, 699]
+	    Location		    [12, 45, 1072, 905]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -10926,36 +11913,47 @@ Library {
 	    Block {
 	      BlockType		      Inport
 	      Name		      "din"
+	      SID		      "348"
 	      Position		      [80, 178, 110, 192]
+	      ZOrder		      -1
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "we"
+	      SID		      "349"
 	      Position		      [40, 198, 70, 212]
+	      ZOrder		      -2
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "ack"
+	      SID		      "350"
 	      Position		      [60, 223, 90, 237]
+	      ZOrder		      -3
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "reset"
+	      SID		      "351"
 	      Position		      [20, 313, 50, 327]
+	      ZOrder		      -4
 	      Port		      "4"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Convert"
+	      SID		      "352"
 	      Ports		      [1, 1]
 	      Position		      [360, 136, 385, 154]
-	      Orientation	      "left"
+	      ZOrder		      -5
+	      BlockMirror	      on
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -10991,8 +11989,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Convert1"
+	      SID		      "353"
 	      Ports		      [1, 1]
 	      Position		      [620, 206, 650, 224]
+	      ZOrder		      -6
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -11028,8 +12029,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Convert2"
+	      SID		      "354"
 	      Ports		      [1, 1]
 	      Position		      [135, 221, 165, 239]
+	      ZOrder		      -7
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -11065,11 +12069,17 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "FIFO"
+	      SID		      "355"
 	      Ports		      [4, 4]
 	      Position		      [370, 110, 400, 135]
+	      ZOrder		      -8
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/FIFO"
 	      SourceType	      "Xilinx FIFO Block Block"
+	      mem_type		      "Block RAM"
 	      performance_options     "Standard_FIFO"
+	      infoedit1		      "Available only for V4, V5, V6, V7, K7, A7 and Zynq devices."
+	      embedded_registers      off
 	      depth		      "512"
 	      percent_nbits	      "1"
 	      rst		      on
@@ -11081,7 +12091,6 @@ Library {
 	      use_almost_full	      off
 	      almost_full_thresh      "14"
 	      dbl_ovrd		      off
-	      mem_type		      "Block RAM"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      explicit_period	      "on"
@@ -11105,8 +12114,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Inverter3"
+	      SID		      "356"
 	      Ports		      [1, 1]
 	      Position		      [765, 207, 805, 223]
+	      ZOrder		      -9
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Inverter"
 	      SourceType	      "Xilinx Inverter Block"
 	      infoedit		      "Bitwise logical negation (one's complement) operator."
@@ -11131,8 +12143,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical2"
+	      SID		      "357"
 	      Ports		      [2, 1]
 	      Position		      [225, 213, 250, 237]
+	      ZOrder		      -10
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "OR"
@@ -11163,8 +12178,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "not_valid"
+	      SID		      "358"
 	      Ports		      [3, 1]
 	      Position		      [540, 196, 585, 234]
+	      ZOrder		      -11
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Register"
 	      SourceType	      "Xilinx Register Block"
 	      init		      "1"
@@ -11191,81 +12209,74 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "warn period Convert0"
+	      SID		      "359"
 	      Ports		      []
 	      Position		      [372, 111, 398, 136]
+	      ZOrder		      -12
 	      ShowName		      off
+	      LibraryVersion	      "1.213"
 	      SourceBlock	      "xbsReplacements_r4/Warning"
-	      SourceType	      ""
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
+	      SourceType	      "Unknown"
 	      period		      "1"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "warn period Logical20"
+	      SID		      "360"
 	      Ports		      []
 	      Position		      [237, 188, 263, 213]
+	      ZOrder		      -13
 	      ShowName		      off
+	      LibraryVersion	      "1.213"
 	      SourceBlock	      "xbsReplacements_r4/Warning"
-	      SourceType	      ""
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
+	      SourceType	      "Unknown"
 	      period		      "1"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "warn period not_valid0"
+	      SID		      "361"
 	      Ports		      []
 	      Position		      [572, 171, 598, 196]
+	      ZOrder		      -14
 	      ShowName		      off
+	      LibraryVersion	      "1.213"
 	      SourceBlock	      "xbsReplacements_r4/Warning"
-	      SourceType	      ""
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
+	      SourceType	      "Unknown"
 	      period		      "1"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "data_out"
+	      SID		      "362"
 	      Position		      [770, 178, 800, 192]
+	      ZOrder		      -15
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "valid"
+	      SID		      "363"
 	      Position		      [900, 208, 930, 222]
+	      ZOrder		      -16
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "full"
+	      SID		      "364"
 	      Position		      [465, 238, 495, 252]
+	      ZOrder		      -17
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "%full"
+	      SID		      "365"
 	      Position		      [440, 213, 470, 227]
+	      ZOrder		      -18
 	      Port		      "4"
 	      IconDisplay	      "Port number"
 	    }
@@ -11387,6 +12398,7 @@ Library {
 	      DstPort		      2
 	    }
 	    Annotation {
+	      SID		      "366"
 	      Name		      "We needed a FIFO which brings the valid data automatically to the output. \nThe regular XILINX Fif"
 	      "os are not FWFT (First Word Fall Through). \nWe tried to make one but it was really hard to make one agreeing w"
 	      "ith the exact specs.\nThis module which we have named it Trickle_FWFT Fifo works very similiarly with minor \nd"
@@ -11394,6 +12406,7 @@ Library {
 	      Position		      [462, 64]
 	    }
 	    Annotation {
+	      SID		      "367"
 	      Name		      "The real depth of this module is depth+1. \nThe valid signal will go high with one cycle delay."
 	      Position		      [451, 355]
 	    }
@@ -11402,31 +12415,45 @@ Library {
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "ctrl_unit"
+	  SID			  "368"
 	  Ports			  [3, 6]
 	  Position		  [1190, 12, 1320, 128]
+	  ZOrder		  -33
 	  BackgroundColor	  "yellow"
 	  MinAlgLoopOccurrences	  off
 	  PropExecContextOutsideSubsystem off
 	  RTWSystemCode		  "Auto"
 	  FunctionWithSeparateData off
 	  Opaque		  off
+	  RequestExecContextInheritance	off
 	  MaskHideContents	  off
-	  MaskPromptString	  "Burst Length?|Accumulation length?"
-	  MaskStyleString	  "edit,edit"
-	  MaskVariables		  "burst_length=@1;acc_length=@2;"
-	  MaskTunableValueString  "on,on"
-	  MaskCallbackString	  "|"
-	  MaskEnableString	  "on,on"
-	  MaskVisibilityString	  "on,on"
-	  MaskToolTipString	  "on,on"
-	  MaskIconFrame		  on
-	  MaskIconOpaque	  on
-	  MaskIconRotate	  "none"
-	  MaskIconUnits		  "autoscale"
-	  MaskValueString	  "valid_length|acc_length"
+	  Object {
+	    $PropName		    "MaskObject"
+	    $ObjectID		    35
+	    $ClassName		    "Simulink.Mask"
+	    Array {
+	      Type		      "Simulink.MaskParameter"
+	      Dimension		      2
+	      Object {
+		$ObjectID		36
+		Type			"edit"
+		Name			"burst_length"
+		Prompt			"Burst Length?"
+		Value			"valid_length"
+	      }
+	      Object {
+		$ObjectID		37
+		Type			"edit"
+		Name			"acc_length"
+		Prompt			"Accumulation length?"
+		Value			"acc_length"
+	      }
+	      PropName		      "Parameters"
+	    }
+	  }
 	  System {
 	    Name		    "ctrl_unit"
-	    Location		    [-27, 99, 1097, 749]
+	    Location		    [12, 45, 1184, 930]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -11442,28 +12469,37 @@ Library {
 	    Block {
 	      BlockType		      Inport
 	      Name		      "valid_data"
+	      SID		      "369"
 	      Position		      [35, 263, 65, 277]
+	      ZOrder		      -1
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "sync"
+	      SID		      "370"
 	      Position		      [35, 358, 65, 372]
+	      ZOrder		      -2
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "en_RB_addr"
+	      SID		      "371"
 	      Position		      [175, 543, 205, 557]
+	      ZOrder		      -3
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Concat1"
+	      SID		      "372"
 	      Ports		      [3, 1]
 	      Position		      [1430, 259, 1455, 311]
+	      ZOrder		      -4
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Concat"
 	      SourceType	      "Xilinx Bus Concatenator Block"
 	      infoedit		      "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary poi"
@@ -11487,8 +12523,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Convert2"
+	      SID		      "373"
 	      Ports		      [1, 1]
 	      Position		      [1335, 275, 1360, 295]
+	      ZOrder		      -5
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -11524,8 +12563,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay1"
+	      SID		      "374"
 	      Ports		      [1, 1]
 	      Position		      [145, 454, 175, 476]
+	      ZOrder		      -6
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -11560,8 +12602,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay2"
+	      SID		      "375"
 	      Ports		      [1, 1]
 	      Position		      [335, 157, 360, 193]
+	      ZOrder		      -7
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -11590,8 +12635,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Mux"
+	      SID		      "376"
 	      Ports		      [3, 1]
 	      Position		      [935, 123, 955, 227]
+	      ZOrder		      -8
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Mux"
 	      SourceType	      "Xilinx Bus Multiplexer Block"
 	      inputs		      "2"
@@ -11624,8 +12672,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Mux2"
+	      SID		      "377"
 	      Ports		      [3, 1]
 	      Position		      [1250, 63, 1270, 167]
+	      ZOrder		      -9
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Mux"
 	      SourceType	      "Xilinx Bus Multiplexer Block"
 	      inputs		      "2"
@@ -11658,17 +12709,20 @@ Library {
 	    Block {
 	      BlockType		      SubSystem
 	      Name		      "RB_active_or_finish"
+	      SID		      "378"
 	      Ports		      [2, 1]
 	      Position		      [710, 638, 910, 742]
+	      ZOrder		      -10
 	      MinAlgLoopOccurrences   off
 	      PropExecContextOutsideSubsystem off
 	      RTWSystemCode	      "Auto"
 	      FunctionWithSeparateData off
 	      Opaque		      off
+	      RequestExecContextInheritance off
 	      MaskHideContents	      off
 	      System {
 		Name			"RB_active_or_finish"
-		Location		[134, 306, 1059, 658]
+		Location		[100, 187, 1073, 774]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -11684,21 +12738,28 @@ Library {
 		Block {
 		  BlockType		  Inport
 		  Name			  "enable_rb_addr"
+		  SID			  "379"
 		  Position		  [285, 27, 315, 43]
+		  ZOrder		  -1
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "sync"
+		  SID			  "380"
 		  Position		  [25, 88, 55, 102]
+		  ZOrder		  -2
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Constant3"
+		  SID			  "381"
 		  Ports			  [0, 1]
 		  Position		  [340, 185, 390, 205]
+		  ZOrder		  -3
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "acc_length/2"
@@ -11723,18 +12784,23 @@ Library {
 		  sggui_pos		  "-1,-1,-1,-1"
 		  block_type		  "constant"
 		  block_version		  "9.2.01"
-		  sg_icon_stat		  "50,20,0,1,white,blue,0,5231020f"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 ],[0 0 20 20 ],[0.77 0.82 0.91]);"
-		  "\npatch([19 16 21 16 19 24 25 26 32 28 24 21 26 21 24 28 32 26 25 24 19 ],[2 5 10 15 18 18 17 18 18 14 18 15 10 5 "
-		  "2 6 2 2 3 2 2 ],[0.98 0.96 0.92]);\nplot([0 0 50 50 0 ],[0 20 20 0 0 ]);\nfprintf('','COMMENT: end icon graphics')"
-		  ";\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'9216');\nfprintf('','COMMENT: en"
-		  "d icon text');\n"
+		  sg_icon_stat		  "50,20,0,1,white,blue,0,d69340b8,right,,[ ],[ ]"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 50 50 0 0 ],[0 0 20 20 0 ]);\npatch([20.55 23.44 25.44 27.44 29.44 25.44 22.55 20.55 ],[12.22 12.22"
+		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([22.55 25.44 23.44 20.55 22.55 ],[10.22 10.22 12.22 12.22"
+		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([20.55 23.44 25.44 22.55 20.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
+		  "patch([22.55 29.44 27.44 25.44 23.44 20.55 22.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
+		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('outp"
+		  "ut',1,'9216');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Counter1"
+		  SID			  "382"
 		  Ports			  [2, 1]
 		  Position		  [335, 112, 385, 163]
+		  ZOrder		  -4
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Counter"
 		  SourceType		  "Xilinx Counter Block"
 		  infoedit		  "Hardware notes: Free running counters are the least expensive in hardware.  A count limited counter i"
@@ -11762,18 +12828,24 @@ Library {
 		  sggui_pos		  "-1,-1,-1,-1"
 		  block_type		  "counter"
 		  block_version		  "9.2.01"
-		  sg_icon_stat		  "50,51,2,1,white,blue,0,eceade92"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 ],[0 0 51 51 ],[0.77 0.82 0.91]);"
-		  "\npatch([11 3 15 3 11 24 28 32 46 35 24 16 28 16 24 35 46 32 28 24 11 ],[6 14 26 38 46 46 42 46 46 35 46 38 26 14 "
-		  "6 17 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 0 50 50 0 ],[0 51 51 0 0 ]);\nfprintf('','COMMENT: end icon graphics"
-		  "');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('input',1,'rst');\ncolor('black');port_lab"
-		  "el('input',2,'en');\ncolor('black');port_label('output',1,'out');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_icon_stat		  "50,51,2,1,white,blue,0,ae3608d6,right,,[ ],[ ]"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 51 51 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 50 50 0 0 ],[0 0 51 51 0 ]);\npatch([9.425 19.54 26.54 33.54 40.54 26.54 16.425 9.425 ],[32.77 32.7"
+		  "7 39.77 32.77 39.77 39.77 39.77 32.77 ],[1 1 1 ]);\npatch([16.425 26.54 19.54 9.425 16.425 ],[25.77 25.77 32.77 32"
+		  ".77 25.77 ],[0.931 0.946 0.973 ]);\npatch([9.425 19.54 26.54 16.425 9.425 ],[18.77 18.77 25.77 25.77 18.77 ],[1 1 "
+		  "1 ]);\npatch([16.425 40.54 33.54 26.54 19.54 9.425 16.425 ],[11.77 11.77 18.77 11.77 18.77 18.77 11.77 ],[0.931 0."
+		  "946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');"
+		  "port_label('input',1,'rst');\ncolor('black');port_label('input',2,'en');\n\ncolor('black');disp('{\\fontsize{14}\\"
+		  "bf++}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter6"
+		  SID			  "383"
 		  Ports			  [1, 1]
 		  Position		  [735, 88, 765, 102]
+		  ZOrder		  -5
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -11798,8 +12870,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter9"
+		  SID			  "384"
 		  Ports			  [1, 1]
 		  Position		  [700, 223, 730, 237]
+		  ZOrder		  -6
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -11824,8 +12899,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical13"
+		  SID			  "385"
 		  Ports			  [3, 1]
 		  Position		  [815, 82, 845, 148]
+		  ZOrder		  -7
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -11856,8 +12934,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical14"
+		  SID			  "386"
 		  Ports			  [2, 1]
 		  Position		  [360, 255, 385, 295]
+		  ZOrder		  -8
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -11888,8 +12969,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical7"
+		  SID			  "387"
 		  Ports			  [2, 1]
 		  Position		  [540, 120, 565, 160]
+		  ZOrder		  -9
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -11920,8 +13004,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Relational3"
+		  SID			  "388"
 		  Ports			  [2, 1]
 		  Position		  [440, 128, 490, 172]
+		  ZOrder		  -10
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Relational"
 		  SourceType		  "Xilinx Arithmetic Relational Operator Block"
 		  mode			  "a=b"
@@ -11948,8 +13035,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "system_start"
+		  SID			  "389"
 		  Ports			  [2, 1]
 		  Position		  [145, 285, 190, 325]
+		  ZOrder		  -11
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Register"
 		  SourceType		  "Xilinx Register Block"
 		  init			  "0"
@@ -11975,8 +13065,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "system_start1"
+		  SID			  "390"
 		  Ports			  [2, 1]
 		  Position		  [465, 255, 510, 295]
+		  ZOrder		  -12
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Register"
 		  SourceType		  "Xilinx Register Block"
 		  init			  "0"
@@ -12002,8 +13095,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "system_start2"
+		  SID			  "391"
 		  Ports			  [3, 1]
 		  Position		  [630, 75, 675, 115]
+		  ZOrder		  -13
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Register"
 		  SourceType		  "Xilinx Register Block"
 		  init			  "0"
@@ -12030,79 +13126,61 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical130"
+		  SID			  "392"
 		  Ports			  []
 		  Position		  [832, 57, 858, 82]
+		  ZOrder		  -14
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical140"
+		  SID			  "393"
 		  Ports			  []
 		  Position		  [372, 230, 398, 255]
+		  ZOrder		  -15
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical70"
+		  SID			  "394"
 		  Ports			  []
 		  Position		  [552, 95, 578, 120]
+		  ZOrder		  -16
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Relational30"
+		  SID			  "395"
 		  Ports			  []
 		  Position		  [477, 103, 503, 128]
+		  ZOrder		  -17
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "rb_active"
+		  SID			  "396"
 		  Position		  [870, 108, 900, 122]
+		  ZOrder		  -18
 		  IconDisplay		  "Port number"
 		}
 		Line {
@@ -12255,32 +13333,46 @@ Library {
 	    Block {
 	      BlockType		      SubSystem
 	      Name		      "address_gen_vacc_DRAM"
+	      SID		      "397"
 	      Ports		      [3, 3]
 	      Position		      [735, 150, 850, 310]
+	      ZOrder		      -11
 	      BackgroundColor	      "[1.000000, 0.501961, 0.000000]"
 	      MinAlgLoopOccurrences   off
 	      PropExecContextOutsideSubsystem off
 	      RTWSystemCode	      "Auto"
 	      FunctionWithSeparateData off
 	      Opaque		      off
+	      RequestExecContextInheritance off
 	      MaskHideContents	      off
-	      MaskPromptString	      "Accumulation length?|Valid period length?"
-	      MaskStyleString	      "edit,edit"
-	      MaskVariables	      "acc_length=@1;valid_length=@2;"
-	      MaskTunableValueString  "on,on"
-	      MaskCallbackString      "|"
-	      MaskEnableString	      "on,on"
-	      MaskVisibilityString    "on,on"
-	      MaskToolTipString	      "on,on"
-	      MaskInitialization      "address_gen_vacc_v2_mask;"
-	      MaskIconFrame	      on
-	      MaskIconOpaque	      on
-	      MaskIconRotate	      "none"
-	      MaskIconUnits	      "autoscale"
-	      MaskValueString	      "acc_length|burst_length"
+	      Object {
+		$PropName		"MaskObject"
+		$ObjectID		38
+		$ClassName		"Simulink.Mask"
+		Initialization		"address_gen_vacc_v2_mask;"
+		Array {
+		  Type			  "Simulink.MaskParameter"
+		  Dimension		  2
+		  Object {
+		    $ObjectID		    39
+		    Type		    "edit"
+		    Name		    "acc_length"
+		    Prompt		    "Accumulation length?"
+		    Value		    "acc_length"
+		  }
+		  Object {
+		    $ObjectID		    40
+		    Type		    "edit"
+		    Name		    "valid_length"
+		    Prompt		    "Valid period length?"
+		    Value		    "burst_length"
+		  }
+		  PropName		  "Parameters"
+		}
+	      }
 	      System {
 		Name			"address_gen_vacc_DRAM"
-		Location		[129, 178, 1030, 944]
+		Location		[95, 59, 1044, 1060]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -12296,28 +13388,37 @@ Library {
 		Block {
 		  BlockType		  Inport
 		  Name			  "sync"
+		  SID			  "398"
 		  Position		  [30, 63, 60, 77]
+		  ZOrder		  -1
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "read_en"
+		  SID			  "399"
 		  Position		  [30, 113, 60, 127]
+		  ZOrder		  -2
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "write_en"
+		  SID			  "400"
 		  Position		  [30, 163, 60, 177]
+		  ZOrder		  -3
 		  Port			  "3"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "and0"
+		  SID			  "401"
 		  Ports			  [2, 1]
 		  Position		  [65, 250, 85, 270]
+		  ZOrder		  -4
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -12348,8 +13449,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "block_counter"
+		  SID			  "402"
 		  Ports			  [1, 1]
 		  Position		  [95, 43, 145, 97]
+		  ZOrder		  -5
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Counter"
 		  SourceType		  "Xilinx Counter Block"
 		  infoedit		  "Hardware notes: Free running counters are the least expensive in hardware.  A count limited counter i"
@@ -12378,20 +13482,22 @@ Library {
 		  block_type		  "counter"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "50,54,1,1,white,blue,0,b089e9c5,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 54 54 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 50 50 0 0 ],[0 0 54 54 0 ]);\npatch([9.425 19.54 26.54 33.54 40.54 26.54 16.425 9.425 ],[34.77 34.7"
-		  "7 41.77 34.77 41.77 41.77 41.77 34.77 ],[1 1 1 ]);\npatch([16.425 26.54 19.54 9.425 16.425 ],[27.77 27.77 34.77 34"
-		  ".77 27.77 ],[0.931 0.946 0.973 ]);\npatch([9.425 19.54 26.54 16.425 9.425 ],[20.77 20.77 27.77 27.77 20.77 ],[1 1 "
-		  "1 ]);\npatch([16.425 40.54 33.54 26.54 19.54 9.425 16.425 ],[13.77 13.77 20.77 13.77 20.77 20.77 13.77 ],[0.931 0."
-		  "946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');"
-		  "port_label('input',1,'en');\n\ncolor('black');disp('{\\fontsize{14}\\bf++}','texmode','on');\nfprintf('','COMMENT:"
-		  " end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 60 60 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 60 60 0 ]);\npatch([12.2 23.76 31.76 39.76 47.76 31.76 20.2 12.2 ],[38.88 38.88 46"
+		  ".88 38.88 46.88 46.88 46.88 38.88 ],[1 1 1 ]);\npatch([20.2 31.76 23.76 12.2 20.2 ],[30.88 30.88 38.88 38.88 30.88"
+		  " ],[0.931 0.946 0.973 ]);\npatch([12.2 23.76 31.76 20.2 12.2 ],[22.88 22.88 30.88 30.88 22.88 ],[1 1 1 ]);\npatch("
+		  "[20.2 47.76 39.76 31.76 23.76 12.2 20.2 ],[14.88 14.88 22.88 14.88 22.88 22.88 14.88 ],[0.931 0.946 0.973 ]);\nfpr"
+		  "intf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');disp('{\\fontsiz"
+		  "e{14}\\bf++}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "cast0"
+		  SID			  "403"
 		  Ports			  [1, 1]
 		  Position		  [395, 150, 425, 170]
+		  ZOrder		  -6
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Convert"
 		  SourceType		  "Xilinx Type Converter Block"
 		  infoedit		  "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do not."
@@ -12426,8 +13532,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "cast1"
+		  SID			  "404"
 		  Ports			  [1, 1]
 		  Position		  [395, 450, 425, 470]
+		  ZOrder		  -7
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Convert"
 		  SourceType		  "Xilinx Type Converter Block"
 		  infoedit		  "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do not."
@@ -12462,8 +13571,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "compare"
+		  SID			  "405"
 		  Ports			  [2, 1]
 		  Position		  [445, 502, 485, 553]
+		  ZOrder		  -8
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Relational"
 		  SourceType		  "Xilinx Arithmetic Relational Operator Block"
 		  mode			  "a=b"
@@ -12490,8 +13602,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "compare1"
+		  SID			  "406"
 		  Ports			  [2, 1]
 		  Position		  [265, 250, 295, 290]
+		  ZOrder		  -9
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Relational"
 		  SourceType		  "Xilinx Arithmetic Relational Operator Block"
 		  mode			  "a=b"
@@ -12518,8 +13633,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "concat0"
+		  SID			  "407"
 		  Ports			  [2, 1]
 		  Position		  [245, 101, 295, 154]
+		  ZOrder		  -10
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Concat"
 		  SourceType		  "Xilinx Bus Concatenator Block"
 		  infoedit		  "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary point at z"
@@ -12543,8 +13661,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "concat1"
+		  SID			  "408"
 		  Ports			  [2, 1]
 		  Position		  [245, 341, 295, 394]
+		  ZOrder		  -11
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Concat"
 		  SourceType		  "Xilinx Bus Concatenator Block"
 		  infoedit		  "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary point at z"
@@ -12568,8 +13689,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "concat2"
+		  SID			  "409"
 		  Ports			  [7, 1]
-		  Position		  [595, 15, 635, 165]
+		  Position		  [595, 10, 635, 160]
+		  ZOrder		  -12
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Concat"
 		  SourceType		  "Xilinx Bus Concatenator Block"
 		  infoedit		  "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary point at z"
@@ -12593,8 +13717,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "concat3"
+		  SID			  "410"
 		  Ports			  [7, 1]
 		  Position		  [595, 310, 635, 460]
+		  ZOrder		  -13
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Concat"
 		  SourceType		  "Xilinx Bus Concatenator Block"
 		  infoedit		  "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary point at z"
@@ -12618,8 +13745,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "const0"
+		  SID			  "411"
 		  Ports			  [0, 1]
 		  Position		  [445, 192, 475, 208]
+		  ZOrder		  -14
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "0"
@@ -12656,8 +13786,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "const1"
+		  SID			  "412"
 		  Ports			  [0, 1]
 		  Position		  [445, 212, 475, 228]
+		  ZOrder		  -15
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "0"
@@ -12694,8 +13827,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "const10"
+		  SID			  "413"
 		  Ports			  [0, 1]
 		  Position		  [45, 343, 65, 367]
+		  ZOrder		  -16
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "valid_length/2"
@@ -12721,19 +13857,22 @@ Library {
 		  block_type		  "constant"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "20,24,0,1,white,blue,0,f59e573f,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 20 20 0 0 ],[0 0 24 24 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 20 20 0 0 ],[0 0 24 24 0 ]);\npatch([5.55 8.44 10.44 12.44 14.44 10.44 7.55 5.55 ],[14.22 14.22 16."
-		  "22 14.22 16.22 16.22 16.22 14.22 ],[1 1 1 ]);\npatch([7.55 10.44 8.44 5.55 7.55 ],[12.22 12.22 14.22 14.22 12.22 ]"
-		  ",[0.931 0.946 0.973 ]);\npatch([5.55 8.44 10.44 7.55 5.55 ],[10.22 10.22 12.22 12.22 10.22 ],[1 1 1 ]);\npatch([7."
-		  "55 14.44 12.44 10.44 8.44 5.55 7.55 ],[8.22 8.22 10.22 8.22 10.22 10.22 8.22 ],[0.931 0.946 0.973 ]);\nfprintf('',"
-		  "'COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'18'"
-		  ");\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 0 ],[0 0 26 26 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 55 55 0 0 ],[0 0 26 26 0 ]);\npatch([20.325 24.66 27.66 30.66 33.66 27.66 23.325 20.325 ],[16.33 16"
+		  ".33 19.33 16.33 19.33 19.33 19.33 16.33 ],[1 1 1 ]);\npatch([23.325 27.66 24.66 20.325 23.325 ],[13.33 13.33 16.33"
+		  " 16.33 13.33 ],[0.931 0.946 0.973 ]);\npatch([20.325 24.66 27.66 23.325 20.325 ],[10.33 10.33 13.33 13.33 10.33 ],"
+		  "[1 1 1 ]);\npatch([23.325 33.66 30.66 27.66 24.66 20.325 23.325 ],[7.33 7.33 10.33 7.33 10.33 10.33 7.33 ],[0.931 "
+		  "0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black'"
+		  ");port_label('output',1,'1');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "const11"
+		  SID			  "414"
 		  Ports			  [0, 1]
 		  Position		  [95, 363, 115, 387]
+		  ZOrder		  -17
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "acc_length/2-1"
@@ -12759,19 +13898,22 @@ Library {
 		  block_type		  "constant"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "20,24,0,1,white,blue,0,b6bce910,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 20 20 0 0 ],[0 0 24 24 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 20 20 0 0 ],[0 0 24 24 0 ]);\npatch([5.55 8.44 10.44 12.44 14.44 10.44 7.55 5.55 ],[14.22 14.22 16."
-		  "22 14.22 16.22 16.22 16.22 14.22 ],[1 1 1 ]);\npatch([7.55 10.44 8.44 5.55 7.55 ],[12.22 12.22 14.22 14.22 12.22 ]"
-		  ",[0.931 0.946 0.973 ]);\npatch([5.55 8.44 10.44 7.55 5.55 ],[10.22 10.22 12.22 12.22 10.22 ],[1 1 1 ]);\npatch([7."
-		  "55 14.44 12.44 10.44 8.44 5.55 7.55 ],[8.22 8.22 10.22 8.22 10.22 10.22 8.22 ],[0.931 0.946 0.973 ]);\nfprintf('',"
-		  "'COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'921"
-		  "5');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 0 ],[0 0 26 26 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 55 55 0 0 ],[0 0 26 26 0 ]);\npatch([20.325 24.66 27.66 30.66 33.66 27.66 23.325 20.325 ],[16.33 16"
+		  ".33 19.33 16.33 19.33 19.33 19.33 16.33 ],[1 1 1 ]);\npatch([23.325 27.66 24.66 20.325 23.325 ],[13.33 13.33 16.33"
+		  " 16.33 13.33 ],[0.931 0.946 0.973 ]);\npatch([20.325 24.66 27.66 23.325 20.325 ],[10.33 10.33 13.33 13.33 10.33 ],"
+		  "[1 1 1 ]);\npatch([23.325 33.66 30.66 27.66 24.66 20.325 23.325 ],[7.33 7.33 10.33 7.33 10.33 10.33 7.33 ],[0.931 "
+		  "0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black'"
+		  ");port_label('output',1,'1');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "const4"
+		  SID			  "415"
 		  Ports			  [0, 1]
 		  Position		  [345, 570, 385, 590]
+		  ZOrder		  -18
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "acc_length/2-1"
@@ -12797,19 +13939,22 @@ Library {
 		  block_type		  "constant"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "40,20,0,1,white,blue,0,b6bce910,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 40 40 0 0 ],[0 0 20 20 0 ]);\npatch([15.55 18.44 20.44 22.44 24.44 20.44 17.55 15.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([17.55 20.44 18.44 15.55 17.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([15.55 18.44 20.44 17.55 15.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([17.55 24.44 22.44 20.44 18.44 15.55 17.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('outp"
-		  "ut',1,'9215');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 0 ],[0 0 26 26 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 55 55 0 0 ],[0 0 26 26 0 ]);\npatch([20.325 24.66 27.66 30.66 33.66 27.66 23.325 20.325 ],[16.33 16"
+		  ".33 19.33 16.33 19.33 19.33 19.33 16.33 ],[1 1 1 ]);\npatch([23.325 27.66 24.66 20.325 23.325 ],[13.33 13.33 16.33"
+		  " 16.33 13.33 ],[0.931 0.946 0.973 ]);\npatch([20.325 24.66 27.66 23.325 20.325 ],[10.33 10.33 13.33 13.33 10.33 ],"
+		  "[1 1 1 ]);\npatch([23.325 33.66 30.66 27.66 24.66 20.325 23.325 ],[7.33 7.33 10.33 7.33 10.33 10.33 7.33 ],[0.931 "
+		  "0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black'"
+		  ");port_label('output',1,'1');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "or0"
+		  SID			  "416"
 		  Ports			  [2, 1]
 		  Position		  [65, 200, 85, 220]
+		  ZOrder		  -19
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "OR"
@@ -12840,8 +13985,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "read_counter"
+		  SID			  "417"
 		  Ports			  [4, 1]
 		  Position		  [115, 241, 165, 294]
+		  ZOrder		  -20
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Counter"
 		  SourceType		  "Xilinx Counter Block"
 		  infoedit		  "Hardware notes: Free running counters are the least expensive in hardware.  A count limited counter i"
@@ -12883,8 +14031,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice0"
+		  SID			  "418"
 		  Ports			  [1, 1]
 		  Position		  [345, 150, 375, 170]
+		  ZOrder		  -21
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -12903,19 +14054,22 @@ Library {
 		  block_type		  "slice"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "30,20,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 30 30 0 0 ],[0 0 20 20 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([12.55 19.44 17.44 15.44 13.44 10.55 12.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('ou"
-		  "tput',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 30 30 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\npatch([21.1 26.88 30.88 34.88 38.88 30.88 25.1 21.1 ],[19.44 19.44 23"
+		  ".44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([25.1 30.88 26.88 21.1 25.1 ],[15.44 15.44 19.44 19.44 15.44"
+		  " ],[0.931 0.946 0.973 ]);\npatch([21.1 26.88 30.88 25.1 21.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 ]);\npatch("
+		  "[25.1 38.88 34.88 30.88 26.88 21.1 25.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973 ]);\nfprintf"
+		  "('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',"
+		  "1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice1"
+		  SID			  "419"
 		  Ports			  [1, 1]
 		  Position		  [345, 90, 375, 110]
+		  ZOrder		  -22
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -12934,19 +14088,22 @@ Library {
 		  block_type		  "slice"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "30,20,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 30 30 0 0 ],[0 0 20 20 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([12.55 19.44 17.44 15.44 13.44 10.55 12.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('ou"
-		  "tput',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 30 30 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\npatch([21.1 26.88 30.88 34.88 38.88 30.88 25.1 21.1 ],[19.44 19.44 23"
+		  ".44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([25.1 30.88 26.88 21.1 25.1 ],[15.44 15.44 19.44 19.44 15.44"
+		  " ],[0.931 0.946 0.973 ]);\npatch([21.1 26.88 30.88 25.1 21.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 ]);\npatch("
+		  "[25.1 38.88 34.88 30.88 26.88 21.1 25.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973 ]);\nfprintf"
+		  "('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',"
+		  "1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice10"
+		  SID			  "420"
 		  Ports			  [1, 1]
 		  Position		  [445, 350, 475, 370]
+		  ZOrder		  -23
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -12976,8 +14133,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice11"
+		  SID			  "421"
 		  Ports			  [1, 1]
 		  Position		  [445, 300, 475, 320]
+		  ZOrder		  -24
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -12996,19 +14156,22 @@ Library {
 		  block_type		  "slice"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "30,20,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 30 30 0 0 ],[0 0 20 20 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([12.55 19.44 17.44 15.44 13.44 10.55 12.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('ou"
-		  "tput',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 30 30 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\npatch([21.1 26.88 30.88 34.88 38.88 30.88 25.1 21.1 ],[19.44 19.44 23"
+		  ".44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([25.1 30.88 26.88 21.1 25.1 ],[15.44 15.44 19.44 19.44 15.44"
+		  " ],[0.931 0.946 0.973 ]);\npatch([21.1 26.88 30.88 25.1 21.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 ]);\npatch("
+		  "[25.1 38.88 34.88 30.88 26.88 21.1 25.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973 ]);\nfprintf"
+		  "('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',"
+		  "1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice12"
+		  SID			  "422"
 		  Ports			  [1, 1]
-		  Position		  [515, 15, 545, 35]
+		  Position		  [515, 0, 545, 20]
+		  ZOrder		  -25
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -13038,8 +14201,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice13"
+		  SID			  "423"
 		  Ports			  [1, 1]
 		  Position		  [515, 60, 545, 80]
+		  ZOrder		  -26
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -13058,19 +14224,22 @@ Library {
 		  block_type		  "slice"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "30,20,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 30 30 0 0 ],[0 0 20 20 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([12.55 19.44 17.44 15.44 13.44 10.55 12.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('ou"
-		  "tput',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 30 30 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\npatch([21.1 26.88 30.88 34.88 38.88 30.88 25.1 21.1 ],[19.44 19.44 23"
+		  ".44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([25.1 30.88 26.88 21.1 25.1 ],[15.44 15.44 19.44 19.44 15.44"
+		  " ],[0.931 0.946 0.973 ]);\npatch([21.1 26.88 30.88 25.1 21.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 ]);\npatch("
+		  "[25.1 38.88 34.88 30.88 26.88 21.1 25.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973 ]);\nfprintf"
+		  "('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',"
+		  "1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice14"
+		  SID			  "424"
 		  Ports			  [1, 1]
 		  Position		  [495, 300, 525, 320]
+		  ZOrder		  -27
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -13100,8 +14269,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice15"
+		  SID			  "425"
 		  Ports			  [1, 1]
 		  Position		  [495, 360, 525, 380]
+		  ZOrder		  -28
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -13120,19 +14292,22 @@ Library {
 		  block_type		  "slice"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "30,20,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 30 30 0 0 ],[0 0 20 20 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([12.55 19.44 17.44 15.44 13.44 10.55 12.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('ou"
-		  "tput',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 30 30 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\npatch([21.1 26.88 30.88 34.88 38.88 30.88 25.1 21.1 ],[19.44 19.44 23"
+		  ".44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([25.1 30.88 26.88 21.1 25.1 ],[15.44 15.44 19.44 19.44 15.44"
+		  " ],[0.931 0.946 0.973 ]);\npatch([21.1 26.88 30.88 25.1 21.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 ]);\npatch("
+		  "[25.1 38.88 34.88 30.88 26.88 21.1 25.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973 ]);\nfprintf"
+		  "('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',"
+		  "1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice2"
+		  SID			  "426"
 		  Ports			  [1, 1]
 		  Position		  [395, 90, 425, 110]
+		  ZOrder		  -29
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -13151,19 +14326,22 @@ Library {
 		  block_type		  "slice"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "30,20,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 30 30 0 0 ],[0 0 20 20 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([12.55 19.44 17.44 15.44 13.44 10.55 12.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('ou"
-		  "tput',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 30 30 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\npatch([21.1 26.88 30.88 34.88 38.88 30.88 25.1 21.1 ],[19.44 19.44 23"
+		  ".44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([25.1 30.88 26.88 21.1 25.1 ],[15.44 15.44 19.44 19.44 15.44"
+		  " ],[0.931 0.946 0.973 ]);\npatch([21.1 26.88 30.88 25.1 21.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 ]);\npatch("
+		  "[25.1 38.88 34.88 30.88 26.88 21.1 25.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973 ]);\nfprintf"
+		  "('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',"
+		  "1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice3"
+		  SID			  "427"
 		  Ports			  [1, 1]
 		  Position		  [395, 50, 425, 70]
+		  ZOrder		  -30
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -13182,19 +14360,22 @@ Library {
 		  block_type		  "slice"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "30,20,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 30 30 0 0 ],[0 0 20 20 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([12.55 19.44 17.44 15.44 13.44 10.55 12.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('ou"
-		  "tput',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 30 30 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\npatch([21.1 26.88 30.88 34.88 38.88 30.88 25.1 21.1 ],[19.44 19.44 23"
+		  ".44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([25.1 30.88 26.88 21.1 25.1 ],[15.44 15.44 19.44 19.44 15.44"
+		  " ],[0.931 0.946 0.973 ]);\npatch([21.1 26.88 30.88 25.1 21.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 ]);\npatch("
+		  "[25.1 38.88 34.88 30.88 26.88 21.1 25.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973 ]);\nfprintf"
+		  "('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',"
+		  "1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice4"
+		  SID			  "428"
 		  Ports			  [1, 1]
 		  Position		  [445, 50, 475, 70]
+		  ZOrder		  -31
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -13224,8 +14405,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice5"
+		  SID			  "429"
 		  Ports			  [1, 1]
-		  Position		  [445, 15, 475, 35]
+		  Position		  [445, 0, 475, 20]
+		  ZOrder		  -32
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -13244,19 +14428,22 @@ Library {
 		  block_type		  "slice"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "30,20,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 30 30 0 0 ],[0 0 20 20 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([12.55 19.44 17.44 15.44 13.44 10.55 12.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('ou"
-		  "tput',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 30 30 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\npatch([21.1 26.88 30.88 34.88 38.88 30.88 25.1 21.1 ],[19.44 19.44 23"
+		  ".44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([25.1 30.88 26.88 21.1 25.1 ],[15.44 15.44 19.44 19.44 15.44"
+		  " ],[0.931 0.946 0.973 ]);\npatch([21.1 26.88 30.88 25.1 21.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 ]);\npatch("
+		  "[25.1 38.88 34.88 30.88 26.88 21.1 25.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973 ]);\nfprintf"
+		  "('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',"
+		  "1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice6"
+		  SID			  "430"
 		  Ports			  [1, 1]
 		  Position		  [345, 450, 375, 470]
+		  ZOrder		  -33
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -13275,19 +14462,22 @@ Library {
 		  block_type		  "slice"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "30,20,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 30 30 0 0 ],[0 0 20 20 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([12.55 19.44 17.44 15.44 13.44 10.55 12.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('ou"
-		  "tput',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 30 30 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\npatch([21.1 26.88 30.88 34.88 38.88 30.88 25.1 21.1 ],[19.44 19.44 23"
+		  ".44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([25.1 30.88 26.88 21.1 25.1 ],[15.44 15.44 19.44 19.44 15.44"
+		  " ],[0.931 0.946 0.973 ]);\npatch([21.1 26.88 30.88 25.1 21.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 ]);\npatch("
+		  "[25.1 38.88 34.88 30.88 26.88 21.1 25.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973 ]);\nfprintf"
+		  "('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',"
+		  "1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice7"
+		  SID			  "431"
 		  Ports			  [1, 1]
 		  Position		  [345, 390, 375, 410]
+		  ZOrder		  -34
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -13306,19 +14496,22 @@ Library {
 		  block_type		  "slice"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "30,20,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 30 30 0 0 ],[0 0 20 20 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([12.55 19.44 17.44 15.44 13.44 10.55 12.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('ou"
-		  "tput',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 30 30 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\npatch([21.1 26.88 30.88 34.88 38.88 30.88 25.1 21.1 ],[19.44 19.44 23"
+		  ".44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([25.1 30.88 26.88 21.1 25.1 ],[15.44 15.44 19.44 19.44 15.44"
+		  " ],[0.931 0.946 0.973 ]);\npatch([21.1 26.88 30.88 25.1 21.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 ]);\npatch("
+		  "[25.1 38.88 34.88 30.88 26.88 21.1 25.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973 ]);\nfprintf"
+		  "('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',"
+		  "1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice8"
+		  SID			  "432"
 		  Ports			  [1, 1]
 		  Position		  [395, 400, 425, 420]
+		  ZOrder		  -35
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -13337,19 +14530,22 @@ Library {
 		  block_type		  "slice"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "30,20,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 30 30 0 0 ],[0 0 20 20 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([12.55 19.44 17.44 15.44 13.44 10.55 12.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('ou"
-		  "tput',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 30 30 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\npatch([21.1 26.88 30.88 34.88 38.88 30.88 25.1 21.1 ],[19.44 19.44 23"
+		  ".44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([25.1 30.88 26.88 21.1 25.1 ],[15.44 15.44 19.44 19.44 15.44"
+		  " ],[0.931 0.946 0.973 ]);\npatch([21.1 26.88 30.88 25.1 21.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 ]);\npatch("
+		  "[25.1 38.88 34.88 30.88 26.88 21.1 25.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973 ]);\nfprintf"
+		  "('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',"
+		  "1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice9"
+		  SID			  "433"
 		  Ports			  [1, 1]
 		  Position		  [395, 350, 425, 370]
+		  ZOrder		  -36
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -13368,19 +14564,22 @@ Library {
 		  block_type		  "slice"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "30,20,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 30 30 0 0 ],[0 0 20 20 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([12.55 19.44 17.44 15.44 13.44 10.55 12.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('ou"
-		  "tput',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 30 30 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\npatch([21.1 26.88 30.88 34.88 38.88 30.88 25.1 21.1 ],[19.44 19.44 23"
+		  ".44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([25.1 30.88 26.88 21.1 25.1 ],[15.44 15.44 19.44 19.44 15.44"
+		  " ],[0.931 0.946 0.973 ]);\npatch([21.1 26.88 30.88 25.1 21.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 ]);\npatch("
+		  "[25.1 38.88 34.88 30.88 26.88 21.1 25.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973 ]);\nfprintf"
+		  "('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',"
+		  "1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "write_counter"
+		  SID			  "434"
 		  Ports			  [2, 1]
 		  Position		  [95, 141, 145, 194]
+		  ZOrder		  -37
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Counter"
 		  SourceType		  "Xilinx Counter Block"
 		  infoedit		  "Hardware notes: Free running counters are the least expensive in hardware.  A count limited counter i"
@@ -13409,32 +14608,37 @@ Library {
 		  block_type		  "counter"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "50,53,2,1,white,blue,0,131a2a7a,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 53 53 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 50 50 0 0 ],[0 0 53 53 0 ]);\npatch([9.425 19.54 26.54 33.54 40.54 26.54 16.425 9.425 ],[33.77 33.7"
-		  "7 40.77 33.77 40.77 40.77 40.77 33.77 ],[1 1 1 ]);\npatch([16.425 26.54 19.54 9.425 16.425 ],[26.77 26.77 33.77 33"
-		  ".77 26.77 ],[0.931 0.946 0.973 ]);\npatch([9.425 19.54 26.54 16.425 9.425 ],[19.77 19.77 26.77 26.77 19.77 ],[1 1 "
-		  "1 ]);\npatch([16.425 40.54 33.54 26.54 19.54 9.425 16.425 ],[12.77 12.77 19.77 12.77 19.77 19.77 12.77 ],[0.931 0."
-		  "946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');"
-		  "port_label('input',1,'rst');\ncolor('black');port_label('input',2,'en');\n\ncolor('black');disp('{\\fontsize{14}\\"
-		  "bf\\lceil++\\rceil}','texmode','on');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 60 60 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 60 60 0 ]);\npatch([12.2 23.76 31.76 39.76 47.76 31.76 20.2 12.2 ],[38.88 38.88 46"
+		  ".88 38.88 46.88 46.88 46.88 38.88 ],[1 1 1 ]);\npatch([20.2 31.76 23.76 12.2 20.2 ],[30.88 30.88 38.88 38.88 30.88"
+		  " ],[0.931 0.946 0.973 ]);\npatch([12.2 23.76 31.76 20.2 12.2 ],[22.88 22.88 30.88 30.88 22.88 ],[1 1 1 ]);\npatch("
+		  "[20.2 47.76 39.76 31.76 23.76 12.2 20.2 ],[14.88 14.88 22.88 14.88 22.88 22.88 14.88 ],[0.931 0.946 0.973 ]);\nfpr"
+		  "intf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');disp('{\\fontsiz"
+		  "e{14}\\bf++}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "write_addr"
+		  SID			  "435"
 		  Position		  [765, 100, 795, 120]
+		  ZOrder		  -38
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "read_addr"
+		  SID			  "436"
 		  Position		  [765, 150, 795, 170]
+		  ZOrder		  -39
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "end_masking"
+		  SID			  "437"
 		  Position		  [565, 500, 595, 520]
+		  ZOrder		  -40
 		  Port			  "3"
 		  IconDisplay		  "Port number"
 		}
@@ -13778,17 +14982,20 @@ Library {
 	    Block {
 	      BlockType		      SubSystem
 	      Name		      "cmd_gen"
+	      SID		      "438"
 	      Ports		      [2, 7]
 	      Position		      [150, 219, 295, 411]
+	      ZOrder		      -12
 	      MinAlgLoopOccurrences   off
 	      PropExecContextOutsideSubsystem off
 	      RTWSystemCode	      "Auto"
 	      FunctionWithSeparateData off
 	      Opaque		      off
+	      RequestExecContextInheritance off
 	      MaskHideContents	      off
 	      System {
 		Name			"cmd_gen"
-		Location		[2, 74, 1142, 724]
+		Location		[12, 45, 1200, 930]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -13804,21 +15011,28 @@ Library {
 		Block {
 		  BlockType		  Inport
 		  Name			  "valid_data"
+		  SID			  "439"
 		  Position		  [15, 138, 45, 152]
+		  ZOrder		  -1
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "sync"
+		  SID			  "440"
 		  Position		  [20, 223, 50, 237]
+		  ZOrder		  -2
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Constant"
+		  SID			  "441"
 		  Ports			  [0, 1]
 		  Position		  [420, 135, 470, 155]
+		  ZOrder		  -3
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "burst_length-1"
@@ -13843,18 +15057,23 @@ Library {
 		  sggui_pos		  "-1,-1,-1,-1"
 		  block_type		  "constant"
 		  block_version		  "9.2.01"
-		  sg_icon_stat		  "50,20,0,1,white,blue,0,b30483ca"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 ],[0 0 20 20 ],[0.77 0.82 0.91]);"
-		  "\npatch([19 16 21 16 19 24 25 26 32 28 24 21 26 21 24 28 32 26 25 24 19 ],[2 5 10 15 18 18 17 18 18 14 18 15 10 5 "
-		  "2 6 2 2 3 2 2 ],[0.98 0.96 0.92]);\nplot([0 0 50 50 0 ],[0 20 20 0 0 ]);\nfprintf('','COMMENT: end icon graphics')"
-		  ";\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'35');\nfprintf('','COMMENT: end "
-		  "icon text');\n"
+		  sg_icon_stat		  "50,20,0,1,white,blue,0,c201f606,right,,[ ],[ ]"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 50 50 0 0 ],[0 0 20 20 0 ]);\npatch([20.55 23.44 25.44 27.44 29.44 25.44 22.55 20.55 ],[12.22 12.22"
+		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([22.55 25.44 23.44 20.55 22.55 ],[10.22 10.22 12.22 12.22"
+		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([20.55 23.44 25.44 22.55 20.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
+		  "patch([22.55 29.44 27.44 25.44 23.44 20.55 22.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
+		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('outp"
+		  "ut',1,'35');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Constant1"
+		  SID			  "442"
 		  Ports			  [0, 1]
 		  Position		  [405, 385, 455, 405]
+		  ZOrder		  -4
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "burst_length-1"
@@ -13879,18 +15098,23 @@ Library {
 		  sggui_pos		  "-1,-1,-1,-1"
 		  block_type		  "constant"
 		  block_version		  "9.2.01"
-		  sg_icon_stat		  "50,20,0,1,white,blue,0,b30483ca"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 ],[0 0 20 20 ],[0.77 0.82 0.91]);"
-		  "\npatch([19 16 21 16 19 24 25 26 32 28 24 21 26 21 24 28 32 26 25 24 19 ],[2 5 10 15 18 18 17 18 18 14 18 15 10 5 "
-		  "2 6 2 2 3 2 2 ],[0.98 0.96 0.92]);\nplot([0 0 50 50 0 ],[0 20 20 0 0 ]);\nfprintf('','COMMENT: end icon graphics')"
-		  ";\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'35');\nfprintf('','COMMENT: end "
-		  "icon text');\n"
+		  sg_icon_stat		  "50,20,0,1,white,blue,0,c201f606,right,,[ ],[ ]"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 50 50 0 0 ],[0 0 20 20 0 ]);\npatch([20.55 23.44 25.44 27.44 29.44 25.44 22.55 20.55 ],[12.22 12.22"
+		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([22.55 25.44 23.44 20.55 22.55 ],[10.22 10.22 12.22 12.22"
+		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([20.55 23.44 25.44 22.55 20.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
+		  "patch([22.55 29.44 27.44 25.44 23.44 20.55 22.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
+		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('outp"
+		  "ut',1,'35');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Constant2"
+		  SID			  "443"
 		  Ports			  [0, 1]
 		  Position		  [410, 465, 460, 485]
+		  ZOrder		  -5
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "2*burst_length+2-1"
@@ -13915,18 +15139,23 @@ Library {
 		  sggui_pos		  "-1,-1,-1,-1"
 		  block_type		  "constant"
 		  block_version		  "9.2.01"
-		  sg_icon_stat		  "50,20,0,1,white,blue,0,31f97e9c"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 ],[0 0 20 20 ],[0.77 0.82 0.91]);"
-		  "\npatch([19 16 21 16 19 24 25 26 32 28 24 21 26 21 24 28 32 26 25 24 19 ],[2 5 10 15 18 18 17 18 18 14 18 15 10 5 "
-		  "2 6 2 2 3 2 2 ],[0.98 0.96 0.92]);\nplot([0 0 50 50 0 ],[0 20 20 0 0 ]);\nfprintf('','COMMENT: end icon graphics')"
-		  ";\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'73');\nfprintf('','COMMENT: end "
-		  "icon text');\n"
+		  sg_icon_stat		  "50,20,0,1,white,blue,0,3c3eaf3e,right,,[ ],[ ]"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 50 50 0 0 ],[0 0 20 20 0 ]);\npatch([20.55 23.44 25.44 27.44 29.44 25.44 22.55 20.55 ],[12.22 12.22"
+		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([22.55 25.44 23.44 20.55 22.55 ],[10.22 10.22 12.22 12.22"
+		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([20.55 23.44 25.44 22.55 20.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
+		  "patch([22.55 29.44 27.44 25.44 23.44 20.55 22.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
+		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('outp"
+		  "ut',1,'73');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Constant3"
+		  SID			  "444"
 		  Ports			  [0, 1]
 		  Position		  [1520, 440, 1555, 460]
+		  ZOrder		  -6
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "2^18-1"
@@ -13963,8 +15192,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Constant4"
+		  SID			  "445"
 		  Ports			  [0, 1]
 		  Position		  [415, 15, 465, 35]
+		  ZOrder		  -7
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "2*burst_length"
@@ -13989,18 +15221,23 @@ Library {
 		  sggui_pos		  "-1,-1,-1,-1"
 		  block_type		  "constant"
 		  block_version		  "9.2.01"
-		  sg_icon_stat		  "50,20,0,1,white,blue,0,fb103772"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 ],[0 0 20 20 ],[0.77 0.82 0.91]);"
-		  "\npatch([19 16 21 16 19 24 25 26 32 28 24 21 26 21 24 28 32 26 25 24 19 ],[2 5 10 15 18 18 17 18 18 14 18 15 10 5 "
-		  "2 6 2 2 3 2 2 ],[0.98 0.96 0.92]);\nplot([0 0 50 50 0 ],[0 20 20 0 0 ]);\nfprintf('','COMMENT: end icon graphics')"
-		  ";\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'72');\nfprintf('','COMMENT: end "
-		  "icon text');\n"
+		  sg_icon_stat		  "50,20,0,1,white,blue,0,118a56b9,right,,[ ],[ ]"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 50 50 0 0 ],[0 0 20 20 0 ]);\npatch([20.55 23.44 25.44 27.44 29.44 25.44 22.55 20.55 ],[12.22 12.22"
+		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([22.55 25.44 23.44 20.55 22.55 ],[10.22 10.22 12.22 12.22"
+		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([20.55 23.44 25.44 22.55 20.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
+		  "patch([22.55 29.44 27.44 25.44 23.44 20.55 22.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
+		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('outp"
+		  "ut',1,'72');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Convert1"
+		  SID			  "446"
 		  Ports			  [1, 1]
 		  Position		  [200, 280, 225, 300]
+		  ZOrder		  -8
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Convert"
 		  SourceType		  "Xilinx Type Converter Block"
 		  infoedit		  "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do not."
@@ -14035,8 +15272,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Delay"
+		  SID			  "447"
 		  Ports			  [2, 1]
 		  Position		  [645, 215, 685, 250]
+		  ZOrder		  -9
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Delay"
 		  SourceType		  "Xilinx Delay Block"
 		  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -14064,8 +15304,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Delay1"
+		  SID			  "448"
 		  Ports			  [1, 1]
 		  Position		  [295, 432, 335, 468]
+		  ZOrder		  -10
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Delay"
 		  SourceType		  "Xilinx Delay Block"
 		  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -14093,8 +15336,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Delay3"
+		  SID			  "449"
 		  Ports			  [1, 1]
 		  Position		  [1110, 522, 1135, 558]
+		  ZOrder		  -11
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Delay"
 		  SourceType		  "Xilinx Delay Block"
 		  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -14122,8 +15368,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Delay4"
+		  SID			  "450"
 		  Ports			  [1, 1]
 		  Position		  [195, 219, 225, 241]
+		  ZOrder		  -12
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Delay"
 		  SourceType		  "Xilinx Delay Block"
 		  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -14151,8 +15400,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter1"
+		  SID			  "451"
 		  Ports			  [1, 1]
 		  Position		  [380, 440, 410, 460]
+		  ZOrder		  -13
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -14177,8 +15429,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter2"
+		  SID			  "452"
 		  Ports			  [1, 1]
 		  Position		  [725, 173, 755, 187]
+		  ZOrder		  -14
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -14203,8 +15458,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter3"
+		  SID			  "453"
 		  Ports			  [1, 1]
 		  Position		  [725, 318, 755, 332]
+		  ZOrder		  -15
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -14229,8 +15487,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter4"
+		  SID			  "454"
 		  Ports			  [1, 1]
 		  Position		  [890, 458, 920, 472]
+		  ZOrder		  -16
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -14255,8 +15516,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter5"
+		  SID			  "455"
 		  Ports			  [1, 1]
 		  Position		  [715, 510, 745, 530]
+		  ZOrder		  -17
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -14281,9 +15545,13 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter8"
+		  SID			  "456"
 		  Ports			  [1, 1]
 		  Position		  [760, 85, 770, 115]
-		  Orientation		  "down"
+		  ZOrder		  -18
+		  BlockRotation		  270
+		  BlockMirror		  on
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -14308,8 +15576,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical"
+		  SID			  "457"
 		  Ports			  [2, 1]
 		  Position		  [795, 218, 820, 247]
+		  ZOrder		  -19
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -14340,8 +15611,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical1"
+		  SID			  "458"
 		  Ports			  [3, 1]
 		  Position		  [795, 165, 820, 195]
+		  ZOrder		  -20
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -14372,8 +15646,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical10"
+		  SID			  "459"
 		  Ports			  [2, 1]
 		  Position		  [960, 456, 985, 489]
+		  ZOrder		  -21
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "OR"
@@ -14404,8 +15681,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical11"
+		  SID			  "460"
 		  Ports			  [2, 1]
 		  Position		  [145, 272, 170, 303]
+		  ZOrder		  -22
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "OR"
@@ -14436,8 +15716,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical12"
+		  SID			  "461"
 		  Ports			  [2, 1]
 		  Position		  [1015, 465, 1040, 505]
+		  ZOrder		  -23
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -14468,8 +15751,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical15"
+		  SID			  "462"
 		  Ports			  [2, 1]
 		  Position		  [75, 137, 100, 168]
+		  ZOrder		  -24
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -14500,8 +15786,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical2"
+		  SID			  "463"
 		  Ports			  [2, 1]
 		  Position		  [1070, 520, 1095, 560]
+		  ZOrder		  -25
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -14532,8 +15821,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical3"
+		  SID			  "464"
 		  Ports			  [3, 1]
 		  Position		  [600, 421, 625, 479]
+		  ZOrder		  -26
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -14564,8 +15856,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical4"
+		  SID			  "465"
 		  Ports			  [2, 1]
 		  Position		  [305, 148, 330, 177]
+		  ZOrder		  -27
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "OR"
@@ -14596,8 +15891,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical5"
+		  SID			  "466"
 		  Ports			  [2, 1]
 		  Position		  [305, 193, 330, 222]
+		  ZOrder		  -28
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "OR"
@@ -14628,8 +15926,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical6"
+		  SID			  "467"
 		  Ports			  [2, 1]
 		  Position		  [375, 247, 400, 278]
+		  ZOrder		  -29
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "OR"
@@ -14660,8 +15961,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical8"
+		  SID			  "468"
 		  Ports			  [2, 1]
 		  Position		  [890, 172, 915, 203]
+		  ZOrder		  -30
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -14692,8 +15996,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical9"
+		  SID			  "469"
 		  Ports			  [2, 1]
 		  Position		  [890, 227, 915, 258]
+		  ZOrder		  -31
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -14724,8 +16031,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Relational"
+		  SID			  "470"
 		  Ports			  [3, 1]
 		  Position		  [520, 138, 570, 182]
+		  ZOrder		  -32
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Relational"
 		  SourceType		  "Xilinx Arithmetic Relational Operator Block"
 		  mode			  "a>=b"
@@ -14752,8 +16062,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Relational1"
+		  SID			  "471"
 		  Ports			  [3, 1]
 		  Position		  [520, 388, 570, 432]
+		  ZOrder		  -33
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Relational"
 		  SourceType		  "Xilinx Arithmetic Relational Operator Block"
 		  mode			  "a<=b"
@@ -14780,8 +16093,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Relational2"
+		  SID			  "472"
 		  Ports			  [3, 1]
 		  Position		  [520, 468, 570, 512]
+		  ZOrder		  -34
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Relational"
 		  SourceType		  "Xilinx Arithmetic Relational Operator Block"
 		  mode			  "a!=b"
@@ -14808,8 +16124,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Relational4"
+		  SID			  "473"
 		  Ports			  [3, 1]
 		  Position		  [520, 18, 570, 62]
+		  ZOrder		  -35
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Relational"
 		  SourceType		  "Xilinx Arithmetic Relational Operator Block"
 		  mode			  "a<=b"
@@ -14836,8 +16155,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Slice"
+		  SID			  "474"
 		  Ports			  [1, 1]
 		  Position		  [520, 216, 560, 234]
+		  ZOrder		  -36
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -14867,8 +16189,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "cmd_counter"
+		  SID			  "475"
 		  Ports			  [2, 1]
 		  Position		  [415, 197, 465, 248]
+		  ZOrder		  -37
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Counter"
 		  SourceType		  "Xilinx Counter Block"
 		  infoedit		  "Hardware notes: Free running counters are the least expensive in hardware.  A count limited counter i"
@@ -14896,21 +16221,24 @@ Library {
 		  sggui_pos		  "-1,-1,-1,-1"
 		  block_type		  "counter"
 		  block_version		  "9.2.01"
-		  sg_icon_stat		  "50,53,2,1,white,blue,0,eceade92,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 53 53 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 50 50 0 0 ],[0 0 53 53 0 ]);\npatch([9.425 19.54 26.54 33.54 40.54 26.54 16.425 9.425 ],[33.77 33.7"
-		  "7 40.77 33.77 40.77 40.77 40.77 33.77 ],[1 1 1 ]);\npatch([16.425 26.54 19.54 9.425 16.425 ],[26.77 26.77 33.77 33"
-		  ".77 26.77 ],[0.931 0.946 0.973 ]);\npatch([9.425 19.54 26.54 16.425 9.425 ],[19.77 19.77 26.77 26.77 19.77 ],[1 1 "
-		  "1 ]);\npatch([16.425 40.54 33.54 26.54 19.54 9.425 16.425 ],[12.77 12.77 19.77 12.77 19.77 19.77 12.77 ],[0.931 0."
+		  sg_icon_stat		  "50,51,2,1,white,blue,0,131a2a7a,right,,[ ],[ ]"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 51 51 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 50 50 0 0 ],[0 0 51 51 0 ]);\npatch([9.425 19.54 26.54 33.54 40.54 26.54 16.425 9.425 ],[32.77 32.7"
+		  "7 39.77 32.77 39.77 39.77 39.77 32.77 ],[1 1 1 ]);\npatch([16.425 26.54 19.54 9.425 16.425 ],[25.77 25.77 32.77 32"
+		  ".77 25.77 ],[0.931 0.946 0.973 ]);\npatch([9.425 19.54 26.54 16.425 9.425 ],[18.77 18.77 25.77 25.77 18.77 ],[1 1 "
+		  "1 ]);\npatch([16.425 40.54 33.54 26.54 19.54 9.425 16.425 ],[11.77 11.77 18.77 11.77 18.77 18.77 11.77 ],[0.931 0."
 		  "946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');"
-		  "port_label('input',1,'rst');\ncolor('black');port_label('input',2,'en');\ncolor('black');port_label('output',1,'ou"
-		  "t');\nfprintf('','COMMENT: end icon text');\n"
+		  "port_label('input',1,'rst');\ncolor('black');port_label('input',2,'en');\n\ncolor('black');disp('{\\fontsize{14}\\"
+		  "bf\\lceil++\\rceil}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "system_start"
+		  SID			  "476"
 		  Ports			  [2, 1]
 		  Position		  [280, 590, 325, 630]
+		  ZOrder		  -38
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Register"
 		  SourceType		  "Xilinx Register Block"
 		  init			  "0"
@@ -14936,336 +16264,270 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Convert10"
+		  SID			  "477"
 		  Ports			  []
 		  Position		  [212, 255, 238, 280]
+		  ZOrder		  -39
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Delay30"
+		  SID			  "478"
 		  Ports			  []
 		  Position		  [1122, 497, 1148, 522]
+		  ZOrder		  -40
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Delay40"
+		  SID			  "479"
 		  Ports			  []
 		  Position		  [212, 194, 238, 219]
+		  ZOrder		  -41
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical0"
+		  SID			  "480"
 		  Ports			  []
 		  Position		  [807, 193, 833, 218]
+		  ZOrder		  -42
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical10"
+		  SID			  "481"
 		  Ports			  []
 		  Position		  [807, 140, 833, 165]
+		  ZOrder		  -43
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical100"
+		  SID			  "482"
 		  Ports			  []
 		  Position		  [972, 431, 998, 456]
+		  ZOrder		  -44
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical110"
+		  SID			  "483"
 		  Ports			  []
 		  Position		  [157, 247, 183, 272]
+		  ZOrder		  -45
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical120"
+		  SID			  "484"
 		  Ports			  []
 		  Position		  [1027, 440, 1053, 465]
+		  ZOrder		  -46
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical150"
+		  SID			  "485"
 		  Ports			  []
 		  Position		  [87, 112, 113, 137]
+		  ZOrder		  -47
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical20"
+		  SID			  "486"
 		  Ports			  []
 		  Position		  [1082, 495, 1108, 520]
+		  ZOrder		  -48
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical60"
+		  SID			  "487"
 		  Ports			  []
 		  Position		  [387, 222, 413, 247]
+		  ZOrder		  -49
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical80"
+		  SID			  "488"
 		  Ports			  []
 		  Position		  [902, 147, 928, 172]
+		  ZOrder		  -50
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical90"
+		  SID			  "489"
 		  Ports			  []
 		  Position		  [902, 202, 928, 227]
+		  ZOrder		  -51
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Relational0"
+		  SID			  "490"
 		  Ports			  []
 		  Position		  [557, 113, 583, 138]
+		  ZOrder		  -52
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Relational10"
+		  SID			  "491"
 		  Ports			  []
 		  Position		  [557, 363, 583, 388]
+		  ZOrder		  -53
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Relational40"
+		  SID			  "492"
 		  Ports			  []
 		  Position		  [557, 15, 583, 40]
+		  ZOrder		  -54
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "re_addr_en"
+		  SID			  "493"
 		  Position		  [955, 183, 985, 197]
+		  ZOrder		  -55
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "wr_addr_en"
+		  SID			  "494"
 		  Position		  [955, 238, 985, 252]
+		  ZOrder		  -56
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "RWn"
+		  SID			  "495"
 		  Position		  [1685, 318, 1715, 332]
+		  ZOrder		  -57
 		  Port			  "3"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "cmd_valid"
+		  SID			  "496"
 		  Position		  [1610, 533, 1640, 547]
+		  ZOrder		  -58
 		  Port			  "4"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "ready"
+		  SID			  "497"
 		  Position		  [790, 513, 820, 527]
+		  ZOrder		  -59
 		  Port			  "5"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "rb_addr_en"
+		  SID			  "498"
 		  Position		  [860, 33, 890, 47]
+		  ZOrder		  -60
 		  Port			  "6"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "wr_be"
+		  SID			  "499"
 		  Position		  [1605, 443, 1635, 457]
+		  ZOrder		  -61
 		  Port			  "7"
 		  IconDisplay		  "Port number"
 		}
@@ -15705,17 +16967,20 @@ Library {
 	    Block {
 	      BlockType		      SubSystem
 	      Name		      "latch_rb_enable"
+	      SID		      "500"
 	      Ports		      [3, 2]
 	      Position		      [395, 507, 500, 593]
+	      ZOrder		      -13
 	      MinAlgLoopOccurrences   off
 	      PropExecContextOutsideSubsystem off
 	      RTWSystemCode	      "Auto"
 	      FunctionWithSeparateData off
 	      Opaque		      off
+	      RequestExecContextInheritance off
 	      MaskHideContents	      off
 	      System {
 		Name			"latch_rb_enable"
-		Location		[2, 74, 1142, 740]
+		Location		[12, 45, 1200, 946]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -15731,28 +16996,37 @@ Library {
 		Block {
 		  BlockType		  Inport
 		  Name			  "sync"
+		  SID			  "501"
 		  Position		  [50, 38, 80, 52]
+		  ZOrder		  -1
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "rb_addr_enable"
+		  SID			  "502"
 		  Position		  [30, 228, 60, 242]
+		  ZOrder		  -2
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "negedge"
+		  SID			  "503"
 		  Position		  [135, 128, 165, 142]
+		  ZOrder		  -3
 		  Port			  "3"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter5"
+		  SID			  "504"
 		  Ports			  [1, 1]
 		  Position		  [210, 179, 235, 191]
+		  ZOrder		  -4
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -15777,8 +17051,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical1"
+		  SID			  "505"
 		  Ports			  [2, 1]
 		  Position		  [120, 180, 145, 220]
+		  ZOrder		  -5
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "OR"
@@ -15809,8 +17086,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical2"
+		  SID			  "506"
 		  Ports			  [2, 1]
 		  Position		  [325, 170, 350, 210]
+		  ZOrder		  -6
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "OR"
@@ -15841,8 +17121,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical3"
+		  SID			  "507"
 		  Ports			  [2, 1]
 		  Position		  [445, 203, 475, 252]
+		  ZOrder		  -7
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -15873,8 +17156,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical4"
+		  SID			  "508"
 		  Ports			  [2, 1]
 		  Position		  [275, 164, 300, 191]
+		  ZOrder		  -8
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -15905,8 +17191,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "system_start3"
+		  SID			  "509"
 		  Ports			  [2, 1]
 		  Position		  [385, 178, 420, 222]
+		  ZOrder		  -9
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Register"
 		  SourceType		  "Xilinx Register Block"
 		  init			  "0"
@@ -15932,85 +17221,69 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical10"
+		  SID			  "510"
 		  Ports			  []
 		  Position		  [132, 155, 158, 180]
+		  ZOrder		  -10
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical20"
+		  SID			  "511"
 		  Ports			  []
 		  Position		  [337, 145, 363, 170]
+		  ZOrder		  -11
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical30"
+		  SID			  "512"
 		  Ports			  []
 		  Position		  [462, 178, 488, 203]
+		  ZOrder		  -12
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "warn period Logical40"
+		  SID			  "513"
 		  Ports			  []
 		  Position		  [287, 139, 313, 164]
+		  ZOrder		  -13
 		  ShowName		  off
+		  LibraryVersion	  "1.213"
 		  SourceBlock		  "xbsReplacements_r4/Warning"
-		  SourceType		  ""
-		  ShowPortLabels	  "FromPortIcon"
-		  SystemSampleTime	  "-1"
-		  FunctionWithSeparateData off
-		  RTWMemSecFuncInitTerm	  "Inherit from model"
-		  RTWMemSecFuncExecute	  "Inherit from model"
-		  RTWMemSecDataConstants  "Inherit from model"
-		  RTWMemSecDataInternal	  "Inherit from model"
-		  RTWMemSecDataParameters "Inherit from model"
+		  SourceType		  "Unknown"
 		  period		  "1"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "inc_addr_en"
+		  SID			  "514"
 		  Position		  [590, 223, 620, 237]
+		  ZOrder		  -14
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "cmd_tag"
+		  SID			  "515"
 		  Position		  [515, 133, 545, 147]
+		  ZOrder		  -15
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
@@ -16106,17 +17379,20 @@ Library {
 	    Block {
 	      BlockType		      SubSystem
 	      Name		      "negedge"
+	      SID		      "516"
 	      Ports		      [1, 1]
 	      Position		      [345, 412, 365, 458]
+	      ZOrder		      -14
 	      MinAlgLoopOccurrences   off
 	      PropExecContextOutsideSubsystem off
 	      RTWSystemCode	      "Auto"
 	      FunctionWithSeparateData off
 	      Opaque		      off
+	      RequestExecContextInheritance off
 	      MaskHideContents	      off
 	      System {
 		Name			"negedge"
-		Location		[72, 372, 493, 522]
+		Location		[38, 253, 507, 638]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -16132,14 +17408,19 @@ Library {
 		Block {
 		  BlockType		  Inport
 		  Name			  "in"
+		  SID			  "517"
 		  Position		  [25, 43, 55, 57]
+		  ZOrder		  -1
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Delay"
+		  SID			  "518"
 		  Ports			  [1, 1]
 		  Position		  [85, 27, 130, 73]
+		  ZOrder		  -2
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Delay"
 		  SourceType		  "Xilinx Delay Block"
 		  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -16167,8 +17448,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter1"
+		  SID			  "519"
 		  Ports			  [1, 1]
 		  Position		  [150, 73, 200, 107]
+		  ZOrder		  -3
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -16193,8 +17477,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical"
+		  SID			  "520"
 		  Ports			  [2, 1]
 		  Position		  [240, 31, 320, 109]
+		  ZOrder		  -4
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -16225,7 +17512,9 @@ Library {
 		Block {
 		  BlockType		  Outport
 		  Name			  "out"
+		  SID			  "521"
 		  Position		  [350, 63, 380, 77]
+		  ZOrder		  -5
 		  IconDisplay		  "Port number"
 		}
 		Line {
@@ -16266,32 +17555,46 @@ Library {
 	    Block {
 	      BlockType		      SubSystem
 	      Name		      "readback_address_dram_vacc"
+	      SID		      "522"
 	      Ports		      [2, 1]
 	      Position		      [775, 438, 875, 547]
+	      ZOrder		      -15
 	      BackgroundColor	      "orange"
 	      MinAlgLoopOccurrences   off
 	      PropExecContextOutsideSubsystem off
 	      RTWSystemCode	      "Auto"
 	      FunctionWithSeparateData off
 	      Opaque		      off
+	      RequestExecContextInheritance off
 	      MaskHideContents	      off
-	      MaskPromptString	      "Accumulation length?|Valid period length?"
-	      MaskStyleString	      "edit,edit"
-	      MaskVariables	      "acc_length=@1;valid_length=@2;"
-	      MaskTunableValueString  "on,on"
-	      MaskCallbackString      "|"
-	      MaskEnableString	      "on,on"
-	      MaskVisibilityString    "on,on"
-	      MaskToolTipString	      "on,on"
-	      MaskInitialization      "readback_address_dram_vacc_mask;"
-	      MaskIconFrame	      on
-	      MaskIconOpaque	      on
-	      MaskIconRotate	      "none"
-	      MaskIconUnits	      "autoscale"
-	      MaskValueString	      "acc_length|valid_length"
+	      Object {
+		$PropName		"MaskObject"
+		$ObjectID		41
+		$ClassName		"Simulink.Mask"
+		Initialization		"readback_address_dram_vacc_mask;"
+		Array {
+		  Type			  "Simulink.MaskParameter"
+		  Dimension		  2
+		  Object {
+		    $ObjectID		    42
+		    Type		    "edit"
+		    Name		    "acc_length"
+		    Prompt		    "Accumulation length?"
+		    Value		    "acc_length"
+		  }
+		  Object {
+		    $ObjectID		    43
+		    Type		    "edit"
+		    Name		    "valid_length"
+		    Prompt		    "Valid period length?"
+		    Value		    "valid_length"
+		  }
+		  PropName		  "Parameters"
+		}
+	      }
 	      System {
 		Name			"readback_address_dram_vacc"
-		Location		[201, 141, 1067, 907]
+		Location		[167, 45, 1081, 1046]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -16307,21 +17610,28 @@ Library {
 		Block {
 		  BlockType		  Inport
 		  Name			  "sync"
+		  SID			  "523"
 		  Position		  [30, 63, 60, 77]
+		  ZOrder		  -1
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "en"
+		  SID			  "524"
 		  Position		  [30, 113, 60, 127]
+		  ZOrder		  -2
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "block_counter"
+		  SID			  "525"
 		  Ports			  [1, 1]
 		  Position		  [95, 43, 145, 97]
+		  ZOrder		  -3
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Counter"
 		  SourceType		  "Xilinx Counter Block"
 		  infoedit		  "Hardware notes: Free running counters are the least expensive in hardware.  A count limited counter i"
@@ -16350,20 +17660,22 @@ Library {
 		  block_type		  "counter"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "50,54,1,1,white,blue,0,b089e9c5,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 54 54 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 50 50 0 0 ],[0 0 54 54 0 ]);\npatch([9.425 19.54 26.54 33.54 40.54 26.54 16.425 9.425 ],[34.77 34.7"
-		  "7 41.77 34.77 41.77 41.77 41.77 34.77 ],[1 1 1 ]);\npatch([16.425 26.54 19.54 9.425 16.425 ],[27.77 27.77 34.77 34"
-		  ".77 27.77 ],[0.931 0.946 0.973 ]);\npatch([9.425 19.54 26.54 16.425 9.425 ],[20.77 20.77 27.77 27.77 20.77 ],[1 1 "
-		  "1 ]);\npatch([16.425 40.54 33.54 26.54 19.54 9.425 16.425 ],[13.77 13.77 20.77 13.77 20.77 20.77 13.77 ],[0.931 0."
-		  "946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');"
-		  "port_label('input',1,'en');\n\ncolor('black');disp('{\\fontsize{14}\\bf++}','texmode','on');\nfprintf('','COMMENT:"
-		  " end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 60 60 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 60 60 0 ]);\npatch([12.2 23.76 31.76 39.76 47.76 31.76 20.2 12.2 ],[38.88 38.88 46"
+		  ".88 38.88 46.88 46.88 46.88 38.88 ],[1 1 1 ]);\npatch([20.2 31.76 23.76 12.2 20.2 ],[30.88 30.88 38.88 38.88 30.88"
+		  " ],[0.931 0.946 0.973 ]);\npatch([12.2 23.76 31.76 20.2 12.2 ],[22.88 22.88 30.88 30.88 22.88 ],[1 1 1 ]);\npatch("
+		  "[20.2 47.76 39.76 31.76 23.76 12.2 20.2 ],[14.88 14.88 22.88 14.88 22.88 22.88 14.88 ],[0.931 0.946 0.973 ]);\nfpr"
+		  "intf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');disp('{\\fontsiz"
+		  "e{14}\\bf++}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "cast1"
+		  SID			  "526"
 		  Ports			  [1, 1]
 		  Position		  [395, 450, 425, 470]
+		  ZOrder		  -4
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Convert"
 		  SourceType		  "Xilinx Type Converter Block"
 		  infoedit		  "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do not."
@@ -16398,8 +17710,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "concat1"
+		  SID			  "527"
 		  Ports			  [2, 1]
 		  Position		  [245, 341, 295, 394]
+		  ZOrder		  -5
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Concat"
 		  SourceType		  "Xilinx Bus Concatenator Block"
 		  infoedit		  "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary point at z"
@@ -16423,8 +17738,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "concat3"
+		  SID			  "528"
 		  Ports			  [7, 1]
 		  Position		  [595, 310, 635, 460]
+		  ZOrder		  -6
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Concat"
 		  SourceType		  "Xilinx Bus Concatenator Block"
 		  infoedit		  "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary point at z"
@@ -16448,8 +17766,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "const0"
+		  SID			  "529"
 		  Ports			  [0, 1]
 		  Position		  [445, 192, 475, 208]
+		  ZOrder		  -7
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "0"
@@ -16486,8 +17807,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "const1"
+		  SID			  "530"
 		  Ports			  [0, 1]
 		  Position		  [445, 212, 475, 228]
+		  ZOrder		  -8
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "0"
@@ -16524,8 +17848,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "read_counter"
+		  SID			  "531"
 		  Ports			  [2, 1]
 		  Position		  [115, 241, 165, 294]
+		  ZOrder		  -9
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Counter"
 		  SourceType		  "Xilinx Counter Block"
 		  infoedit		  "Hardware notes: Free running counters are the least expensive in hardware.  A count limited counter i"
@@ -16566,8 +17893,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice10"
+		  SID			  "532"
 		  Ports			  [1, 1]
 		  Position		  [445, 350, 475, 370]
+		  ZOrder		  -10
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -16597,8 +17927,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice11"
+		  SID			  "533"
 		  Ports			  [1, 1]
 		  Position		  [445, 300, 475, 320]
+		  ZOrder		  -11
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -16617,19 +17950,22 @@ Library {
 		  block_type		  "slice"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "30,20,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 30 30 0 0 ],[0 0 20 20 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([12.55 19.44 17.44 15.44 13.44 10.55 12.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('ou"
-		  "tput',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 30 30 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\npatch([21.1 26.88 30.88 34.88 38.88 30.88 25.1 21.1 ],[19.44 19.44 23"
+		  ".44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([25.1 30.88 26.88 21.1 25.1 ],[15.44 15.44 19.44 19.44 15.44"
+		  " ],[0.931 0.946 0.973 ]);\npatch([21.1 26.88 30.88 25.1 21.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 ]);\npatch("
+		  "[25.1 38.88 34.88 30.88 26.88 21.1 25.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973 ]);\nfprintf"
+		  "('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',"
+		  "1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice14"
+		  SID			  "534"
 		  Ports			  [1, 1]
 		  Position		  [495, 300, 525, 320]
+		  ZOrder		  -12
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -16659,8 +17995,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice15"
+		  SID			  "535"
 		  Ports			  [1, 1]
 		  Position		  [495, 360, 525, 380]
+		  ZOrder		  -13
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -16679,19 +18018,22 @@ Library {
 		  block_type		  "slice"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "30,20,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 30 30 0 0 ],[0 0 20 20 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([12.55 19.44 17.44 15.44 13.44 10.55 12.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('ou"
-		  "tput',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 30 30 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\npatch([21.1 26.88 30.88 34.88 38.88 30.88 25.1 21.1 ],[19.44 19.44 23"
+		  ".44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([25.1 30.88 26.88 21.1 25.1 ],[15.44 15.44 19.44 19.44 15.44"
+		  " ],[0.931 0.946 0.973 ]);\npatch([21.1 26.88 30.88 25.1 21.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 ]);\npatch("
+		  "[25.1 38.88 34.88 30.88 26.88 21.1 25.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973 ]);\nfprintf"
+		  "('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',"
+		  "1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice6"
+		  SID			  "536"
 		  Ports			  [1, 1]
 		  Position		  [345, 450, 375, 470]
+		  ZOrder		  -14
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -16710,19 +18052,22 @@ Library {
 		  block_type		  "slice"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "30,20,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 30 30 0 0 ],[0 0 20 20 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([12.55 19.44 17.44 15.44 13.44 10.55 12.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('ou"
-		  "tput',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 30 30 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\npatch([21.1 26.88 30.88 34.88 38.88 30.88 25.1 21.1 ],[19.44 19.44 23"
+		  ".44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([25.1 30.88 26.88 21.1 25.1 ],[15.44 15.44 19.44 19.44 15.44"
+		  " ],[0.931 0.946 0.973 ]);\npatch([21.1 26.88 30.88 25.1 21.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 ]);\npatch("
+		  "[25.1 38.88 34.88 30.88 26.88 21.1 25.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973 ]);\nfprintf"
+		  "('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',"
+		  "1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice7"
+		  SID			  "537"
 		  Ports			  [1, 1]
 		  Position		  [345, 390, 375, 410]
+		  ZOrder		  -15
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -16741,19 +18086,22 @@ Library {
 		  block_type		  "slice"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "30,20,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 30 30 0 0 ],[0 0 20 20 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([12.55 19.44 17.44 15.44 13.44 10.55 12.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('ou"
-		  "tput',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 30 30 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\npatch([21.1 26.88 30.88 34.88 38.88 30.88 25.1 21.1 ],[19.44 19.44 23"
+		  ".44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([25.1 30.88 26.88 21.1 25.1 ],[15.44 15.44 19.44 19.44 15.44"
+		  " ],[0.931 0.946 0.973 ]);\npatch([21.1 26.88 30.88 25.1 21.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 ]);\npatch("
+		  "[25.1 38.88 34.88 30.88 26.88 21.1 25.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973 ]);\nfprintf"
+		  "('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',"
+		  "1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice8"
+		  SID			  "538"
 		  Ports			  [1, 1]
 		  Position		  [395, 400, 425, 420]
+		  ZOrder		  -16
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -16772,19 +18120,22 @@ Library {
 		  block_type		  "slice"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "30,20,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 30 30 0 0 ],[0 0 20 20 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([12.55 19.44 17.44 15.44 13.44 10.55 12.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('ou"
-		  "tput',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 30 30 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\npatch([21.1 26.88 30.88 34.88 38.88 30.88 25.1 21.1 ],[19.44 19.44 23"
+		  ".44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([25.1 30.88 26.88 21.1 25.1 ],[15.44 15.44 19.44 19.44 15.44"
+		  " ],[0.931 0.946 0.973 ]);\npatch([21.1 26.88 30.88 25.1 21.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 ]);\npatch("
+		  "[25.1 38.88 34.88 30.88 26.88 21.1 25.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973 ]);\nfprintf"
+		  "('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',"
+		  "1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "slice9"
+		  SID			  "539"
 		  Ports			  [1, 1]
 		  Position		  [395, 350, 425, 370]
+		  ZOrder		  -17
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Slice"
 		  SourceType		  "Xilinx Bit Slice Extractor Block"
 		  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type"
@@ -16803,18 +18154,20 @@ Library {
 		  block_type		  "slice"
 		  block_version		  "9.2.01"
 		  sg_icon_stat		  "30,20,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 20 20 0 ],[0.77 0.82 0.9"
-		  "1 ]);\nplot([0 30 30 0 0 ],[0 0 20 20 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[12.22 12.22"
-		  " 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[10.22 10.22 12.22 12.22"
-		  " 10.22 ],[0.931 0.946 0.973 ]);\npatch([10.55 13.44 15.44 12.55 10.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 1 ]);\n"
-		  "patch([12.55 19.44 17.44 15.44 13.44 10.55 12.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973 ]);\nf"
-		  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('ou"
-		  "tput',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 30 30 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\npatch([21.1 26.88 30.88 34.88 38.88 30.88 25.1 21.1 ],[19.44 19.44 23"
+		  ".44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([25.1 30.88 26.88 21.1 25.1 ],[15.44 15.44 19.44 19.44 15.44"
+		  " ],[0.931 0.946 0.973 ]);\npatch([21.1 26.88 30.88 25.1 21.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 ]);\npatch("
+		  "[25.1 38.88 34.88 30.88 26.88 21.1 25.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973 ]);\nfprintf"
+		  "('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',"
+		  "1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "readback_addr"
+		  SID			  "540"
 		  Position		  [765, 150, 795, 170]
+		  ZOrder		  -18
 		  IconDisplay		  "Port number"
 		}
 		Line {
@@ -16955,6 +18308,7 @@ Library {
 		  }
 		}
 		Annotation {
+		  SID			  "541"
 		  Position		  [337, 113]
 		}
 	      }
@@ -16962,77 +18316,79 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "warn period Delay10"
+	      SID		      "542"
 	      Ports		      []
 	      Position		      [162, 429, 188, 454]
+	      ZOrder		      -16
 	      ShowName		      off
+	      LibraryVersion	      "1.213"
 	      SourceBlock	      "xbsReplacements_r4/Warning"
-	      SourceType	      ""
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
+	      SourceType	      "Unknown"
 	      period		      "1"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "warn period Delay20"
+	      SID		      "543"
 	      Ports		      []
 	      Position		      [347, 132, 373, 157]
+	      ZOrder		      -17
 	      ShowName		      off
+	      LibraryVersion	      "1.213"
 	      SourceBlock	      "xbsReplacements_r4/Warning"
-	      SourceType	      ""
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
+	      SourceType	      "Unknown"
 	      period		      "1"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "address"
+	      SID		      "544"
 	      Position		      [1320, 108, 1350, 122]
+	      ZOrder		      -18
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "cmd_tag"
+	      SID		      "545"
 	      Position		      [1495, 278, 1525, 292]
+	      ZOrder		      -19
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "RB_active"
+	      SID		      "546"
 	      Position		      [1025, 683, 1055, 697]
+	      ZOrder		      -20
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "RWn"
+	      SID		      "547"
 	      Position		      [405, 283, 435, 297]
+	      ZOrder		      -21
 	      Port		      "4"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "cmd_valid"
+	      SID		      "548"
 	      Position		      [405, 308, 435, 322]
+	      ZOrder		      -22
 	      Port		      "5"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "ready"
+	      SID		      "549"
 	      Position		      [405, 333, 435, 347]
+	      ZOrder		      -23
 	      Port		      "6"
 	      IconDisplay	      "Port number"
 	    }
@@ -17045,7 +18401,7 @@ Library {
 	    }
 	    Line {
 	      Name		      "v"
-	      Labels		      [0, 0; 0, 0; 0, 0]
+	      Labels		      [0, 0]
 	      SrcBlock		      "Delay1"
 	      SrcPort		      1
 	      Points		      [35, 0]
@@ -17253,6 +18609,7 @@ Library {
 	      }
 	    }
 	    Annotation {
+	      SID		      "550"
 	      Position		      [5, 190]
 	    }
 	  }
@@ -17260,43 +18617,134 @@ Library {
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "dram"
+	  SID			  "551"
 	  Tag			  "xps:dram"
 	  Ports			  [8, 4]
 	  Position		  [1775, 124, 1915, 376]
+	  ZOrder		  -34
 	  BackgroundColor	  "[1.000000, 1.000000, 0.000000]"
 	  AncestorBlock		  "xps_library/dram"
+	  LibraryVersion	  "*"
 	  MinAlgLoopOccurrences	  off
 	  PropExecContextOutsideSubsystem off
 	  RTWSystemCode		  "Auto"
 	  FunctionWithSeparateData off
 	  Opaque		  off
+	  RequestExecContextInheritance	off
 	  MaskHideContents	  off
-	  MaskType		  "dram"
-	  MaskDescription	  "Interface to 1GB DDR2 DIMMs on BEE2.\n\nTo simulate using ModelSim, place a ModelSim block named"
-	  " 'ModelSim' (case-sensitive) in the top level of the design."
-	  MaskPromptString	  "DIMM|Data Type|Data binary point|Datapath clock rate (MHz)|Sample period|Simulate DRAM using Mo"
-	  "delSim|Enable bank management|Use wide data bus (288 bits)|Use half-burst|Share with PowerPC"
-	  MaskStyleString	  "popup(1|2|3|4),popup(Boolean|Unsigned|Signed  (2's comp)),edit,edit,edit,checkbox,checkbox,check"
-	  "box,checkbox,checkbox"
-	  MaskVariables		  "dimm=@1;arith_type=@2;bin_pt=@3;ip_clock=@4;sample_period=@5;use_sim=&6;bank_mgt=&7;wide_data=&8;"
-	  "half_burst=&9;shared=&10;"
-	  MaskTunableValueString  "on,on,on,on,on,on,on,on,on,on"
-	  MaskCallbackString	  "|||||||myname=gcb;\nif strcmp(get_param(myname, 'wide_data'), 'off')\n    set_param(myname, '"
-	  "MaskEnables', {'on','on','on','on','on','on','on','on','on','on'});\nelse\n    set_param(myname, 'half_burst', 'off"
-	  "');\n    set_param(myname, 'MaskEnables', {'on','on','on','on','on','on','on','on','off','on'});\nend||"
-	  MaskEnableString	  "on,on,on,on,on,on,on,on,on,on"
-	  MaskVisibilityString	  "on,on,on,on,on,on,on,on,on,on"
-	  MaskToolTipString	  "on,on,on,on,on,on,on,on,on,on"
-	  MaskInitialization	  "dram_mask;"
-	  MaskSelfModifiable	  on
-	  MaskIconFrame		  on
-	  MaskIconOpaque	  on
-	  MaskIconRotate	  "none"
-	  MaskIconUnits		  "autoscale"
-	  MaskValueString	  "1|Unsigned|0|200|1|on|on|off|off|on"
+	  Object {
+	    $PropName		    "MaskObject"
+	    $ObjectID		    44
+	    $ClassName		    "Simulink.Mask"
+	    Type		    "dram"
+	    Description		    "Interface to 1GB DDR2 DIMMs on BEE2.\n\nTo simulate using ModelSim, place a ModelSim block name"
+	    "d 'ModelSim' (case-sensitive) in the top level of the design."
+	    Initialization	    "dram_mask;"
+	    SelfModifiable	    "on"
+	    Array {
+	      Type		      "Simulink.MaskParameter"
+	      Dimension		      10
+	      Object {
+		$ObjectID		45
+		Type			"popup"
+		Array {
+		  Type			  "Cell"
+		  Dimension		  4
+		  Cell			  "1"
+		  Cell			  "2"
+		  Cell			  "3"
+		  Cell			  "4"
+		  PropName		  "TypeOptions"
+		}
+		Name			"dimm"
+		Prompt			"DIMM"
+		Value			"1"
+	      }
+	      Object {
+		$ObjectID		46
+		Type			"popup"
+		Array {
+		  Type			  "Cell"
+		  Dimension		  3
+		  Cell			  "Boolean"
+		  Cell			  "Unsigned"
+		  Cell			  "Signed  (2's comp)"
+		  PropName		  "TypeOptions"
+		}
+		Name			"arith_type"
+		Prompt			"Data Type"
+		Value			"Unsigned"
+	      }
+	      Object {
+		$ObjectID		47
+		Type			"edit"
+		Name			"bin_pt"
+		Prompt			"Data binary point"
+		Value			"0"
+	      }
+	      Object {
+		$ObjectID		48
+		Type			"edit"
+		Name			"ip_clock"
+		Prompt			"Datapath clock rate (MHz)"
+		Value			"200"
+	      }
+	      Object {
+		$ObjectID		49
+		Type			"edit"
+		Name			"sample_period"
+		Prompt			"Sample period"
+		Value			"1"
+	      }
+	      Object {
+		$ObjectID		50
+		Type			"checkbox"
+		Name			"use_sim"
+		Prompt			"Simulate DRAM using ModelSim"
+		Value			"on"
+		Evaluate		"off"
+	      }
+	      Object {
+		$ObjectID		51
+		Type			"checkbox"
+		Name			"bank_mgt"
+		Prompt			"Enable bank management"
+		Value			"on"
+		Evaluate		"off"
+	      }
+	      Object {
+		$ObjectID		52
+		Type			"checkbox"
+		Name			"wide_data"
+		Prompt			"Use wide data bus (288 bits)"
+		Value			"off"
+		Evaluate		"off"
+		Callback		"myname=gcb;\nif strcmp(get_param(myname, 'wide_data'), 'off')\n    set_param(myname, 'MaskEnables', {'on'"
+		",'on','on','on','on','on','on','on','on','on'});\nelse\n    set_param(myname, 'half_burst', 'off');\n    set_param(m"
+		"yname, 'MaskEnables', {'on','on','on','on','on','on','on','on','off','on'});\nend"
+	      }
+	      Object {
+		$ObjectID		53
+		Type			"checkbox"
+		Name			"half_burst"
+		Prompt			"Use half-burst"
+		Value			"off"
+		Evaluate		"off"
+	      }
+	      Object {
+		$ObjectID		54
+		Type			"checkbox"
+		Name			"shared"
+		Prompt			"Share with PowerPC"
+		Value			"on"
+		Evaluate		"off"
+	      }
+	      PropName		      "Parameters"
+	    }
+	  }
 	  System {
 	    Name		    "dram"
-	    Location		    [2, 74, 1006, 708]
+	    Location		    [12, 45, 1064, 914]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -17309,73 +18757,95 @@ Library {
 	    TiledPageScale	    1
 	    ShowPageBoundaries	    off
 	    ZoomFactor		    "100"
+	    SIDHighWatermark	    "65"
 	    Block {
 	      BlockType		      Inport
 	      Name		      "rst"
+	      SID		      "551:1"
 	      Position		      [40, 62, 70, 78]
+	      ZOrder		      -1
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "address"
+	      SID		      "551:2"
 	      Position		      [40, 107, 70, 123]
+	      ZOrder		      -2
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "data_in"
+	      SID		      "551:3"
 	      Position		      [40, 152, 70, 168]
+	      ZOrder		      -3
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "wr_be"
+	      SID		      "551:4"
 	      Position		      [40, 197, 70, 213]
+	      ZOrder		      -4
 	      Port		      "4"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "RWn"
+	      SID		      "551:5"
 	      Position		      [40, 242, 70, 258]
+	      ZOrder		      -5
 	      Port		      "5"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "cmd_tag"
+	      SID		      "551:6"
 	      Position		      [40, 287, 70, 303]
+	      ZOrder		      -6
 	      Port		      "6"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "cmd_valid"
+	      SID		      "551:7"
 	      Position		      [40, 332, 70, 348]
+	      ZOrder		      -7
 	      Port		      "7"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "rd_ack"
+	      SID		      "551:8"
 	      Position		      [40, 377, 70, 393]
+	      ZOrder		      -8
 	      Port		      "8"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Constant
 	      Name		      "Constant"
+	      SID		      "551:9"
 	      Position		      [540, 60, 570, 90]
+	      ZOrder		      -9
 	      Value		      "0"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Simulation Multiplexer"
+	      SID		      "551:10"
 	      Ports		      [2, 1]
 	      Position		      [875, 67, 920, 103]
+	      ZOrder		      -10
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Simulation Multiplexer"
 	      SourceType	      "Xilinx Simulation Multiplexer Block"
 	      infoedit		      "Distinguish input subsystems as \"simulation only\" and \"generation only\".  The input specif"
@@ -17401,9 +18871,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Simulation Multiplexer1"
+	      SID		      "551:11"
 	      Ports		      [2, 1]
 	      Position		      [875, 157, 920, 193]
+	      ZOrder		      -11
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Simulation Multiplexer"
 	      SourceType	      "Xilinx Simulation Multiplexer Block"
 	      infoedit		      "Distinguish input subsystems as \"simulation only\" and \"generation only\".  The input specif"
@@ -17429,9 +18902,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Simulation Multiplexer2"
+	      SID		      "551:12"
 	      Ports		      [2, 1]
 	      Position		      [875, 247, 920, 283]
+	      ZOrder		      -12
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Simulation Multiplexer"
 	      SourceType	      "Xilinx Simulation Multiplexer Block"
 	      infoedit		      "Distinguish input subsystems as \"simulation only\" and \"generation only\".  The input specif"
@@ -17457,9 +18933,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Simulation Multiplexer3"
+	      SID		      "551:13"
 	      Ports		      [2, 1]
 	      Position		      [875, 337, 920, 373]
+	      ZOrder		      -13
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Simulation Multiplexer"
 	      SourceType	      "Xilinx Simulation Multiplexer Block"
 	      infoedit		      "Distinguish input subsystems as \"simulation only\" and \"generation only\".  The input specif"
@@ -17485,56 +18964,75 @@ Library {
 	    Block {
 	      BlockType		      Terminator
 	      Name		      "Terminator"
+	      SID		      "551:14"
 	      Position		      [450, 60, 470, 80]
+	      ZOrder		      -14
 	      ShowName		      off
 	    }
 	    Block {
 	      BlockType		      Terminator
 	      Name		      "Terminator1"
+	      SID		      "551:15"
 	      Position		      [450, 105, 470, 125]
+	      ZOrder		      -15
 	      ShowName		      off
 	    }
 	    Block {
 	      BlockType		      Terminator
 	      Name		      "Terminator2"
+	      SID		      "551:16"
 	      Position		      [450, 150, 470, 170]
+	      ZOrder		      -16
 	      ShowName		      off
 	    }
 	    Block {
 	      BlockType		      Terminator
 	      Name		      "Terminator3"
+	      SID		      "551:17"
 	      Position		      [450, 195, 470, 215]
+	      ZOrder		      -17
 	      ShowName		      off
 	    }
 	    Block {
 	      BlockType		      Terminator
 	      Name		      "Terminator4"
+	      SID		      "551:18"
 	      Position		      [450, 240, 470, 260]
+	      ZOrder		      -18
 	      ShowName		      off
 	    }
 	    Block {
 	      BlockType		      Terminator
 	      Name		      "Terminator5"
+	      SID		      "551:19"
 	      Position		      [450, 285, 470, 305]
+	      ZOrder		      -19
 	      ShowName		      off
 	    }
 	    Block {
 	      BlockType		      Terminator
 	      Name		      "Terminator6"
+	      SID		      "551:20"
 	      Position		      [450, 330, 470, 350]
+	      ZOrder		      -20
 	      ShowName		      off
 	    }
 	    Block {
 	      BlockType		      Terminator
 	      Name		      "Terminator7"
+	      SID		      "551:21"
 	      Position		      [450, 375, 470, 395]
+	      ZOrder		      -21
 	      ShowName		      off
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "convert_address"
+	      SID		      "551:22"
 	      Ports		      [1, 1]
 	      Position		      [120, 105, 155, 125]
+	      ZOrder		      -22
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -17570,8 +19068,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "convert_cmd_tag"
+	      SID		      "551:23"
 	      Ports		      [1, 1]
 	      Position		      [120, 285, 155, 305]
+	      ZOrder		      -23
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -17607,8 +19108,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "convert_cmd_valid"
+	      SID		      "551:24"
 	      Ports		      [1, 1]
 	      Position		      [120, 330, 155, 350]
+	      ZOrder		      -24
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -17644,8 +19148,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "convert_data_in"
+	      SID		      "551:25"
 	      Ports		      [1, 1]
 	      Position		      [440, 308, 475, 372]
+	      ZOrder		      -25
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -17681,8 +19188,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "convert_rd_ack"
+	      SID		      "551:26"
 	      Ports		      [1, 1]
 	      Position		      [120, 375, 155, 395]
+	      ZOrder		      -26
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -17718,8 +19228,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "convert_rst"
+	      SID		      "551:27"
 	      Ports		      [1, 1]
 	      Position		      [120, 60, 155, 80]
+	      ZOrder		      -27
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -17755,8 +19268,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "convert_rwn"
+	      SID		      "551:28"
 	      Ports		      [1, 1]
 	      Position		      [120, 240, 155, 260]
+	      ZOrder		      -28
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -17792,8 +19308,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "convert_wr_be"
+	      SID		      "551:29"
 	      Ports		      [1, 1]
 	      Position		      [120, 195, 155, 215]
+	      ZOrder		      -29
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -17829,8 +19348,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "dram_vacc_dram_vacc_dram_Mem_Cmd_Ack"
+	      SID		      "551:30"
 	      Ports		      [1, 1]
 	      Position		      [670, 64, 725, 86]
+	      ZOrder		      -30
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway In"
 	      SourceType	      "Xilinx Gateway In Block"
 	      infoedit		      "Gateway in block.  Converts inputs of type Simulink integer, double and fixed point to  Xilinx"
@@ -17849,41 +19371,53 @@ Library {
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsADC		      off
+	      ADCChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
+	      inherit_from_input      off
 	      hdl_port		      "on"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayin"
 	      block_version	      "9.2.01"
-	      sg_icon_stat	      "55,22,1,1,white,yellow,0,4bb76ffd"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 ],[0 0 22 22 ],[0.95 0.93 "
-	      "0.65]);\npatch([22 18 23 18 22 28 30 32 38 33 28 25 31 25 28 33 38 32 30 28 22 ],[2 6 11 16 20 20 18 20 20 15 2"
-	      "0 17 11 5 2 7 2 2 4 2 2 ],[0.98 0.96 0.92]);\nplot([0 0 55 55 0 ],[0 22 22 0 0 ]);\nfprintf('','COMMENT: end ic"
-	      "on graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('input',1,'\\fontsize{11pt}\\"
-	      "bf In ','texmode','on');\ncolor('black');port_label('output',1,' ');\nfprintf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "55,22,1,1,white,yellow,1,00d3666e,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 0 ],[0 0 22 22 0 ],[0.95 0"
+	      ".93 0.65 ]);\nplot([0 55 55 0 0 ],[0 0 22 22 0 ]);\npatch([20.325 24.66 27.66 30.66 33.66 27.66 23.325 20.325 ]"
+	      ",[14.33 14.33 17.33 14.33 17.33 17.33 17.33 14.33 ],[1 1 1 ]);\npatch([23.325 27.66 24.66 20.325 23.325 ],[11.3"
+	      "3 11.33 14.33 14.33 11.33 ],[0.985 0.979 0.895 ]);\npatch([20.325 24.66 27.66 23.325 20.325 ],[8.33 8.33 11.33 "
+	      "11.33 8.33 ],[1 1 1 ]);\npatch([23.325 33.66 30.66 27.66 24.66 20.325 23.325 ],[5.33 5.33 8.33 5.33 8.33 8.33 5"
+	      ".33 ],[0.985 0.979 0.895 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text')"
+	      ";\ncolor('black');port_label('input',1,'\\fontsize{11pt}\\bf In ','texmode','on');\ncolor('black');port_label('"
+	      "output',1,' ');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "dram_vacc_dram_vacc_dram_Mem_Cmd_Address"
+	      SID		      "551:31"
 	      Ports		      [1, 1]
 	      Position		      [335, 105, 375, 125]
+	      ZOrder		      -31
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      on
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "9.2.01"
-	      sg_icon_stat	      "40,20,1,1,white,yellow,0,cc31b7ac,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,20,1,1,white,yellow,1,cc31b7ac,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 20 20 0 ],[0.95 0"
 	      ".93 0.65 ]);\nplot([0 40 40 0 0 ],[0 0 20 20 0 ]);\npatch([15.55 18.44 20.44 22.44 24.44 20.44 17.55 15.55 ],[1"
 	      "2.22 12.22 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([17.55 20.44 18.44 15.55 17.55 ],[10.22 10.2"
@@ -17896,24 +19430,30 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "dram_vacc_dram_vacc_dram_Mem_Cmd_RNW"
+	      SID		      "551:32"
 	      Ports		      [1, 1]
 	      Position		      [335, 240, 375, 260]
+	      ZOrder		      -32
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      on
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "9.2.01"
-	      sg_icon_stat	      "40,20,1,1,white,yellow,0,cc31b7ac,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,20,1,1,white,yellow,1,cc31b7ac,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 20 20 0 ],[0.95 0"
 	      ".93 0.65 ]);\nplot([0 40 40 0 0 ],[0 0 20 20 0 ]);\npatch([15.55 18.44 20.44 22.44 24.44 20.44 17.55 15.55 ],[1"
 	      "2.22 12.22 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([17.55 20.44 18.44 15.55 17.55 ],[10.22 10.2"
@@ -17926,24 +19466,30 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "dram_vacc_dram_vacc_dram_Mem_Cmd_Tag"
+	      SID		      "551:33"
 	      Ports		      [1, 1]
 	      Position		      [335, 285, 375, 305]
+	      ZOrder		      -33
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      on
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "9.2.01"
-	      sg_icon_stat	      "40,20,1,1,white,yellow,0,cc31b7ac,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,20,1,1,white,yellow,1,cc31b7ac,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 20 20 0 ],[0.95 0"
 	      ".93 0.65 ]);\nplot([0 40 40 0 0 ],[0 0 20 20 0 ]);\npatch([15.55 18.44 20.44 22.44 24.44 20.44 17.55 15.55 ],[1"
 	      "2.22 12.22 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([17.55 20.44 18.44 15.55 17.55 ],[10.22 10.2"
@@ -17956,24 +19502,30 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "dram_vacc_dram_vacc_dram_Mem_Cmd_Valid"
+	      SID		      "551:34"
 	      Ports		      [1, 1]
 	      Position		      [335, 330, 375, 350]
+	      ZOrder		      -34
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      on
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "9.2.01"
-	      sg_icon_stat	      "40,20,1,1,white,yellow,0,cc31b7ac,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,20,1,1,white,yellow,1,cc31b7ac,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 20 20 0 ],[0.95 0"
 	      ".93 0.65 ]);\nplot([0 40 40 0 0 ],[0 0 20 20 0 ]);\npatch([15.55 18.44 20.44 22.44 24.44 20.44 17.55 15.55 ],[1"
 	      "2.22 12.22 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([17.55 20.44 18.44 15.55 17.55 ],[10.22 10.2"
@@ -17986,24 +19538,30 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "dram_vacc_dram_vacc_dram_Mem_Rd_Ack"
+	      SID		      "551:35"
 	      Ports		      [1, 1]
 	      Position		      [335, 375, 375, 395]
+	      ZOrder		      -35
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      on
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "9.2.01"
-	      sg_icon_stat	      "40,20,1,1,white,yellow,0,cc31b7ac,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,20,1,1,white,yellow,1,cc31b7ac,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 20 20 0 ],[0.95 0"
 	      ".93 0.65 ]);\nplot([0 40 40 0 0 ],[0 0 20 20 0 ]);\npatch([15.55 18.44 20.44 22.44 24.44 20.44 17.55 15.55 ],[1"
 	      "2.22 12.22 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([17.55 20.44 18.44 15.55 17.55 ],[10.22 10.2"
@@ -18016,8 +19574,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "dram_vacc_dram_vacc_dram_Mem_Rd_Dout"
+	      SID		      "551:36"
 	      Ports		      [1, 1]
 	      Position		      [670, 154, 725, 176]
+	      ZOrder		      -36
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway In"
 	      SourceType	      "Xilinx Gateway In Block"
 	      infoedit		      "Gateway in block.  Converts inputs of type Simulink integer, double and fixed point to  Xilinx"
@@ -18036,25 +19597,34 @@ Library {
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsADC		      off
+	      ADCChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
+	      inherit_from_input      off
 	      hdl_port		      "on"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayin"
 	      block_version	      "9.2.01"
-	      sg_icon_stat	      "55,22,1,1,white,yellow,0,4bb76ffd"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 ],[0 0 22 22 ],[0.95 0.93 "
-	      "0.65]);\npatch([22 18 23 18 22 28 30 32 38 33 28 25 31 25 28 33 38 32 30 28 22 ],[2 6 11 16 20 20 18 20 20 15 2"
-	      "0 17 11 5 2 7 2 2 4 2 2 ],[0.98 0.96 0.92]);\nplot([0 0 55 55 0 ],[0 22 22 0 0 ]);\nfprintf('','COMMENT: end ic"
-	      "on graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('input',1,'\\fontsize{11pt}\\"
-	      "bf In ','texmode','on');\ncolor('black');port_label('output',1,' ');\nfprintf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "55,22,1,1,white,yellow,1,00d3666e,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 0 ],[0 0 22 22 0 ],[0.95 0"
+	      ".93 0.65 ]);\nplot([0 55 55 0 0 ],[0 0 22 22 0 ]);\npatch([20.325 24.66 27.66 30.66 33.66 27.66 23.325 20.325 ]"
+	      ",[14.33 14.33 17.33 14.33 17.33 17.33 17.33 14.33 ],[1 1 1 ]);\npatch([23.325 27.66 24.66 20.325 23.325 ],[11.3"
+	      "3 11.33 14.33 14.33 11.33 ],[0.985 0.979 0.895 ]);\npatch([20.325 24.66 27.66 23.325 20.325 ],[8.33 8.33 11.33 "
+	      "11.33 8.33 ],[1 1 1 ]);\npatch([23.325 33.66 30.66 27.66 24.66 20.325 23.325 ],[5.33 5.33 8.33 5.33 8.33 8.33 5"
+	      ".33 ],[0.985 0.979 0.895 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text')"
+	      ";\ncolor('black');port_label('input',1,'\\fontsize{11pt}\\bf In ','texmode','on');\ncolor('black');port_label('"
+	      "output',1,' ');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "dram_vacc_dram_vacc_dram_Mem_Rd_Tag"
+	      SID		      "551:37"
 	      Ports		      [1, 1]
 	      Position		      [670, 244, 725, 266]
+	      ZOrder		      -37
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway In"
 	      SourceType	      "Xilinx Gateway In Block"
 	      infoedit		      "Gateway in block.  Converts inputs of type Simulink integer, double and fixed point to  Xilinx"
@@ -18073,25 +19643,34 @@ Library {
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsADC		      off
+	      ADCChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
+	      inherit_from_input      off
 	      hdl_port		      "on"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayin"
 	      block_version	      "9.2.01"
-	      sg_icon_stat	      "55,22,1,1,white,yellow,0,4bb76ffd"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 ],[0 0 22 22 ],[0.95 0.93 "
-	      "0.65]);\npatch([22 18 23 18 22 28 30 32 38 33 28 25 31 25 28 33 38 32 30 28 22 ],[2 6 11 16 20 20 18 20 20 15 2"
-	      "0 17 11 5 2 7 2 2 4 2 2 ],[0.98 0.96 0.92]);\nplot([0 0 55 55 0 ],[0 22 22 0 0 ]);\nfprintf('','COMMENT: end ic"
-	      "on graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('input',1,'\\fontsize{11pt}\\"
-	      "bf In ','texmode','on');\ncolor('black');port_label('output',1,' ');\nfprintf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "55,22,1,1,white,yellow,1,00d3666e,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 0 ],[0 0 22 22 0 ],[0.95 0"
+	      ".93 0.65 ]);\nplot([0 55 55 0 0 ],[0 0 22 22 0 ]);\npatch([20.325 24.66 27.66 30.66 33.66 27.66 23.325 20.325 ]"
+	      ",[14.33 14.33 17.33 14.33 17.33 17.33 17.33 14.33 ],[1 1 1 ]);\npatch([23.325 27.66 24.66 20.325 23.325 ],[11.3"
+	      "3 11.33 14.33 14.33 11.33 ],[0.985 0.979 0.895 ]);\npatch([20.325 24.66 27.66 23.325 20.325 ],[8.33 8.33 11.33 "
+	      "11.33 8.33 ],[1 1 1 ]);\npatch([23.325 33.66 30.66 27.66 24.66 20.325 23.325 ],[5.33 5.33 8.33 5.33 8.33 8.33 5"
+	      ".33 ],[0.985 0.979 0.895 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text')"
+	      ";\ncolor('black');port_label('input',1,'\\fontsize{11pt}\\bf In ','texmode','on');\ncolor('black');port_label('"
+	      "output',1,' ');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "dram_vacc_dram_vacc_dram_Mem_Rd_Valid"
+	      SID		      "551:38"
 	      Ports		      [1, 1]
 	      Position		      [670, 334, 725, 356]
+	      ZOrder		      -38
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway In"
 	      SourceType	      "Xilinx Gateway In Block"
 	      infoedit		      "Gateway in block.  Converts inputs of type Simulink integer, double and fixed point to  Xilinx"
@@ -18110,41 +19689,53 @@ Library {
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsADC		      off
+	      ADCChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
+	      inherit_from_input      off
 	      hdl_port		      "on"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayin"
 	      block_version	      "9.2.01"
-	      sg_icon_stat	      "55,22,1,1,white,yellow,0,4bb76ffd"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 ],[0 0 22 22 ],[0.95 0.93 "
-	      "0.65]);\npatch([22 18 23 18 22 28 30 32 38 33 28 25 31 25 28 33 38 32 30 28 22 ],[2 6 11 16 20 20 18 20 20 15 2"
-	      "0 17 11 5 2 7 2 2 4 2 2 ],[0.98 0.96 0.92]);\nplot([0 0 55 55 0 ],[0 22 22 0 0 ]);\nfprintf('','COMMENT: end ic"
-	      "on graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('input',1,'\\fontsize{11pt}\\"
-	      "bf In ','texmode','on');\ncolor('black');port_label('output',1,' ');\nfprintf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "55,22,1,1,white,yellow,1,00d3666e,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 0 ],[0 0 22 22 0 ],[0.95 0"
+	      ".93 0.65 ]);\nplot([0 55 55 0 0 ],[0 0 22 22 0 ]);\npatch([20.325 24.66 27.66 30.66 33.66 27.66 23.325 20.325 ]"
+	      ",[14.33 14.33 17.33 14.33 17.33 17.33 17.33 14.33 ],[1 1 1 ]);\npatch([23.325 27.66 24.66 20.325 23.325 ],[11.3"
+	      "3 11.33 14.33 14.33 11.33 ],[0.985 0.979 0.895 ]);\npatch([20.325 24.66 27.66 23.325 20.325 ],[8.33 8.33 11.33 "
+	      "11.33 8.33 ],[1 1 1 ]);\npatch([23.325 33.66 30.66 27.66 24.66 20.325 23.325 ],[5.33 5.33 8.33 5.33 8.33 8.33 5"
+	      ".33 ],[0.985 0.979 0.895 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text')"
+	      ";\ncolor('black');port_label('input',1,'\\fontsize{11pt}\\bf In ','texmode','on');\ncolor('black');port_label('"
+	      "output',1,' ');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "dram_vacc_dram_vacc_dram_Mem_Rst"
+	      SID		      "551:39"
 	      Ports		      [1, 1]
 	      Position		      [335, 60, 375, 80]
+	      ZOrder		      -39
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      on
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "9.2.01"
-	      sg_icon_stat	      "40,20,1,1,white,yellow,0,cc31b7ac,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,20,1,1,white,yellow,1,cc31b7ac,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 20 20 0 ],[0.95 0"
 	      ".93 0.65 ]);\nplot([0 40 40 0 0 ],[0 0 20 20 0 ]);\npatch([15.55 18.44 20.44 22.44 24.44 20.44 17.55 15.55 ],[1"
 	      "2.22 12.22 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([17.55 20.44 18.44 15.55 17.55 ],[10.22 10.2"
@@ -18157,24 +19748,30 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "dram_vacc_dram_vacc_dram_Mem_Wr_BE"
+	      SID		      "551:40"
 	      Ports		      [1, 1]
 	      Position		      [335, 195, 375, 215]
+	      ZOrder		      -40
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      on
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "9.2.01"
-	      sg_icon_stat	      "40,20,1,1,white,yellow,0,cc31b7ac,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,20,1,1,white,yellow,1,cc31b7ac,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 20 20 0 ],[0.95 0"
 	      ".93 0.65 ]);\nplot([0 40 40 0 0 ],[0 0 20 20 0 ]);\npatch([15.55 18.44 20.44 22.44 24.44 20.44 17.55 15.55 ],[1"
 	      "2.22 12.22 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([17.55 20.44 18.44 15.55 17.55 ],[10.22 10.2"
@@ -18187,24 +19784,30 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "dram_vacc_dram_vacc_dram_Mem_Wr_Din"
+	      SID		      "551:41"
 	      Ports		      [1, 1]
 	      Position		      [335, 150, 375, 170]
+	      ZOrder		      -41
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      on
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "9.2.01"
-	      sg_icon_stat	      "40,20,1,1,white,yellow,0,cc31b7ac,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,20,1,1,white,yellow,1,cc31b7ac,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 20 20 0 ],[0.95 0"
 	      ".93 0.65 ]);\nplot([0 40 40 0 0 ],[0 0 20 20 0 ]);\npatch([15.55 18.44 20.44 22.44 24.44 20.44 17.55 15.55 ],[1"
 	      "2.22 12.22 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([17.55 20.44 18.44 15.55 17.55 ],[10.22 10.2"
@@ -18217,8 +19820,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "force_data_in"
+	      SID		      "551:42"
 	      Ports		      [1, 1]
 	      Position		      [200, 150, 235, 170]
+	      ZOrder		      -42
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -18246,8 +19852,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "force_rd_dout"
+	      SID		      "551:43"
 	      Ports		      [1, 1]
 	      Position		      [980, 165, 1015, 185]
+	      ZOrder		      -43
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -18275,17 +19884,20 @@ Library {
 	    Block {
 	      BlockType		      SubSystem
 	      Name		      "sim_wrapper"
+	      SID		      "551:44"
 	      Ports		      [8, 4]
 	      Position		      [505, 435, 670, 790]
+	      ZOrder		      -44
 	      MinAlgLoopOccurrences   off
 	      PropExecContextOutsideSubsystem off
 	      RTWSystemCode	      "Auto"
 	      FunctionWithSeparateData off
 	      Opaque		      off
+	      RequestExecContextInheritance off
 	      MaskHideContents	      off
 	      System {
 		Name			"sim_wrapper"
-		Location		[6, 74, 1018, 699]
+		Location		[12, 45, 1072, 905]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -18301,66 +19913,85 @@ Library {
 		Block {
 		  BlockType		  Inport
 		  Name			  "rst"
+		  SID			  "551:45"
 		  Position		  [140, 193, 170, 207]
+		  ZOrder		  -1
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "address"
+		  SID			  "551:46"
 		  Position		  [140, 233, 170, 247]
+		  ZOrder		  -2
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "data_in"
+		  SID			  "551:47"
 		  Position		  [140, 273, 170, 287]
+		  ZOrder		  -3
 		  Port			  "3"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "wr_be"
+		  SID			  "551:48"
 		  Position		  [140, 313, 170, 327]
+		  ZOrder		  -4
 		  Port			  "4"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "RWn"
+		  SID			  "551:49"
 		  Position		  [140, 353, 170, 367]
+		  ZOrder		  -5
 		  Port			  "5"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "cmd_tag"
+		  SID			  "551:50"
 		  Position		  [140, 393, 170, 407]
+		  ZOrder		  -6
 		  Port			  "6"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "cmd_valid"
+		  SID			  "551:51"
 		  Position		  [140, 433, 170, 447]
+		  ZOrder		  -7
 		  Port			  "7"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "rd_ack"
+		  SID			  "551:52"
 		  Position		  [140, 473, 170, 487]
+		  ZOrder		  -8
 		  Port			  "8"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Disregard Subsystem"
+		  SID			  "551:53"
 		  Tag			  "discardX"
 		  Ports			  []
 		  Position		  [29, 15, 80, 65]
+		  ZOrder		  -9
 		  ShowName		  off
 		  AttributesFormatString  "Disregard Subsystem\\nFor Generation"
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Disregard Subsystem"
 		  SourceType		  "Xilinx Disregard Subsystem For Generation Block"
 		  infoedit		  "Place this block into a subsystem to have System Generator ignore the subsystem during code generatio"
@@ -18379,8 +20010,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "ModelSim"
+		  SID			  "551:54"
 		  Ports			  []
 		  Position		  [107, 16, 172, 64]
+		  ZOrder		  -10
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/ModelSim"
 		  SourceType		  "ModelSim HDL Co-Simulation Interface Block"
 		  infoedit		  "Allow other blocks to schedule HDL co-simulation tasks.<P><P>Note that selecting \"Skip compilation\""
@@ -18410,20 +20044,27 @@ Library {
 		Block {
 		  BlockType		  Terminator
 		  Name			  "Terminator"
+		  SID			  "551:55"
 		  Position		  [600, 415, 620, 435]
+		  ZOrder		  -11
 		  ShowName		  off
 		}
 		Block {
 		  BlockType		  Terminator
 		  Name			  "Terminator1"
+		  SID			  "551:56"
 		  Position		  [600, 470, 620, 490]
+		  ZOrder		  -12
 		  ShowName		  off
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "dram_sim"
+		  SID			  "551:57"
 		  Ports			  [8, 6]
 		  Position		  [380, 180, 535, 500]
+		  ZOrder		  -13
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Black Box"
 		  SourceType		  "Xilinx Black Box Block"
 		  infoedit		  " Incorporates black box HDL and simulation model into a System Generator design.<P><P>You must supply"
@@ -18457,27 +20098,35 @@ Library {
 		Block {
 		  BlockType		  Outport
 		  Name			  "cmd_ack"
+		  SID			  "551:58"
 		  Position		  [725, 198, 755, 212]
+		  ZOrder		  -14
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "data_out"
+		  SID			  "551:59"
 		  Position		  [725, 253, 755, 267]
+		  ZOrder		  -15
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "rd_tag"
+		  SID			  "551:60"
 		  Position		  [725, 308, 755, 322]
+		  ZOrder		  -16
 		  Port			  "3"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Outport
 		  Name			  "rd_valid"
+		  SID			  "551:61"
 		  Position		  [725, 363, 755, 377]
+		  ZOrder		  -17
 		  Port			  "4"
 		  IconDisplay		  "Port number"
 		}
@@ -18570,27 +20219,35 @@ Library {
 	    Block {
 	      BlockType		      Outport
 	      Name		      "cmd_ack"
+	      SID		      "551:62"
 	      Position		      [1050, 78, 1080, 92]
+	      ZOrder		      -45
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "data_out"
+	      SID		      "551:63"
 	      Position		      [1050, 168, 1080, 182]
+	      ZOrder		      -46
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "rd_tag"
+	      SID		      "551:64"
 	      Position		      [1050, 258, 1080, 272]
+	      ZOrder		      -47
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "rd_valid"
+	      SID		      "551:65"
 	      Position		      [1050, 348, 1080, 362]
+	      ZOrder		      -48
 	      Port		      "4"
 	      IconDisplay	      "Port number"
 	    }
@@ -18928,8 +20585,10 @@ Library {
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "fifo_empty_check"
+	  SID			  "552"
 	  Ports			  [6, 1]
 	  Position		  [1520, 476, 1605, 559]
+	  ZOrder		  -35
 	  BackgroundColor	  "yellow"
 	  NamePlacement		  "alternate"
 	  MinAlgLoopOccurrences	  off
@@ -18937,10 +20596,11 @@ Library {
 	  RTWSystemCode		  "Auto"
 	  FunctionWithSeparateData off
 	  Opaque		  off
+	  RequestExecContextInheritance	off
 	  MaskHideContents	  off
 	  System {
 	    Name		    "fifo_empty_check"
-	    Location		    [2, 74, 1142, 740]
+	    Location		    [12, 45, 1200, 946]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -18956,49 +20616,64 @@ Library {
 	    Block {
 	      BlockType		      Inport
 	      Name		      "cmd_valid"
+	      SID		      "553"
 	      Position		      [15, 88, 45, 102]
+	      ZOrder		      -1
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "tag_in"
+	      SID		      "554"
 	      Position		      [20, 13, 50, 27]
+	      ZOrder		      -2
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "RWn"
+	      SID		      "555"
 	      Position		      [15, 233, 45, 247]
+	      ZOrder		      -3
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "dram_data_tag"
+	      SID		      "556"
 	      Position		      [185, 213, 215, 227]
+	      ZOrder		      -4
 	      Port		      "4"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "rd_ack"
+	      SID		      "557"
 	      Position		      [265, 268, 295, 282]
+	      ZOrder		      -5
 	      Port		      "5"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "rd_valid"
+	      SID		      "558"
 	      Position		      [265, 328, 295, 342]
+	      ZOrder		      -6
 	      Port		      "6"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Convert"
+	      SID		      "559"
 	      Ports		      [1, 1]
 	      Position		      [795, 266, 820, 284]
+	      ZOrder		      -7
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Convert"
 	      SourceType	      "Xilinx Type Converter Block"
 	      infoedit		      "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do"
@@ -19034,8 +20709,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Counter"
+	      SID		      "560"
 	      Ports		      [1, 1]
 	      Position		      [600, 250, 650, 300]
+	      ZOrder		      -8
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Counter"
 	      SourceType	      "Xilinx Counter Block"
 	      infoedit		      "Hardware notes: Free running counters are the least expensive in hardware.  A count limited co"
@@ -19076,8 +20754,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay1"
+	      SID		      "561"
 	      Ports		      [1, 1]
 	      Position		      [400, 267, 440, 283]
+	      ZOrder		      -9
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -19106,8 +20787,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay2"
+	      SID		      "562"
 	      Ports		      [1, 1]
 	      Position		      [400, 327, 440, 343]
+	      ZOrder		      -10
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -19136,8 +20820,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical"
+	      SID		      "563"
 	      Ports		      [2, 1]
 	      Position		      [140, 147, 165, 178]
+	      ZOrder		      -11
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -19168,8 +20855,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical1"
+	      SID		      "564"
 	      Ports		      [3, 1]
 	      Position		      [505, 240, 535, 310]
+	      ZOrder		      -12
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -19200,8 +20890,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical2"
+	      SID		      "565"
 	      Ports		      [2, 1]
 	      Position		      [510, 20, 540, 80]
+	      ZOrder		      -13
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -19232,8 +20925,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Register1"
+	      SID		      "566"
 	      Ports		      [3, 1]
 	      Position		      [875, 235, 920, 285]
+	      ZOrder		      -14
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Register"
 	      SourceType	      "Xilinx Register Block"
 	      init		      "0"
@@ -19260,8 +20956,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Relational"
+	      SID		      "567"
 	      Ports		      [2, 1]
 	      Position		      [385, 128, 430, 172]
+	      ZOrder		      -15
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Relational"
 	      SourceType	      "Xilinx Arithmetic Relational Operator Block"
 	      mode		      "a=b"
@@ -19288,8 +20987,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Relational1"
+	      SID		      "568"
 	      Ports		      [3, 1]
 	      Position		      [375, 13, 420, 57]
+	      ZOrder		      -16
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Relational"
 	      SourceType	      "Xilinx Arithmetic Relational Operator Block"
 	      mode		      "a!=b"
@@ -19316,8 +21018,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "last_read_tag"
+	      SID		      "569"
 	      Ports		      [2, 1]
 	      Position		      [260, 113, 305, 162]
+	      ZOrder		      -17
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Register"
 	      SourceType	      "Xilinx Register Block"
 	      init		      "0"
@@ -19343,17 +21048,20 @@ Library {
 	    Block {
 	      BlockType		      SubSystem
 	      Name		      "negedge"
+	      SID		      "570"
 	      Ports		      [1, 1]
 	      Position		      [685, 263, 730, 287]
+	      ZOrder		      -18
 	      MinAlgLoopOccurrences   off
 	      PropExecContextOutsideSubsystem off
 	      RTWSystemCode	      "Auto"
 	      FunctionWithSeparateData off
 	      Opaque		      off
+	      RequestExecContextInheritance off
 	      MaskHideContents	      off
 	      System {
 		Name			"negedge"
-		Location		[72, 372, 493, 522]
+		Location		[38, 253, 507, 638]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -19369,14 +21077,19 @@ Library {
 		Block {
 		  BlockType		  Inport
 		  Name			  "in"
+		  SID			  "571"
 		  Position		  [25, 43, 55, 57]
+		  ZOrder		  -1
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Delay"
+		  SID			  "572"
 		  Ports			  [1, 1]
 		  Position		  [85, 27, 130, 73]
+		  ZOrder		  -2
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Delay"
 		  SourceType		  "Xilinx Delay Block"
 		  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -19404,8 +21117,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter1"
+		  SID			  "573"
 		  Ports			  [1, 1]
 		  Position		  [130, 73, 180, 107]
+		  ZOrder		  -3
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -19430,8 +21146,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical"
+		  SID			  "574"
 		  Ports			  [2, 1]
 		  Position		  [240, 31, 320, 109]
+		  ZOrder		  -4
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -19462,7 +21181,9 @@ Library {
 		Block {
 		  BlockType		  Outport
 		  Name			  "out"
+		  SID			  "575"
 		  Position		  [350, 63, 380, 77]
+		  ZOrder		  -5
 		  IconDisplay		  "Port number"
 		}
 		Line {
@@ -19503,61 +21224,48 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "warn period Logical10"
+	      SID		      "576"
 	      Ports		      []
 	      Position		      [522, 215, 548, 240]
+	      ZOrder		      -19
 	      ShowName		      off
+	      LibraryVersion	      "1.213"
 	      SourceBlock	      "xbsReplacements_r4/Warning"
-	      SourceType	      ""
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
+	      SourceType	      "Unknown"
 	      period		      "1"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "warn period Register10"
+	      SID		      "577"
 	      Ports		      []
 	      Position		      [907, 210, 933, 235]
+	      ZOrder		      -20
 	      ShowName		      off
+	      LibraryVersion	      "1.213"
 	      SourceBlock	      "xbsReplacements_r4/Warning"
-	      SourceType	      ""
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
+	      SourceType	      "Unknown"
 	      period		      "1"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "warn period Relational10"
+	      SID		      "578"
 	      Ports		      []
 	      Position		      [407, 15, 433, 40]
+	      ZOrder		      -21
 	      ShowName		      off
+	      LibraryVersion	      "1.213"
 	      SourceBlock	      "xbsReplacements_r4/Warning"
-	      SourceType	      ""
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
+	      SourceType	      "Unknown"
 	      period		      "1"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "done"
+	      SID		      "579"
 	      Position		      [1005, 253, 1035, 267]
+	      ZOrder		      -22
 	      IconDisplay	      "Port number"
 	    }
 	    Line {
@@ -19723,8 +21431,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "startup_delay"
+	  SID			  "580"
 	  Ports			  [0, 1]
 	  Position		  [360, 376, 400, 394]
+	  ZOrder		  -36
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Constant"
 	  SourceType		  "Xilinx Constant Block Block"
 	  const			  "(2^28-1)"
@@ -19761,63 +21472,61 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "warn period Delay10"
+	  SID			  "581"
 	  Ports			  []
 	  Position		  [1262, 157, 1288, 182]
+	  ZOrder		  -37
 	  ShowName		  off
+	  LibraryVersion	  "1.213"
 	  SourceBlock		  "xbsReplacements_r4/Warning"
-	  SourceType		  ""
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
+	  SourceType		  "Unknown"
 	  period		  "1"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "warn period Delay20"
+	  SID			  "582"
 	  Ports			  []
 	  Position		  [1262, 262, 1288, 287]
+	  ZOrder		  -38
 	  ShowName		  off
+	  LibraryVersion	  "1.213"
 	  SourceBlock		  "xbsReplacements_r4/Warning"
-	  SourceType		  ""
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
+	  SourceType		  "Unknown"
 	  period		  "1"
 	}
 	Block {
 	  BlockType		  Outport
 	  Name			  "ready"
+	  SID			  "583"
 	  Position		  [650, 238, 680, 252]
+	  ZOrder		  -39
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Outport
 	  Name			  "dout"
+	  SID			  "584"
 	  Position		  [2565, 178, 2595, 192]
+	  ZOrder		  -40
 	  Port			  "2"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Outport
 	  Name			  "valid"
+	  SID			  "585"
 	  Position		  [2565, 223, 2595, 237]
+	  ZOrder		  -41
 	  Port			  "3"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Outport
 	  Name			  "RB_done"
+	  SID			  "586"
 	  Position		  [2305, 473, 2335, 487]
+	  ZOrder		  -42
 	  Port			  "4"
 	  IconDisplay		  "Port number"
 	}
@@ -20327,6 +22036,7 @@ Library {
 	  DstPort		  4
 	}
 	Annotation {
+	  SID			  "587"
 	  Name			  "first 2^28-1 cycles DRAM \nis not ready!"
 	  Position		  [444, 438]
 	}
@@ -20335,8 +22045,10 @@ Library {
     Block {
       BlockType		      SubSystem
       Name		      "dsp48e_bram_vacc"
+      SID		      "588"
       Ports		      [2, 2]
-      Position		      [25, 202, 125, 233]
+      Position		      [25, 202, 100, 238]
+      ZOrder		      -3
       BackgroundColor	      "[0.500000, 1.000000, 0.500000]"
       UserDataPersistent      on
       UserData		      "DataTag1"
@@ -20345,31 +22057,67 @@ Library {
       RTWSystemCode	      "Auto"
       FunctionWithSeparateData off
       Opaque		      off
+      RequestExecContextInheritance off
       MaskHideContents	      off
-      MaskType		      "dsp48e_bram_vacc"
-      MaskDescription	      "A vector accumulator modeled after a shift register.  It outputs its previous accumulated"
-      " vector after a new_acc pulse is received.\n\nBased on the simple_bram_vacc block, this version replaces the add"
-      "er and mux with a single DSP48E block, allowing high-speed compilation.\n\nOutput bit width cannot exceed 32. Ou"
-      "tput binary point matches the input."
-      MaskPromptString	      "Vector length:|Output type:|Binary point (input):|Bit width (output):"
-      MaskStyleString	      "edit,popup(Unsigned|Signed  (2's comp)),edit,edit"
-      MaskVariables	      "vec_len=@1;arith_type=&2;bin_pt_in=@3;n_bits_out=@4;"
-      MaskTunableValueString  "on,on,on,on"
-      MaskCallbackString      "|||"
-      MaskEnableString	      "on,on,on,on"
-      MaskVisibilityString    "on,on,on,on"
-      MaskToolTipString	      "on,on,on,on"
-      MaskInitialization      "dsp48e_bram_vacc_init(gcb, ...\n    'vec_len', vec_len, ...\n    'arith_type', arith_ty"
-      "pe, ...\n    'bin_pt_in', bin_pt_in, ...\n    'n_bits_out', n_bits_out);"
-      MaskSelfModifiable      on
-      MaskIconFrame	      on
-      MaskIconOpaque	      on
-      MaskIconRotate	      "none"
-      MaskIconUnits	      "autoscale"
-      MaskValueString	      "8|Signed  (2's comp)|0|32"
+      Object {
+	$PropName		"MaskObject"
+	$ObjectID		55
+	$ClassName		"Simulink.Mask"
+	Type			"dsp48e_bram_vacc"
+	Description		"A vector accumulator modeled after a shift register.  It outputs its previous accumulated vector after "
+	"a new_acc pulse is received.\n\nBased on the simple_bram_vacc block, this version replaces the adder and mux with a s"
+	"ingle DSP48E block, allowing high-speed compilation.\n\nThe input and outputs ports are limited to 48 bits. Overflow "
+	"is not catered for. \n\nEach accumulation uses the full 48 bits, irrespective of mask parameters. \nThe output of the"
+	" accumulation then slices off the output bits.\nThe binary point is kept at the same relative location to ensure that"
+	" the signal value is not changed. "
+	Initialization		"dsp48e_bram_vacc_init(gcb, ...\n    'vec_len', vec_len, ...\n    'arith_type', arith_type, ...\n    "
+	"'bin_pt_in', bin_pt_in, ...\n    'n_bits_out', n_bits_out);"
+	SelfModifiable		"on"
+	Array {
+	  Type			  "Simulink.MaskParameter"
+	  Dimension		  4
+	  Object {
+	    $ObjectID		    56
+	    Type		    "edit"
+	    Name		    "vec_len"
+	    Prompt		    "Vector length:"
+	    Value		    "8"
+	  }
+	  Object {
+	    $ObjectID		    57
+	    Type		    "popup"
+	    Array {
+	      Type		      "Cell"
+	      Dimension		      2
+	      Cell		      "Unsigned"
+	      Cell		      "Signed  (2's comp)"
+	      PropName		      "TypeOptions"
+	    }
+	    Name		    "arith_type"
+	    Prompt		    "Output type:"
+	    Value		    "Signed  (2's comp)"
+	    Evaluate		    "off"
+	  }
+	  Object {
+	    $ObjectID		    58
+	    Type		    "edit"
+	    Name		    "bin_pt_in"
+	    Prompt		    "Binary point (input):"
+	    Value		    "31"
+	  }
+	  Object {
+	    $ObjectID		    59
+	    Type		    "edit"
+	    Name		    "n_bits_out"
+	    Prompt		    "Bit width (output):"
+	    Value		    "32"
+	  }
+	  PropName		  "Parameters"
+	}
+      }
       System {
 	Name			"dsp48e_bram_vacc"
-	Location		[809, 697, 1731, 955]
+	Location		[0, 27, 1920, 1200]
 	Open			off
 	ModelBrowserVisibility	off
 	ModelBrowserWidth	200
@@ -20381,26 +22129,34 @@ Library {
 	TiledPaperMargins	[0.500000, 0.500000, 0.500000, 0.500000]
 	TiledPageScale		1
 	ShowPageBoundaries	off
-	ZoomFactor		"100"
+	ZoomFactor		"150"
+	SIDHighWatermark	"68"
 	Block {
 	  BlockType		  Inport
 	  Name			  "new_acc"
+	  SID			  "588:1"
 	  Position		  [15, 173, 45, 187]
+	  ZOrder		  -1
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Inport
 	  Name			  "din"
+	  SID			  "588:2"
 	  Position		  [15, 68, 45, 82]
+	  ZOrder		  -2
 	  Port			  "2"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "Concat"
+	  SID			  "588:3"
 	  Ports			  [3, 1]
 	  Position		  [295, 157, 345, 203]
+	  ZOrder		  -3
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Concat"
 	  SourceType		  "Xilinx Bus Concatenator Block"
 	  infoedit		  "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary point at ze"
@@ -20424,9 +22180,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Convert_AB"
+	  SID			  "588:4"
 	  Ports			  [1, 1]
 	  Position		  [95, 37, 145, 53]
+	  ZOrder		  -4
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Convert"
 	  SourceType		  "Xilinx Type Converter Block"
 	  infoedit		  "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do not."
@@ -20461,9 +22220,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Convert_C"
+	  SID			  "588:5"
 	  Ports			  [1, 1]
 	  Position		  [295, 67, 345, 83]
+	  ZOrder		  -5
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Convert"
 	  SourceType		  "Xilinx Type Converter Block"
 	  infoedit		  "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do not."
@@ -20483,7 +22245,7 @@ Library {
 	  xl_use_area		  off
 	  xl_area		  "[0,0,0,0,0,0,0]"
 	  has_advanced_control	  "0"
-	  sggui_pos		  "20,27,633,525"
+	  sggui_pos		  "11,19,633,624"
 	  block_type		  "convert"
 	  block_version		  "10.1.3"
 	  sg_icon_stat		  "50,16,1,1,white,blue,0,edca21da,right,,[ ],[ ]"
@@ -20498,8 +22260,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "DSP48E"
+	  SID			  "588:6"
 	  Ports			  [7, 1]
 	  Position		  [395, 37, 495, 143]
+	  ZOrder		  -6
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/DSP48E"
 	  SourceType		  "Xilinx DSP48E Block"
 	  use_a			  "Direct from A Port"
@@ -20563,7 +22328,7 @@ Library {
 	  xl_use_area		  off
 	  xl_area		  "[0,0,0,0,0,0,0]"
 	  has_advanced_control	  "0"
-	  sggui_pos		  "0,0,658,967"
+	  sggui_pos		  "-9,19,658,967"
 	  block_type		  "dsp48e"
 	  block_version		  "10.1.3"
 	  sg_icon_stat		  "100,106,7,1,white,blue,0,51584ea8,right,,[ ],[ ]"
@@ -20581,9 +22346,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Inverter"
+	  SID			  "588:7"
 	  Ports			  [1, 1]
 	  Position		  [195, 172, 245, 188]
+	  ZOrder		  -7
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Inverter"
 	  SourceType		  "Xilinx Inverter Block"
 	  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -20608,37 +22376,44 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Reinterpret"
+	  SID			  "588:8"
 	  Ports			  [1, 1]
-	  Position		  [770, 82, 820, 98]
-	  ShowName		  off
+	  Position		  [775, 82, 825, 98]
+	  ZOrder		  -8
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Reinterpret"
 	  SourceType		  "Xilinx Type Reinterpreter Block"
-	  infoedit		  "Changes signal type without altering the binary representation.   You can changed the signal between s"
-	  "igned and unsigned, and relocate the binary point.<br><br>Hardware notes: In hardware this block costs nothing.<br>"
-	  "<br>Example:  Suppose the input is 6 bits wide, signed, with 2 fractional bits, and the output is forced to unsigne"
-	  "d with 0 fractional bits.  Then an input of -2.0 (1110.00 in binary 2's complement) becomes an output of 56 (111000"
-	  " in binary)."
+	  infoedit		  "Changes signal type without altering the binary representation.   You can change the signal between si"
+	  "gned and unsigned, and relocate the binary point.<br><br>Hardware notes: In hardware this block costs nothing.<br><"
+	  "br>Example:  Suppose the input is 6 bits wide, signed, with 2 fractional bits, and the output is forced to unsigned"
+	  " with 0 fractional bits.  Then an input of -2.0 (1110.00 in binary 2's complement) becomes an output of 56 (111000 "
+	  "in binary)."
 	  force_arith_type	  on
 	  arith_type		  "Signed  (2's comp)"
 	  force_bin_pt		  on
-	  bin_pt		  "bin_pt_in"
+	  bin_pt		  "max(0, bin_pt_in - (48 - n_bits_out))"
 	  has_advanced_control	  "0"
-	  sggui_pos		  "15,25,372,364"
+	  sggui_pos		  "-9,19,372,364"
 	  block_type		  "reinterpret"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "50,16,1,1,white,blue,0,6b04d0b0,right,"
-	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 1 1 0 ],[0 0 1 1 ],[0.77 0.82 0.91]);\npat"
-	  "ch([0.42 0.36 0.44 0.36 0.42 0.5 0.52 0.54 0.64 0.56 0.5 0.46 0.54 0.46 0.5 0.56 0.64 0.54 0.52 0.5 0.42 ],[0.125 0"
-	  ".3125 0.5625 0.8125 1 1 0.9375 1 1 0.75 0.9375 0.8125 0.5625 0.3125 0.1875 0.375 0.125 0.125 0.1875 0.125 0.125 ],["
-	  "0.98 0.96 0.92]);\nplot([0 1 1 0 0 ],[0 0 1 1 0 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT"
-	  ": begin icon text');\ncolor('black');disp('reinterpret');\nfprintf('','COMMENT: end icon text');\n"
+	  sg_icon_stat		  "50,16,1,1,white,blue,0,6b04d0b0,right,,[ ],[ ]"
+	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 16 16 0 ],[0.77 0.82 0.91"
+	  " ]);\nplot([0 50 50 0 0 ],[0 0 16 16 0 ]);\npatch([20.55 23.44 25.44 27.44 29.44 25.44 22.55 20.55 ],[10.22 10.22 1"
+	  "2.22 10.22 12.22 12.22 12.22 10.22 ],[1 1 1 ]);\npatch([22.55 25.44 23.44 20.55 22.55 ],[8.22 8.22 10.22 10.22 8.22"
+	  " ],[0.931 0.946 0.973 ]);\npatch([20.55 23.44 25.44 22.55 20.55 ],[6.22 6.22 8.22 8.22 6.22 ],[1 1 1 ]);\npatch([22"
+	  ".55 29.44 27.44 25.44 23.44 20.55 22.55 ],[4.22 4.22 6.22 4.22 6.22 6.22 4.22 ],[0.931 0.946 0.973 ]);\nfprintf('',"
+	  "'COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\n\ncolor('black');disp('reinterpret');\nf"
+	  "printf('','COMMENT: end icon text');\n"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "Reinterpret_A"
+	  SID			  "588:9"
 	  Ports			  [1, 1]
 	  Position		  [295, 37, 345, 53]
+	  ZOrder		  -9
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Reinterpret"
 	  SourceType		  "Xilinx Type Reinterpreter Block"
 	  infoedit		  "Changes signal type without altering the binary representation.   You can changed the signal between s"
@@ -20666,9 +22441,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Reinterpret_B"
+	  SID			  "588:10"
 	  Ports			  [1, 1]
 	  Position		  [295, 52, 345, 68]
+	  ZOrder		  -10
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Reinterpret"
 	  SourceType		  "Xilinx Type Reinterpreter Block"
 	  infoedit		  "Changes signal type without altering the binary representation.   You can changed the signal between s"
@@ -20696,9 +22474,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Reinterpret_C"
+	  SID			  "588:11"
 	  Ports			  [1, 1]
 	  Position		  [195, 67, 245, 83]
+	  ZOrder		  -11
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Reinterpret"
 	  SourceType		  "Xilinx Type Reinterpreter Block"
 	  infoedit		  "Changes signal type without altering the binary representation.   You can changed the signal between s"
@@ -20711,7 +22492,7 @@ Library {
 	  force_bin_pt		  on
 	  bin_pt		  "0"
 	  has_advanced_control	  "0"
-	  sggui_pos		  "15,25,372,364"
+	  sggui_pos		  "6,19,372,364"
 	  block_type		  "reinterpret"
 	  block_version		  "10.1.3"
 	  sg_icon_stat		  "50,16,1,1,white,blue,0,6b04d0b0,right,,[ ],[ ]"
@@ -20725,40 +22506,13 @@ Library {
 	}
 	Block {
 	  BlockType		  Reference
-	  Name			  "Slice"
-	  Ports			  [1, 1]
-	  Position		  [670, 82, 720, 98]
-	  ShowName		  off
-	  SourceBlock		  "xbsIndex_r4/Slice"
-	  SourceType		  "Xilinx Bit Slice Extractor Block"
-	  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type "
-	  "is ordinarily unsigned with binary point at zero, but can be Boolean when the slice is one bit wide.<br><br>Hardwar"
-	  "e notes: In hardware this block costs nothing."
-	  nbits			  "n_bits_out"
-	  boolean_output	  off
-	  mode			  "Lower Bit Location + Width"
-	  bit1			  "0"
-	  base1			  "MSB of Input"
-	  bit0			  "0"
-	  base0			  "LSB of Input"
-	  dbl_ovrd		  off
-	  has_advanced_control	  "0"
-	  sggui_pos		  "-1,-1,-1,-1"
-	  block_type		  "slice"
-	  block_version		  "11.4"
-	  sg_icon_stat		  "50,16,1,1,white,blue,0,1fd851a7,right,"
-	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 1 1 0 ],[0 0 1 1 ],[0.77 0.82 0.91]);\npat"
-	  "ch([0.42 0.36 0.44 0.36 0.42 0.5 0.52 0.54 0.64 0.56 0.5 0.46 0.54 0.46 0.5 0.56 0.64 0.54 0.52 0.5 0.42 ],[0.125 0"
-	  ".3125 0.5625 0.8125 1 1 0.9375 1 1 0.75 0.9375 0.8125 0.5625 0.3125 0.1875 0.375 0.125 0.125 0.1875 0.125 0.125 ],["
-	  "0.98 0.96 0.92]);\nplot([0 1 1 0 0 ],[0 0 1 1 0 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT"
-	  ": begin icon text');\ncolor('black');port_label('output',1,'[a:b]');\nfprintf('','COMMENT: end icon text');\n"
-	}
-	Block {
-	  BlockType		  Reference
 	  Name			  "Slice_A"
+	  SID			  "588:13"
 	  Ports			  [1, 1]
 	  Position		  [195, 37, 245, 53]
+	  ZOrder		  -13
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Slice"
 	  SourceType		  "Xilinx Bit Slice Extractor Block"
 	  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type "
@@ -20788,9 +22542,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Slice_B"
+	  SID			  "588:14"
 	  Ports			  [1, 1]
 	  Position		  [195, 52, 245, 68]
+	  ZOrder		  -14
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Slice"
 	  SourceType		  "Xilinx Bit Slice Extractor Block"
 	  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type "
@@ -20820,41 +22577,46 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Slice_p"
+	  SID			  "588:15"
 	  Ports			  [1, 1]
-	  Position		  [520, 82, 570, 98]
-	  ShowName		  off
+	  Position		  [685, 82, 720, 98]
+	  ZOrder		  2
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Slice"
 	  SourceType		  "Xilinx Bit Slice Extractor Block"
 	  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type "
 	  "is ordinarily unsigned with binary point at zero, but can be Boolean when the slice is one bit wide.<br><br>Hardwar"
 	  "e notes: In hardware this block costs nothing."
-	  nbits			  "32"
+	  nbits			  "n_bits_out"
 	  boolean_output	  off
-	  mode			  "Lower Bit Location + Width"
+	  mode			  "Upper Bit Location + Width"
 	  bit1			  "0"
 	  base1			  "MSB of Input"
 	  bit0			  "0"
 	  base0			  "LSB of Input"
 	  dbl_ovrd		  off
 	  has_advanced_control	  "0"
-	  sggui_pos		  "-1,-1,-1,-1"
+	  sggui_pos		  "-9,19,543,459"
 	  block_type		  "slice"
 	  block_version		  "11.4"
-	  sg_icon_stat		  "50,16,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
-	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 16 16 0 ],[0.77 0.82 0.91"
-	  " ]);\nplot([0 50 50 0 0 ],[0 0 16 16 0 ]);\npatch([20.55 23.44 25.44 27.44 29.44 25.44 22.55 20.55 ],[10.22 10.22 1"
-	  "2.22 10.22 12.22 12.22 12.22 10.22 ],[1 1 1 ]);\npatch([22.55 25.44 23.44 20.55 22.55 ],[8.22 8.22 10.22 10.22 8.22"
-	  " ],[0.931 0.946 0.973 ]);\npatch([20.55 23.44 25.44 22.55 20.55 ],[6.22 6.22 8.22 8.22 6.22 ],[1 1 1 ]);\npatch([22"
-	  ".55 29.44 27.44 25.44 23.44 20.55 22.55 ],[4.22 4.22 6.22 4.22 6.22 6.22 4.22 ],[0.931 0.946 0.973 ]);\nfprintf('',"
+	  sg_icon_stat		  "35,16,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
+	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 35 35 0 0 ],[0 0 16 16 0 ],[0.77 0.82 0.91"
+	  " ]);\nplot([0 35 35 0 0 ],[0 0 16 16 0 ]);\npatch([12.55 15.44 17.44 19.44 21.44 17.44 14.55 12.55 ],[10.22 10.22 1"
+	  "2.22 10.22 12.22 12.22 12.22 10.22 ],[1 1 1 ]);\npatch([14.55 17.44 15.44 12.55 14.55 ],[8.22 8.22 10.22 10.22 8.22"
+	  " ],[0.931 0.946 0.973 ]);\npatch([12.55 15.44 17.44 14.55 12.55 ],[6.22 6.22 8.22 8.22 6.22 ],[1 1 1 ]);\npatch([14"
+	  ".55 21.44 19.44 17.44 15.44 12.55 14.55 ],[4.22 4.22 6.22 4.22 6.22 6.22 4.22 ],[0.931 0.946 0.973 ]);\nfprintf('',"
 	  "'COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');port_label('output',1,'[a"
 	  ":b]');\nfprintf('','COMMENT: end icon text');\n"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "alumode"
+	  SID			  "588:16"
 	  Ports			  [0, 1]
 	  Position		  [295, 97, 345, 113]
+	  ZOrder		  -16
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Constant"
 	  SourceType		  "Xilinx Constant Block Block"
 	  const			  "0"
@@ -20895,9 +22657,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "carryin"
+	  SID			  "588:17"
 	  Ports			  [0, 1]
 	  Position		  [295, 112, 345, 128]
+	  ZOrder		  -17
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Constant"
 	  SourceType		  "Xilinx Constant Block Block"
 	  const			  "0"
@@ -20938,9 +22703,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "carryinsel"
+	  SID			  "588:18"
 	  Ports			  [0, 1]
 	  Position		  [295, 127, 345, 143]
+	  ZOrder		  -18
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Constant"
 	  SourceType		  "Xilinx Constant Block Block"
 	  const			  "0"
@@ -20981,37 +22749,51 @@ Library {
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "delay_bram"
+	  SID			  "588:19"
 	  Ports			  [1, 1]
-	  Position		  [595, 65, 645, 115]
+	  Position		  [565, 65, 615, 115]
+	  ZOrder		  -19
 	  BackgroundColor	  "gray"
 	  MinAlgLoopOccurrences	  off
 	  PropExecContextOutsideSubsystem off
 	  RTWSystemCode		  "Auto"
 	  FunctionWithSeparateData off
 	  Opaque		  off
+	  RequestExecContextInheritance	off
 	  MaskHideContents	  off
-	  MaskType		  "delay_bram"
-	  MaskDescription	  "A delay block that uses BRAM for its storage."
-	  MaskHelp		  "eval('xlWeb(''http://casper.berkeley.edu/wiki/Delay_bram'')')"
-	  MaskPromptString	  "Delay By:|BRAM Latency"
-	  MaskStyleString	  "edit,edit"
-	  MaskVariables		  "DelayLen=@1;bram_latency=@2;"
-	  MaskTunableValueString  "on,on"
-	  MaskCallbackString	  "|"
-	  MaskEnableString	  "on,on"
-	  MaskVisibilityString	  "on,on"
-	  MaskToolTipString	  "on,on"
-	  MaskInitialization	  "if (DelayLen <= bram_latency)\n	error('delay value must be greater than BRAM Latency');\nend\n"
-	  "BitWidth = max(ceil(log2(DelayLen)), 2);"
-	  MaskSelfModifiable	  on
-	  MaskIconFrame		  on
-	  MaskIconOpaque	  on
-	  MaskIconRotate	  "none"
-	  MaskIconUnits		  "autoscale"
-	  MaskValueString	  "vec_len - 2|2"
+	  Object {
+	    $PropName		    "MaskObject"
+	    $ObjectID		    60
+	    $ClassName		    "Simulink.Mask"
+	    Type		    "delay_bram"
+	    Description		    "A delay block that uses BRAM for its storage."
+	    Help		    "eval('xlWeb(''http://casper.berkeley.edu/wiki/Delay_bram'')')"
+	    Initialization	    "if (DelayLen <= bram_latency)\n	error('delay value must be greater than BRAM Latency');\nend\n"
+	    "BitWidth = max(ceil(log2(DelayLen)), 2);"
+	    SelfModifiable	    "on"
+	    Array {
+	      Type		      "Simulink.MaskParameter"
+	      Dimension		      2
+	      Object {
+		$ObjectID		61
+		Type			"edit"
+		Name			"DelayLen"
+		Prompt			"Delay By:"
+		Value			"vec_len - 2"
+	      }
+	      Object {
+		$ObjectID		62
+		Type			"edit"
+		Name			"bram_latency"
+		Prompt			"BRAM Latency"
+		Value			"2"
+	      }
+	      PropName		      "Parameters"
+	    }
+	  }
 	  System {
 	    Name		    "delay_bram"
-	    Location		    [1588, 111, 1868, 284]
+	    Location		    [1554, 45, 1882, 453]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -21024,17 +22806,23 @@ Library {
 	    TiledPageScale	    1
 	    ShowPageBoundaries	    off
 	    ZoomFactor		    "100"
+	    SIDHighWatermark	    "10"
 	    Block {
 	      BlockType		      Inport
 	      Name		      "In1"
+	      SID		      "588:19:1"
 	      Position		      [40, 83, 70, 97]
+	      ZOrder		      -1
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Constant2"
+	      SID		      "588:19:2"
 	      Ports		      [0, 1]
 	      Position		      [75, 98, 110, 122]
+	      ZOrder		      -2
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Constant"
 	      SourceType	      "Xilinx Constant Block Block"
 	      const		      "1"
@@ -21071,8 +22859,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Counter"
+	      SID		      "588:19:3"
 	      Ports		      [0, 1]
 	      Position		      [65, 25, 105, 65]
+	      ZOrder		      -3
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Counter"
 	      SourceType	      "Xilinx Counter Block"
 	      infoedit		      "Hardware notes: Free running counters are the least expensive in hardware.  A count limited co"
@@ -21100,18 +22891,23 @@ Library {
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "counter"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,40,0,1,white,blue,0,335d209d,right,"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 1 1 0 ],[0 0 1 1 ],[0.77 0.82 0.91"
-	      "]);\npatch([0.25 0.075 0.3 0.075 0.25 0.525 0.6 0.675 0.95 0.725 0.5 0.35 0.6 0.35 0.5 0.725 0.95 0.675 0.6 0.5"
-	      "25 0.25 ],[0.1 0.275 0.5 0.725 0.9 0.9 0.825 0.9 0.9 0.675 0.9 0.75 0.5 0.25 0.1 0.325 0.1 0.1 0.175 0.1 0.1 ],"
-	      "[0.98 0.96 0.92]);\nplot([0 1 1 0 0 ],[0 0 1 1 0 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','CO"
-	      "MMENT: begin icon text');\ncolor('black');port_label('output',1,'out');\nfprintf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "40,40,0,1,white,blue,0,4b061529,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 40 40 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 40 40 0 0 ],[0 0 40 40 0 ]);\npatch([8.875 16.1 21.1 26.1 31.1 21.1 13.875 8.875 ],[25.55"
+	      " 25.55 30.55 25.55 30.55 30.55 30.55 25.55 ],[1 1 1 ]);\npatch([13.875 21.1 16.1 8.875 13.875 ],[20.55 20.55 25"
+	      ".55 25.55 20.55 ],[0.931 0.946 0.973 ]);\npatch([8.875 16.1 21.1 13.875 8.875 ],[15.55 15.55 20.55 20.55 15.55 "
+	      "],[1 1 1 ]);\npatch([13.875 31.1 26.1 21.1 16.1 8.875 13.875 ],[10.55 10.55 15.55 10.55 15.55 15.55 10.55 ],[0."
+	      "931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolo"
+	      "r('black');disp('{\\fontsize{14}\\bf\\lceil++\\rceil}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Single Port RAM"
+	      SID		      "588:19:4"
 	      Ports		      [3, 1]
 	      Position		      [125, 63, 190, 117]
+	      ZOrder		      -4
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Single Port RAM"
 	      SourceType	      "Xilinx Single Port Random Access Memory Block"
 	      depth		      "2^BitWidth"
@@ -21124,27 +22920,29 @@ Library {
 	      latency		      "bram_latency"
 	      dbl_ovrd		      off
 	      optimize		      "Area"
-	      use_rpm		      off
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "spram"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "65,54,3,1,white,blue,0,f2d5aa4c,right,"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 1 1 0 ],[0 0 1 1 ],[0.77 0.82 0.91"
-	      "]);\npatch([0.276923 0.138462 0.338462 0.138462 0.276923 0.492308 0.553846 0.615385 0.846154 0.661538 0.476923 "
-	      "0.353846 0.569231 0.353846 0.476923 0.661538 0.846154 0.615385 0.553846 0.492308 0.276923 ],[0.111111 0.277778 "
-	      "0.518519 0.759259 0.925926 0.925926 0.851852 0.925926 0.925926 0.703704 0.925926 0.777778 0.518519 0.259259 0.1"
-	      "11111 0.333333 0.111111 0.111111 0.185185 0.111111 0.111111 ],[0.98 0.96 0.92]);\nplot([0 1 1 0 0 ],[0 0 1 1 0 "
-	      "]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_la"
-	      "bel('input',1,'addr');\ncolor('black');port_label('input',2,'data');\ncolor('black');port_label('input',3,'we')"
-	      ";\ncolor('black');disp('z^{-2}','texmode','on');\nfprintf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "65,54,3,1,white,blue,0,558c5cad,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 65 65 0 0 ],[0 0 54 54 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 65 65 0 0 ],[0 0 54 54 0 ]);\npatch([16.425 26.54 33.54 40.54 47.54 33.54 23.425 16.425 ]"
+	      ",[34.77 34.77 41.77 34.77 41.77 41.77 41.77 34.77 ],[1 1 1 ]);\npatch([23.425 33.54 26.54 16.425 23.425 ],[27.7"
+	      "7 27.77 34.77 34.77 27.77 ],[0.931 0.946 0.973 ]);\npatch([16.425 26.54 33.54 23.425 16.425 ],[20.77 20.77 27.7"
+	      "7 27.77 20.77 ],[1 1 1 ]);\npatch([23.425 47.54 40.54 33.54 26.54 16.425 23.425 ],[13.77 13.77 20.77 13.77 20.7"
+	      "7 20.77 13.77 ],[0.931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin i"
+	      "con text');\ncolor('black');port_label('input',1,'addr');\ncolor('black');port_label('input',2,'data');\ncolor("
+	      "'black');port_label('input',3,'we');\n\ncolor('black');disp('z^{-2}','texmode','on');\nfprintf('','COMMENT: end"
+	      " icon text');"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "Out1"
+	      SID		      "588:19:5"
 	      Position		      [210, 83, 240, 97]
+	      ZOrder		      -5
 	      IconDisplay	      "Port number"
 	    }
 	    Line {
@@ -21176,9 +22974,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "opmode_Z"
+	  SID			  "588:20"
 	  Ports			  [0, 1]
 	  Position		  [195, 157, 245, 173]
+	  ZOrder		  -20
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Constant"
 	  SourceType		  "Xilinx Constant Block Block"
 	  const			  "3"
@@ -21219,35 +23020,40 @@ Library {
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "pulse_ext"
+	  SID			  "588:21"
 	  Ports			  [1, 1]
 	  Position		  [95, 173, 145, 187]
+	  ZOrder		  -21
 	  ShowName		  off
 	  MinAlgLoopOccurrences	  off
 	  PropExecContextOutsideSubsystem off
 	  RTWSystemCode		  "Auto"
 	  FunctionWithSeparateData off
 	  Opaque		  off
+	  RequestExecContextInheritance	off
 	  MaskHideContents	  off
-	  MaskType		  "pulse_ext"
-	  MaskDescription	  "Extends a boolean signal to be high for the specified number of clocks after\nthe last high inpu"
-	  "t."
-	  MaskHelp		  "eval('xlWeb(''http://casper.berkeley.edu/wiki/Pulse_ext'')')"
-	  MaskPromptString	  "Length of Pulse"
-	  MaskStyleString	  "edit"
-	  MaskVariables		  "pulse_len=@1;"
-	  MaskTunableValueString  "on"
-	  MaskEnableString	  "on"
-	  MaskVisibilityString	  "on"
-	  MaskToolTipString	  "on"
-	  MaskInitialization	  "bits = ceil(log2(pulse_len+1));"
-	  MaskIconFrame		  on
-	  MaskIconOpaque	  on
-	  MaskIconRotate	  "none"
-	  MaskIconUnits		  "autoscale"
-	  MaskValueString	  "vec_len"
+	  Object {
+	    $PropName		    "MaskObject"
+	    $ObjectID		    63
+	    $ClassName		    "Simulink.Mask"
+	    Type		    "pulse_ext"
+	    Description		    "Extends a boolean signal to be high for the specified number of clocks after\nthe last high inp"
+	    "ut."
+	    Help		    "eval('xlWeb(''http://casper.berkeley.edu/wiki/Pulse_ext'')')"
+	    Initialization	    "bits = ceil(log2(pulse_len+1));"
+	    Object {
+	      $PropName		      "Parameters"
+	      $ObjectID		      64
+	      $ClassName	      "Simulink.MaskParameter"
+	      Type		      "edit"
+	      Name		      "pulse_len"
+	      Prompt		      "Length of Pulse"
+	      Value		      "vec_len"
+	    }
+	  }
 	  System {
 	    Name		    "pulse_ext"
-	    Location		    [690, 701, 1252, 951]
+	    Location		    [656, 582, 1266, 1067]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -21263,14 +23069,19 @@ Library {
 	    Block {
 	      BlockType		      Inport
 	      Name		      "in"
+	      SID		      "588:22"
 	      Position		      [20, 43, 50, 57]
+	      ZOrder		      -1
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Constant5"
+	      SID		      "588:23"
 	      Ports		      [0, 1]
 	      Position		      [145, 109, 215, 141]
+	      ZOrder		      -2
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Constant"
 	      SourceType	      "Xilinx Constant Block Block"
 	      const		      "pulse_len"
@@ -21296,18 +23107,22 @@ Library {
 	      block_type	      "constant"
 	      block_version	      "10.1.3"
 	      sg_icon_stat	      "70,32,0,1,white,blue,0,7a8c02d8,right,"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 1 1 0 ],[0 0 1 1 ],[0.77 0.82 0.91"
-	      "]);\npatch([0.371429 0.3 0.4 0.3 0.371429 0.485714 0.514286 0.542857 0.671429 0.571429 0.471429 0.4 0.5 0.4 0.4"
-	      "71429 0.571429 0.671429 0.542857 0.514286 0.485714 0.371429 ],[0.09375 0.25 0.46875 0.6875 0.84375 0.84375 0.78"
-	      "125 0.84375 0.84375 0.625 0.84375 0.6875 0.46875 0.25 0.09375 0.3125 0.09375 0.09375 0.15625 0.09375 0.09375 ],"
-	      "[0.98 0.96 0.92]);\nplot([0 1 1 0 0 ],[0 0 1 1 0 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','CO"
-	      "MMENT: begin icon text');\ncolor('black');port_label('output',1,'8');\nfprintf('','COMMENT: end icon text');\n"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 0 ],[0 0 26 26 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 55 55 0 0 ],[0 0 26 26 0 ]);\npatch([20.325 24.66 27.66 30.66 33.66 27.66 23.325 20.325 ]"
+	      ",[16.33 16.33 19.33 16.33 19.33 19.33 19.33 16.33 ],[1 1 1 ]);\npatch([23.325 27.66 24.66 20.325 23.325 ],[13.3"
+	      "3 13.33 16.33 16.33 13.33 ],[0.931 0.946 0.973 ]);\npatch([20.325 24.66 27.66 23.325 20.325 ],[10.33 10.33 13.3"
+	      "3 13.33 10.33 ],[1 1 1 ]);\npatch([23.325 33.66 30.66 27.66 24.66 20.325 23.325 ],[7.33 7.33 10.33 7.33 10.33 1"
+	      "0.33 7.33 ],[0.931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon "
+	      "text');\ncolor('black');port_label('output',1,'1');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Counter3"
+	      SID		      "588:24"
 	      Ports		      [2, 1]
 	      Position		      [165, 35, 215, 90]
+	      ZOrder		      -3
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Counter"
 	      SourceType	      "Xilinx Counter Block"
 	      infoedit		      "Hardware notes: Free running counters are the least expensive in hardware.  A count limited co"
@@ -21335,20 +23150,24 @@ Library {
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "counter"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "50,55,2,1,white,blue,0,d605779c,right,"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 1 1 0 ],[0 0 1 1 ],[0.77 0.82 0.91"
-	      "]);\npatch([0.22 0.06 0.3 0.06 0.22 0.48 0.56 0.64 0.92 0.7 0.48 0.32 0.56 0.32 0.48 0.7 0.92 0.64 0.56 0.48 0."
-	      "22 ],[0.145455 0.290909 0.509091 0.727273 0.872727 0.872727 0.8 0.872727 0.872727 0.672727 0.872727 0.727273 0."
-	      "509091 0.290909 0.145455 0.345455 0.145455 0.145455 0.218182 0.145455 0.145455 ],[0.98 0.96 0.92]);\nplot([0 1 "
-	      "1 0 0 ],[0 0 1 1 0 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncol"
-	      "or('black');port_label('input',1,'rst');\ncolor('black');port_label('input',2,'en');\ncolor('black');port_label"
-	      "('output',1,'out');\nfprintf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "50,55,2,1,white,blue,0,ae3608d6,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 55 55 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 50 50 0 0 ],[0 0 55 55 0 ]);\npatch([9.425 19.54 26.54 33.54 40.54 26.54 16.425 9.425 ],["
+	      "34.77 34.77 41.77 34.77 41.77 41.77 41.77 34.77 ],[1 1 1 ]);\npatch([16.425 26.54 19.54 9.425 16.425 ],[27.77 2"
+	      "7.77 34.77 34.77 27.77 ],[0.931 0.946 0.973 ]);\npatch([9.425 19.54 26.54 16.425 9.425 ],[20.77 20.77 27.77 27."
+	      "77 20.77 ],[1 1 1 ]);\npatch([16.425 40.54 33.54 26.54 19.54 9.425 16.425 ],[13.77 13.77 20.77 13.77 20.77 20.7"
+	      "7 13.77 ],[0.931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon te"
+	      "xt');\ncolor('black');port_label('input',1,'rst');\ncolor('black');port_label('input',2,'en');\n\ncolor('black'"
+	      ");disp('{\\fontsize{14}\\bf++}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Relational5"
+	      SID		      "588:25"
 	      Ports		      [2, 1]
 	      Position		      [240, 93, 285, 137]
+	      ZOrder		      -4
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Relational"
 	      SourceType	      "Xilinx Arithmetic Relational Operator Block"
 	      mode		      "a!=b"
@@ -21374,18 +23193,21 @@ Library {
 	    Block {
 	      BlockType		      SubSystem
 	      Name		      "posedge"
+	      SID		      "588:26"
 	      Tag		      "Rising Edge Detector"
 	      Ports		      [1, 1]
 	      Position		      [85, 37, 130, 63]
+	      ZOrder		      -5
 	      MinAlgLoopOccurrences   off
 	      PropExecContextOutsideSubsystem off
 	      RTWSystemCode	      "Auto"
 	      FunctionWithSeparateData off
 	      Opaque		      off
+	      RequestExecContextInheritance off
 	      MaskHideContents	      off
 	      System {
 		Name			"posedge"
-		Location		[2, 82, 1014, 732]
+		Location		[12, 45, 1072, 930]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -21401,14 +23223,19 @@ Library {
 		Block {
 		  BlockType		  Inport
 		  Name			  "In"
+		  SID			  "588:27"
 		  Position		  [25, 43, 55, 57]
+		  ZOrder		  -1
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Delay"
+		  SID			  "588:28"
 		  Ports			  [1, 1]
 		  Position		  [75, 27, 120, 73]
+		  ZOrder		  -2
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Delay"
 		  SourceType		  "Xilinx Delay Block"
 		  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -21436,8 +23263,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter"
+		  SID			  "588:29"
 		  Ports			  [1, 1]
 		  Position		  [150, 33, 200, 67]
+		  ZOrder		  -3
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -21462,8 +23292,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical"
+		  SID			  "588:30"
 		  Ports			  [2, 1]
 		  Position		  [225, 29, 285, 116]
+		  ZOrder		  -4
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -21494,7 +23327,9 @@ Library {
 		Block {
 		  BlockType		  Outport
 		  Name			  "Out"
+		  SID			  "588:31"
 		  Position		  [305, 63, 335, 77]
+		  ZOrder		  -5
 		  IconDisplay		  "Port number"
 		}
 		Line {
@@ -21536,7 +23371,9 @@ Library {
 	    Block {
 	      BlockType		      Outport
 	      Name		      "out"
+	      SID		      "588:32"
 	      Position		      [325, 108, 355, 122]
+	      ZOrder		      -6
 	      IconDisplay	      "Port number"
 	    }
 	    Line {
@@ -21585,13 +23422,17 @@ Library {
 	Block {
 	  BlockType		  Outport
 	  Name			  "dout"
+	  SID			  "588:33"
 	  Position		  [870, 83, 900, 97]
+	  ZOrder		  -22
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Outport
 	  Name			  "valid"
+	  SID			  "588:34"
 	  Position		  [870, 213, 900, 227]
+	  ZOrder		  -23
 	  Port			  "2"
 	  IconDisplay		  "Port number"
 	}
@@ -21600,20 +23441,6 @@ Library {
 	  SrcPort		  1
 	  DstBlock		  "DSP48E"
 	  DstPort		  3
-	}
-	Line {
-	  SrcBlock		  "Slice"
-	  SrcPort		  1
-	  Points		  [15, 0]
-	  Branch {
-	    DstBlock		    "Reinterpret"
-	    DstPort		    1
-	  }
-	  Branch {
-	    Points		    [0, -70; -670, 0; 0, 25]
-	    DstBlock		    "Convert_AB"
-	    DstPort		    1
-	  }
 	}
 	Line {
 	  SrcBlock		  "Reinterpret"
@@ -21723,12 +23550,6 @@ Library {
 	  DstPort		  1
 	}
 	Line {
-	  SrcBlock		  "DSP48E"
-	  SrcPort		  1
-	  DstBlock		  "Slice_p"
-	  DstPort		  1
-	}
-	Line {
 	  SrcBlock		  "pulse_ext"
 	  SrcPort		  1
 	  Points		  [20, 0]
@@ -21743,7 +23564,7 @@ Library {
 	  }
 	}
 	Line {
-	  SrcBlock		  "Slice_p"
+	  SrcBlock		  "DSP48E"
 	  SrcPort		  1
 	  DstBlock		  "delay_bram"
 	  DstPort		  1
@@ -21751,10 +23572,25 @@ Library {
 	Line {
 	  SrcBlock		  "delay_bram"
 	  SrcPort		  1
-	  DstBlock		  "Slice"
+	  Points		  [19, 0]
+	  Branch {
+	    DstBlock		    "Slice_p"
+	    DstPort		    1
+	  }
+	  Branch {
+	    Points		    [0, -70; -569, 0; 0, 25]
+	    DstBlock		    "Convert_AB"
+	    DstPort		    1
+	  }
+	}
+	Line {
+	  SrcBlock		  "Slice_p"
+	  SrcPort		  1
+	  DstBlock		  "Reinterpret"
 	  DstPort		  1
 	}
 	Annotation {
+	  SID			  "588:35"
 	  Position		  [540, 204]
 	}
       }
@@ -21762,8 +23598,10 @@ Library {
     Block {
       BlockType		      SubSystem
       Name		      "qdr_vacc"
+      SID		      "589"
       Ports		      [6, 7]
       Position		      [310, 20, 475, 180]
+      ZOrder		      -4
       BackgroundColor	      "[1.000000, 0.501961, 0.501961]"
       AttributesFormatString  "Vector Length: 139264"
       MinAlgLoopOccurrences   off
@@ -21771,29 +23609,32 @@ Library {
       RTWSystemCode	      "Auto"
       FunctionWithSeparateData off
       Opaque		      off
+      RequestExecContextInheritance off
       MaskHideContents	      off
-      MaskDescription	      "A vector accumulator for medium length vectors designed for ROACH's QDR memory.\n\nOrigin"
-      "ally designed for the packetised correlator, this block accepts input data of type Fix_32_0. OOB_data_in provide"
-      "s an extra 4 bits that are accumulated seperately (originally designed to keep track of how many \"bad\" values "
-      "in a vector were accumulated).\n\nMinimum vector length is 2 * burst_length.\nMinimum burst length is 10 (recomm"
-      "ended default is 2^4=16).\n\nThe vector length does not need to be a multiple of the burst length.\n"
-      MaskPromptString	      "Vector length??(# cycles)"
-      MaskStyleString	      "edit"
-      MaskVariables	      "vector_len=@1;"
-      MaskTunableValueString  "on"
-      MaskEnableString	      "on"
-      MaskVisibilityString    "on"
-      MaskToolTipString	      "on"
-      MaskInitialization      "vector_bits = ceil(log2(vector_len));\nburst_bits = 4;\nburst_len = 2^burst_bits;\n\nfm"
-      "tstr = sprintf('Vector Length: %d', vector_len);\nset_param(gcb, 'AttributesFormatString', fmtstr);\n"
-      MaskIconFrame	      on
-      MaskIconOpaque	      on
-      MaskIconRotate	      "none"
-      MaskIconUnits	      "autoscale"
-      MaskValueString	      "139264"
+      Object {
+	$PropName		"MaskObject"
+	$ObjectID		65
+	$ClassName		"Simulink.Mask"
+	Description		"A vector accumulator for medium length vectors designed for ROACH's QDR memory.\n\nOriginally designed "
+	"for the packetised correlator, this block accepts input data of type Fix_32_0. OOB_data_in provides an extra 4 bits t"
+	"hat are accumulated seperately (originally designed to keep track of how many \"bad\" values in a vector were accumul"
+	"ated).\n\nMinimum vector length is 2 * burst_length.\nMinimum burst length is 10 (recommended default is 2^4=16).\n\n"
+	"The vector length does not need to be a multiple of the burst length.\n"
+	Initialization		"vector_bits = ceil(log2(vector_len));\nburst_bits = 4;\nburst_len = 2^burst_bits;\n\nfmtstr = sprint"
+	"f('Vector Length: %d', vector_len);\nset_param(gcb, 'AttributesFormatString', fmtstr);\n"
+	Object {
+	  $PropName		  "Parameters"
+	  $ObjectID		  66
+	  $ClassName		  "Simulink.MaskParameter"
+	  Type			  "edit"
+	  Name			  "vector_len"
+	  Prompt		  "Vector length??(# cycles)"
+	  Value			  "139264"
+	}
+      }
       System {
 	Name			"qdr_vacc"
-	Location		[2, 74, 1359, 748]
+	Location		[12, 45, 1417, 954]
 	Open			off
 	ModelBrowserVisibility	off
 	ModelBrowserWidth	200
@@ -21809,50 +23650,65 @@ Library {
 	Block {
 	  BlockType		  Inport
 	  Name			  "n_acum"
+	  SID			  "590"
 	  Position		  [265, 18, 295, 32]
+	  ZOrder		  -1
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Inport
 	  Name			  "sync"
+	  SID			  "591"
 	  Position		  [125, 388, 155, 402]
+	  ZOrder		  -2
 	  Port			  "2"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Inport
 	  Name			  "data_in"
+	  SID			  "592"
 	  Position		  [265, 168, 295, 182]
+	  ZOrder		  -3
 	  Port			  "3"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Inport
 	  Name			  "oob_data_in"
+	  SID			  "593"
 	  Position		  [265, 133, 295, 147]
+	  ZOrder		  -4
 	  Port			  "4"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Inport
 	  Name			  "we"
+	  SID			  "594"
 	  Position		  [265, 203, 295, 217]
+	  ZOrder		  -5
 	  Port			  "5"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Inport
 	  Name			  "re"
+	  SID			  "595"
 	  Position		  [1710, 218, 1740, 232]
+	  ZOrder		  -6
 	  Port			  "6"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "Assert"
+	  SID			  "596"
 	  Ports			  [1, 1]
 	  Position		  [320, 167, 355, 183]
+	  ZOrder		  -7
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Assert"
 	  SourceType		  "Xilinx Assert Block"
 	  infoedit		  "Asserts a user-defined sample rate and/or type on a signal.<P><P>Hardware notes: In hardware this bloc"
@@ -21886,9 +23742,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Assert1"
+	  SID			  "597"
 	  Ports			  [1, 1]
 	  Position		  [320, 132, 355, 148]
+	  ZOrder		  -8
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Assert"
 	  SourceType		  "Xilinx Assert Block"
 	  infoedit		  "Asserts a user-defined sample rate and/or type on a signal.<P><P>Hardware notes: In hardware this bloc"
@@ -21922,9 +23781,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Concat"
+	  SID			  "598"
 	  Ports			  [2, 1]
 	  Position		  [475, 145, 505, 185]
+	  ZOrder		  -9
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Concat"
 	  SourceType		  "Xilinx Bus Concatenator Block"
 	  infoedit		  "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary point at ze"
@@ -21948,9 +23810,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Concat1"
+	  SID			  "599"
 	  Ports			  [2, 1]
 	  Position		  [1705, 110, 1735, 170]
+	  ZOrder		  -10
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Concat"
 	  SourceType		  "Xilinx Bus Concatenator Block"
 	  infoedit		  "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary point at ze"
@@ -21974,9 +23839,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Concat2"
+	  SID			  "600"
 	  Ports			  [14, 1]
 	  Position		  [1170, 554, 1210, 816]
+	  ZOrder		  -11
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Concat"
 	  SourceType		  "Xilinx Bus Concatenator Block"
 	  infoedit		  "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary point at ze"
@@ -22000,9 +23868,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Constant"
+	  SID			  "601"
 	  Ports			  [0, 1]
 	  Position		  [300, 453, 340, 477]
+	  ZOrder		  -12
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Constant"
 	  SourceType		  "Xilinx Constant Block Block"
 	  const			  "vector_len"
@@ -22027,19 +23898,24 @@ Library {
 	  sggui_pos		  "20,20,414,344"
 	  block_type		  "constant"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,24,0,1,white,blue,0,bad77ab0,right"
-	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 ],[0 0 26 26 ],[0.77 0.82 0.91]);\n"
-	  "patch([20 16 22 16 20 27 29 31 38 32 26 22 28 22 26 32 38 31 29 27 20 ],[3 7 13 19 23 23 21 23 23 17 23 19 13 7 3 9"
-	  " 3 3 5 3 3 ],[0.98 0.96 0.92]);\nplot([0 55 55 0 0 ],[0 0 26 26 0 ]);\nfprintf('','COMMENT: end icon graphics');\nf"
-	  "printf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'139264');\nfprintf('','COMMENT: end i"
-	  "con text');\n"
+	  sg_icon_stat		  "40,24,0,1,white,blue,0,43c6a5cd,right,,[ ],[ ]"
+	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 24 24 0 ],[0.77 0.82 0.91"
+	  " ]);\nplot([0 40 40 0 0 ],[0 0 24 24 0 ]);\npatch([13.325 17.66 20.66 23.66 26.66 20.66 16.325 13.325 ],[15.33 15.3"
+	  "3 18.33 15.33 18.33 18.33 18.33 15.33 ],[1 1 1 ]);\npatch([16.325 20.66 17.66 13.325 16.325 ],[12.33 12.33 15.33 15"
+	  ".33 12.33 ],[0.931 0.946 0.973 ]);\npatch([13.325 17.66 20.66 16.325 13.325 ],[9.33 9.33 12.33 12.33 9.33 ],[1 1 1 "
+	  "]);\npatch([16.325 26.66 23.66 20.66 17.66 13.325 16.325 ],[6.33 6.33 9.33 6.33 9.33 9.33 6.33 ],[0.931 0.946 0.973"
+	  " ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label"
+	  "('output',1,'139264');\nfprintf('','COMMENT: end icon text');"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "Constant1"
+	  SID			  "602"
 	  Ports			  [0, 1]
 	  Position		  [300, 548, 340, 572]
+	  ZOrder		  -13
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Constant"
 	  SourceType		  "Xilinx Constant Block Block"
 	  const			  "0"
@@ -22064,19 +23940,24 @@ Library {
 	  sggui_pos		  "20,20,414,344"
 	  block_type		  "constant"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,24,0,1,white,blue,0,72d575a1,right"
-	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 ],[0 0 26 26 ],[0.77 0.82 0.91]);\n"
-	  "patch([20 16 22 16 20 27 29 31 38 32 26 22 28 22 26 32 38 31 29 27 20 ],[3 7 13 19 23 23 21 23 23 17 23 19 13 7 3 9"
-	  " 3 3 5 3 3 ],[0.98 0.96 0.92]);\nplot([0 55 55 0 0 ],[0 0 26 26 0 ]);\nfprintf('','COMMENT: end icon graphics');\nf"
-	  "printf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'0');\nfprintf('','COMMENT: end icon t"
-	  "ext');\n"
+	  sg_icon_stat		  "40,24,0,1,white,blue,0,bf4ddd8b,right,,[ ],[ ]"
+	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 24 24 0 ],[0.77 0.82 0.91"
+	  " ]);\nplot([0 40 40 0 0 ],[0 0 24 24 0 ]);\npatch([13.325 17.66 20.66 23.66 26.66 20.66 16.325 13.325 ],[15.33 15.3"
+	  "3 18.33 15.33 18.33 18.33 18.33 15.33 ],[1 1 1 ]);\npatch([16.325 20.66 17.66 13.325 16.325 ],[12.33 12.33 15.33 15"
+	  ".33 12.33 ],[0.931 0.946 0.973 ]);\npatch([13.325 17.66 20.66 16.325 13.325 ],[9.33 9.33 12.33 12.33 9.33 ],[1 1 1 "
+	  "]);\npatch([16.325 26.66 23.66 20.66 17.66 13.325 16.325 ],[6.33 6.33 9.33 6.33 9.33 9.33 6.33 ],[0.931 0.946 0.973"
+	  " ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label"
+	  "('output',1,'0');\nfprintf('','COMMENT: end icon text');"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "Constant3"
+	  SID			  "603"
 	  Ports			  [0, 1]
 	  Position		  [1290, 224, 1305, 236]
+	  ZOrder		  -14
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Constant"
 	  SourceType		  "Xilinx Constant Block Block"
 	  const			  "(2^4)-1"
@@ -22113,9 +23994,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Convert1"
+	  SID			  "604"
 	  Ports			  [1, 1]
 	  Position		  [1665, 115, 1685, 135]
+	  ZOrder		  -15
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Convert"
 	  SourceType		  "Xilinx Type Converter Block"
 	  infoedit		  "Hardware notes: rounding and saturating require hardware resources; truncating and wrapping do not."
@@ -22150,9 +24034,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay2"
+	  SID			  "605"
 	  Ports			  [1, 1]
 	  Position		  [1455, 257, 1480, 273]
+	  ZOrder		  -16
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -22180,9 +24067,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay3"
+	  SID			  "606"
 	  Ports			  [1, 1]
 	  Position		  [1455, 292, 1480, 308]
+	  ZOrder		  -17
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -22210,7 +24100,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From"
+	  SID			  "607"
 	  Position		  [955, 293, 1015, 307]
+	  ZOrder		  -18
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "qdr_data"
@@ -22218,7 +24110,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From1"
+	  SID			  "608"
 	  Position		  [980, 788, 1040, 802]
+	  ZOrder		  -19
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "input_overflow"
@@ -22226,7 +24120,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From10"
+	  SID			  "609"
 	  Position		  [1580, 148, 1640, 162]
+	  ZOrder		  -20
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "qdr_data"
@@ -22234,7 +24130,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From11"
+	  SID			  "610"
 	  Position		  [780, 88, 840, 102]
+	  ZOrder		  -21
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "in_burst_rdy"
@@ -22242,7 +24140,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From12"
+	  SID			  "611"
 	  Position		  [1230, 428, 1290, 442]
+	  ZOrder		  -22
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "qdr_data"
@@ -22250,7 +24150,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From13"
+	  SID			  "612"
 	  Position		  [1230, 443, 1290, 457]
+	  ZOrder		  -23
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "in_data"
@@ -22258,7 +24160,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From14"
+	  SID			  "613"
 	  Position		  [1590, 358, 1650, 372]
+	  ZOrder		  -24
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "qdr_data"
@@ -22266,7 +24170,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From15"
+	  SID			  "614"
 	  Position		  [1290, 458, 1350, 472]
+	  ZOrder		  -25
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "acc_data"
@@ -22274,7 +24180,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From16"
+	  SID			  "615"
 	  Position		  [1230, 488, 1290, 502]
+	  ZOrder		  -26
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "qdr_rd_en"
@@ -22282,7 +24190,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From17"
+	  SID			  "616"
 	  Position		  [1230, 503, 1290, 517]
+	  ZOrder		  -27
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "fifo_rd_en"
@@ -22290,7 +24200,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From18"
+	  SID			  "617"
 	  Position		  [1290, 473, 1350, 487]
+	  ZOrder		  -28
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "qdr_wr_en"
@@ -22298,7 +24210,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From19"
+	  SID			  "618"
 	  Position		  [1230, 518, 1290, 532]
+	  ZOrder		  -29
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "qdr_valid"
@@ -22306,7 +24220,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From2"
+	  SID			  "619"
 	  Position		  [520, 228, 580, 242]
+	  ZOrder		  -30
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "fifo_rd_en"
@@ -22314,7 +24230,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From20"
+	  SID			  "620"
 	  Position		  [955, 193, 1015, 207]
+	  ZOrder		  -31
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "output_full"
@@ -22322,7 +24240,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From21"
+	  SID			  "621"
 	  Position		  [1880, 393, 1940, 407]
+	  ZOrder		  -32
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "input_overflow"
@@ -22330,7 +24250,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From22"
+	  SID			  "622"
 	  Position		  [400, 218, 460, 232]
+	  ZOrder		  -33
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "phy_rdy"
@@ -22338,7 +24260,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From23"
+	  SID			  "623"
 	  Position		  [955, 318, 1015, 332]
+	  ZOrder		  -34
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "blank"
@@ -22346,7 +24270,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From24"
+	  SID			  "624"
 	  Position		  [1230, 533, 1290, 547]
+	  ZOrder		  -35
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "blank"
@@ -22354,7 +24280,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From25"
+	  SID			  "625"
 	  Position		  [1590, 373, 1650, 387]
+	  ZOrder		  -36
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "rb_en"
@@ -22362,7 +24290,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From26"
+	  SID			  "626"
 	  Position		  [780, 58, 840, 72]
+	  ZOrder		  -37
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "acc_len"
@@ -22370,7 +24300,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From27"
+	  SID			  "627"
 	  Position		  [1530, 418, 1590, 432]
+	  ZOrder		  -38
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "qdr_rd_en"
@@ -22378,7 +24310,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From28"
+	  SID			  "628"
 	  Position		  [1590, 403, 1650, 417]
+	  ZOrder		  -39
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "rb_done"
@@ -22386,7 +24320,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From29"
+	  SID			  "629"
 	  Position		  [1530, 388, 1590, 402]
+	  ZOrder		  -40
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "qdr_addr"
@@ -22394,7 +24330,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From3"
+	  SID			  "630"
 	  Position		  [955, 268, 1015, 282]
+	  ZOrder		  -41
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "in_data"
@@ -22402,7 +24340,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From30"
+	  SID			  "631"
 	  Position		  [1590, 448, 1650, 462]
+	  ZOrder		  -42
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "qdr_valid"
@@ -22410,7 +24350,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From31"
+	  SID			  "632"
 	  Position		  [1590, 433, 1650, 447]
+	  ZOrder		  -43
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "output_full"
@@ -22418,7 +24360,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From32"
+	  SID			  "633"
 	  Position		  [460, 58, 520, 72]
+	  ZOrder		  -44
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "acc_len"
@@ -22426,7 +24370,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From33"
+	  SID			  "634"
 	  Position		  [980, 648, 1040, 662]
+	  ZOrder		  -45
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "qdr_valid"
@@ -22434,7 +24380,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From34"
+	  SID			  "635"
 	  Position		  [955, 233, 1015, 247]
+	  ZOrder		  -46
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "rst"
@@ -22442,7 +24390,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From35"
+	  SID			  "636"
 	  Position		  [1290, 548, 1350, 562]
+	  ZOrder		  -47
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "qdr_addr"
@@ -22450,7 +24400,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From36"
+	  SID			  "637"
 	  Position		  [780, 118, 840, 132]
+	  ZOrder		  -48
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "rst"
@@ -22458,7 +24410,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From37"
+	  SID			  "638"
 	  Position		  [1880, 408, 1940, 422]
+	  ZOrder		  -49
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "rst"
@@ -22466,7 +24420,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From38"
+	  SID			  "639"
 	  Position		  [205, 443, 265, 457]
+	  ZOrder		  -50
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "valid_in"
@@ -22474,7 +24430,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From39"
+	  SID			  "640"
 	  Position		  [980, 768, 1040, 782]
+	  ZOrder		  -51
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "in_burst_rdy"
@@ -22482,7 +24440,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From4"
+	  SID			  "641"
 	  Position		  [780, 103, 840, 117]
+	  ZOrder		  -52
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "fifo_rd_en"
@@ -22490,7 +24450,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From40"
+	  SID			  "642"
 	  Position		  [980, 748, 1040, 762]
+	  ZOrder		  -53
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "fifo_rd_en"
@@ -22498,7 +24460,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From41"
+	  SID			  "643"
 	  Position		  [980, 728, 1040, 742]
+	  ZOrder		  -54
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "cal_fail"
@@ -22506,7 +24470,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From42"
+	  SID			  "644"
 	  Position		  [980, 808, 1040, 822]
+	  ZOrder		  -55
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "rst"
@@ -22514,7 +24480,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From43"
+	  SID			  "645"
 	  Position		  [980, 708, 1040, 722]
+	  ZOrder		  -56
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "rb_done"
@@ -22522,7 +24490,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From44"
+	  SID			  "646"
 	  Position		  [980, 688, 1040, 702]
+	  ZOrder		  -57
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "output_full"
@@ -22530,7 +24500,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From45"
+	  SID			  "647"
 	  Position		  [980, 668, 1040, 682]
+	  ZOrder		  -58
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "phy_rdy"
@@ -22538,7 +24510,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From46"
+	  SID			  "648"
 	  Position		  [980, 628, 1040, 642]
+	  ZOrder		  -59
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "rb_en"
@@ -22546,7 +24520,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From47"
+	  SID			  "649"
 	  Position		  [980, 608, 1040, 622]
+	  ZOrder		  -60
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "valid_in"
@@ -22554,7 +24530,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From48"
+	  SID			  "650"
 	  Position		  [980, 588, 1040, 602]
+	  ZOrder		  -61
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "qdr_rd_en"
@@ -22562,7 +24540,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From49"
+	  SID			  "651"
 	  Position		  [980, 568, 1040, 582]
+	  ZOrder		  -62
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "out_ack"
@@ -22570,7 +24550,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From5"
+	  SID			  "652"
 	  Position		  [955, 153, 1015, 167]
+	  ZOrder		  -63
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "acc_len"
@@ -22578,7 +24560,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From50"
+	  SID			  "653"
 	  Position		  [980, 548, 1040, 562]
+	  ZOrder		  -64
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "output_over"
@@ -22586,7 +24570,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From51"
+	  SID			  "654"
 	  Position		  [1880, 423, 1940, 437]
+	  ZOrder		  -65
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "output_over"
@@ -22594,7 +24580,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From52"
+	  SID			  "655"
 	  Position		  [550, 258, 580, 272]
+	  ZOrder		  -66
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "rst"
@@ -22602,7 +24590,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From53"
+	  SID			  "656"
 	  Position		  [460, 88, 520, 102]
+	  ZOrder		  -67
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "rst"
@@ -22610,7 +24600,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From54"
+	  SID			  "657"
 	  Position		  [1620, 248, 1660, 262]
+	  ZOrder		  -68
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "rst"
@@ -22618,7 +24610,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From55"
+	  SID			  "658"
 	  Position		  [1885, 173, 1945, 187]
+	  ZOrder		  -69
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "out_ack"
@@ -22626,7 +24620,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From56"
+	  SID			  "659"
 	  Position		  [520, 388, 580, 402]
+	  ZOrder		  -70
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "unbuf_in_data"
@@ -22634,7 +24630,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From57"
+	  SID			  "660"
 	  Position		  [1230, 563, 1290, 577]
+	  ZOrder		  -71
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "new_acc"
@@ -22642,7 +24640,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From59"
+	  SID			  "661"
 	  Position		  [1885, 498, 1945, 512]
+	  ZOrder		  -72
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "new_acc"
@@ -22650,7 +24650,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From6"
+	  SID			  "662"
 	  Position		  [955, 113, 1015, 127]
+	  ZOrder		  -73
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "in_burst_rdy"
@@ -22658,7 +24660,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From7"
+	  SID			  "663"
 	  Position		  [1580, 118, 1640, 132]
+	  ZOrder		  -74
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "rb_done"
@@ -22666,7 +24670,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From8"
+	  SID			  "664"
 	  Position		  [1675, 188, 1735, 202]
+	  ZOrder		  -75
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "rb_en"
@@ -22674,7 +24680,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From9"
+	  SID			  "665"
 	  Position		  [1880, 378, 1940, 392]
+	  ZOrder		  -76
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "cal_fail"
@@ -22682,25 +24690,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out1"
+	  SID			  "666"
 	  Ports			  [1, 1]
 	  Position		  [580, 71, 620, 79]
+	  ZOrder		  -77
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -22712,25 +24726,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out10"
+	  SID			  "667"
 	  Ports			  [1, 1]
 	  Position		  [860, 121, 900, 129]
+	  ZOrder		  -78
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -22742,25 +24762,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out11"
+	  SID			  "668"
 	  Ports			  [1, 1]
 	  Position		  [1380, 491, 1420, 499]
+	  ZOrder		  -79
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -22772,25 +24798,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out12"
+	  SID			  "669"
 	  Ports			  [1, 1]
 	  Position		  [1380, 476, 1420, 484]
+	  ZOrder		  -80
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -22802,25 +24834,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out13"
+	  SID			  "670"
 	  Ports			  [1, 1]
 	  Position		  [1680, 421, 1720, 429]
+	  ZOrder		  -81
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -22832,25 +24870,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out14"
+	  SID			  "671"
 	  Ports			  [1, 1]
 	  Position		  [1380, 446, 1420, 454]
+	  ZOrder		  -82
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -22862,25 +24906,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out15"
+	  SID			  "672"
 	  Ports			  [1, 1]
 	  Position		  [1380, 431, 1420, 439]
+	  ZOrder		  -83
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -22892,25 +24942,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out16"
+	  SID			  "673"
 	  Ports			  [1, 1]
 	  Position		  [1380, 461, 1420, 469]
+	  ZOrder		  -84
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -22922,25 +24978,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out17"
+	  SID			  "674"
 	  Ports			  [1, 1]
 	  Position		  [1680, 406, 1720, 414]
+	  ZOrder		  -85
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -22952,25 +25014,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out18"
+	  SID			  "675"
 	  Ports			  [1, 1]
 	  Position		  [1380, 551, 1420, 559]
+	  ZOrder		  -86
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -22982,25 +25050,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out19"
+	  SID			  "676"
 	  Ports			  [1, 1]
 	  Position		  [1380, 521, 1420, 529]
+	  ZOrder		  -87
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23012,25 +25086,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out2"
+	  SID			  "677"
 	  Ports			  [1, 1]
 	  Position		  [580, 61, 620, 69]
+	  ZOrder		  -88
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23042,25 +25122,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out20"
+	  SID			  "678"
 	  Ports			  [1, 1]
 	  Position		  [1680, 376, 1720, 384]
+	  ZOrder		  -89
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23072,25 +25158,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out21"
+	  SID			  "679"
 	  Ports			  [1, 1]
 	  Position		  [1680, 361, 1720, 369]
+	  ZOrder		  -90
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23102,25 +25194,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out22"
+	  SID			  "680"
 	  Ports			  [1, 1]
 	  Position		  [1380, 506, 1420, 514]
+	  ZOrder		  -91
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23132,25 +25230,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out23"
+	  SID			  "681"
 	  Ports			  [1, 1]
 	  Position		  [1680, 391, 1720, 399]
+	  ZOrder		  -92
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23162,25 +25266,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out24"
+	  SID			  "682"
 	  Ports			  [1, 1]
 	  Position		  [605, 371, 645, 379]
+	  ZOrder		  -93
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23192,25 +25302,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out25"
+	  SID			  "683"
 	  Ports			  [1, 1]
 	  Position		  [1680, 451, 1720, 459]
+	  ZOrder		  -94
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23222,25 +25338,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out26"
+	  SID			  "684"
 	  Ports			  [1, 1]
 	  Position		  [1680, 436, 1720, 444]
+	  ZOrder		  -95
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23252,25 +25374,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out27"
+	  SID			  "685"
 	  Ports			  [1, 1]
 	  Position		  [860, 106, 900, 114]
+	  ZOrder		  -96
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23282,25 +25410,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out28"
+	  SID			  "686"
 	  Ports			  [1, 1]
 	  Position		  [1380, 536, 1420, 544]
+	  ZOrder		  -97
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23312,25 +25446,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out29"
+	  SID			  "687"
 	  Ports			  [1, 1]
 	  Position		  [605, 361, 645, 369]
+	  ZOrder		  -98
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23342,25 +25482,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out3"
+	  SID			  "688"
 	  Ports			  [1, 1]
 	  Position		  [580, 81, 620, 89]
+	  ZOrder		  -99
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23372,25 +25518,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out30"
+	  SID			  "689"
 	  Ports			  [1, 1]
 	  Position		  [605, 381, 645, 389]
+	  ZOrder		  -100
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23402,25 +25554,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out31"
+	  SID			  "690"
 	  Ports			  [1, 1]
 	  Position		  [580, 91, 620, 99]
+	  ZOrder		  -101
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23432,25 +25590,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out32"
+	  SID			  "691"
 	  Ports			  [1, 1]
 	  Position		  [605, 391, 645, 399]
+	  ZOrder		  -102
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23462,25 +25626,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out33"
+	  SID			  "692"
 	  Ports			  [1, 1]
 	  Position		  [1380, 566, 1420, 574]
+	  ZOrder		  -103
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23492,25 +25662,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out4"
+	  SID			  "693"
 	  Ports			  [1, 1]
 	  Position		  [860, 76, 900, 84]
+	  ZOrder		  -104
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23522,25 +25698,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out5"
+	  SID			  "694"
 	  Ports			  [1, 1]
 	  Position		  [1240, 36, 1280, 44]
+	  ZOrder		  -105
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23552,25 +25734,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out6"
+	  SID			  "695"
 	  Ports			  [1, 1]
 	  Position		  [1240, 26, 1280, 34]
+	  ZOrder		  -106
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23582,25 +25770,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out7"
+	  SID			  "696"
 	  Ports			  [1, 1]
 	  Position		  [1240, 46, 1280, 54]
+	  ZOrder		  -107
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23612,25 +25806,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out8"
+	  SID			  "697"
 	  Ports			  [1, 1]
 	  Position		  [860, 61, 900, 69]
+	  ZOrder		  -108
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23642,25 +25842,31 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Gateway Out9"
+	  SID			  "698"
 	  Ports			  [1, 1]
 	  Position		  [860, 91, 900, 99]
+	  ZOrder		  -109
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Gateway Out"
 	  SourceType		  "Xilinx Gateway Out Block"
 	  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, o"
 	  "r fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, depen"
 	  "ding on how they are configured."
+	  inherit_from_input	  off
 	  hdl_port		  off
 	  timing_constraint	  "None"
 	  locs_specified	  off
 	  LOCs			  "{}"
+	  UseAsDAC		  off
+	  DACChannel		  "'1'"
 	  xl_use_area		  off
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  has_advanced_control	  "0"
 	  sggui_pos		  "20,20,336,384"
 	  block_type		  "gatewayout"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 ]"
 	  ");\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6.11"
 	  " 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0.96"
@@ -23672,193 +25878,219 @@ Library {
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto"
+	  SID			  "699"
 	  Position		  [1500, 153, 1565, 167]
+	  ZOrder		  -110
 	  ShowName		  off
 	  GotoTag		  "qdr_data"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto1"
+	  SID			  "700"
 	  Position		  [1200, 163, 1265, 177]
+	  ZOrder		  -111
 	  ShowName		  off
 	  GotoTag		  "fifo_rd_en"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto10"
+	  SID			  "701"
 	  Position		  [1315, 88, 1380, 102]
+	  ZOrder		  -112
 	  ShowName		  off
 	  GotoTag		  "qdr_wr_en"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto11"
+	  SID			  "702"
 	  Position		  [1500, 188, 1565, 202]
+	  ZOrder		  -113
 	  ShowName		  off
 	  GotoTag		  "qdr_valid"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto12"
+	  SID			  "703"
 	  Position		  [1935, 218, 2000, 232]
+	  ZOrder		  -114
 	  ShowName		  off
 	  GotoTag		  "output_full"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto13"
+	  SID			  "704"
 	  Position		  [1500, 293, 1565, 307]
+	  ZOrder		  -115
 	  ShowName		  off
 	  GotoTag		  "cal_fail"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto14"
+	  SID			  "705"
 	  Position		  [755, 258, 820, 272]
+	  ZOrder		  -116
 	  ShowName		  off
 	  GotoTag		  "input_overflow"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto15"
+	  SID			  "706"
 	  Position		  [1500, 258, 1565, 272]
+	  ZOrder		  -117
 	  ShowName		  off
 	  GotoTag		  "phy_rdy"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto16"
+	  SID			  "707"
 	  Position		  [1200, 223, 1265, 237]
+	  ZOrder		  -118
 	  ShowName		  off
 	  GotoTag		  "blank"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto17"
+	  SID			  "708"
 	  Position		  [1315, 73, 1380, 87]
+	  ZOrder		  -119
 	  ShowName		  off
 	  GotoTag		  "qdr_addr"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto18"
+	  SID			  "709"
 	  Position		  [350, 18, 415, 32]
+	  ZOrder		  -120
 	  ShowName		  off
 	  GotoTag		  "acc_len"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto19"
+	  SID			  "710"
 	  Position		  [525, 178, 590, 192]
+	  ZOrder		  -121
 	  ShowName		  off
 	  GotoTag		  "valid_in"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto2"
+	  SID			  "711"
 	  Position		  [800, 168, 865, 182]
+	  ZOrder		  -122
 	  ShowName		  off
 	  GotoTag		  "in_data"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto20"
+	  SID			  "712"
 	  Position		  [1935, 248, 2000, 262]
+	  ZOrder		  -123
 	  ShowName		  off
 	  GotoTag		  "output_over"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto21"
+	  SID			  "713"
 	  Position		  [435, 188, 500, 202]
+	  ZOrder		  -124
 	  ShowName		  off
 	  GotoTag		  "unbuf_in_data"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto22"
+	  SID			  "714"
 	  Position		  [1200, 243, 1265, 257]
+	  ZOrder		  -125
 	  ShowName		  off
 	  GotoTag		  "new_acc"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto3"
+	  SID			  "715"
 	  Position		  [645, 438, 710, 452]
+	  ZOrder		  -126
 	  ShowName		  off
 	  GotoTag		  "rst"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto4"
+	  SID			  "716"
 	  Position		  [800, 228, 865, 242]
+	  ZOrder		  -127
 	  ShowName		  off
 	  GotoTag		  "in_burst_rdy"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto5"
+	  SID			  "717"
 	  Position		  [1200, 183, 1265, 197]
+	  ZOrder		  -128
 	  ShowName		  off
 	  GotoTag		  "rb_done"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto6"
+	  SID			  "718"
 	  Position		  [1200, 203, 1265, 217]
+	  ZOrder		  -129
 	  ShowName		  off
 	  GotoTag		  "rb_en"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto7"
+	  SID			  "719"
 	  Position		  [1775, 288, 1840, 302]
+	  ZOrder		  -130
 	  ShowName		  off
 	  GotoTag		  "out_ack"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto8"
+	  SID			  "720"
 	  Position		  [1230, 318, 1295, 332]
+	  ZOrder		  -131
 	  ShowName		  off
 	  GotoTag		  "acc_data"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto9"
+	  SID			  "721"
 	  Position		  [1315, 103, 1380, 117]
+	  ZOrder		  -132
 	  ShowName		  off
 	  GotoTag		  "qdr_rd_en"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "Inverter"
+	  SID			  "722"
 	  Ports			  [1, 1]
 	  Position		  [500, 444, 525, 456]
+	  ZOrder		  -133
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Inverter"
 	  SourceType		  "Xilinx Inverter Block"
 	  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -23883,9 +26115,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Inverter1"
+	  SID			  "723"
 	  Ports			  [1, 1]
 	  Position		  [1885, 189, 1910, 201]
+	  ZOrder		  -134
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Inverter"
 	  SourceType		  "Xilinx Inverter Block"
 	  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -23910,9 +26145,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Logical1"
+	  SID			  "724"
 	  Ports			  [4, 1]
 	  Position		  [1965, 377, 1995, 438]
+	  ZOrder		  -135
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Logical"
 	  SourceType		  "Xilinx Logical Block Block"
 	  logical_function	  "OR"
@@ -23943,9 +26181,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Logical2"
+	  SID			  "725"
 	  Ports			  [2, 1]
 	  Position		  [475, 201, 505, 234]
+	  ZOrder		  -136
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Logical"
 	  SourceType		  "Xilinx Logical Block Block"
 	  logical_function	  "AND"
@@ -23976,9 +26217,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Logical3"
+	  SID			  "726"
 	  Ports			  [2, 1]
 	  Position		  [545, 426, 575, 459]
+	  ZOrder		  -137
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Logical"
 	  SourceType		  "Xilinx Logical Block Block"
 	  logical_function	  "AND"
@@ -24009,9 +26253,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Logical4"
+	  SID			  "727"
 	  Ports			  [2, 1]
 	  Position		  [205, 401, 245, 439]
+	  ZOrder		  -138
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Logical"
 	  SourceType		  "Xilinx Logical Block Block"
 	  logical_function	  "OR"
@@ -24042,9 +26289,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Logical5"
+	  SID			  "728"
 	  Ports			  [2, 1]
 	  Position		  [440, 441, 470, 474]
+	  ZOrder		  -139
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Logical"
 	  SourceType		  "Xilinx Logical Block Block"
 	  logical_function	  "OR"
@@ -24075,9 +26325,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Logical6"
+	  SID			  "729"
 	  Ports			  [2, 1]
 	  Position		  [1965, 171, 1995, 204]
+	  ZOrder		  -140
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Logical"
 	  SourceType		  "Xilinx Logical Block Block"
 	  logical_function	  "AND"
@@ -24108,9 +26361,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Reinterpret"
+	  SID			  "730"
 	  Ports			  [1, 1]
 	  Position		  [375, 167, 410, 183]
+	  ZOrder		  -141
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Reinterpret"
 	  SourceType		  "Xilinx Type Reinterpreter Block"
 	  infoedit		  "Changes signal type without altering the binary representation.   You can changed the signal between s"
@@ -24138,9 +26394,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Reinterpret1"
+	  SID			  "731"
 	  Ports			  [1, 1]
 	  Position		  [375, 132, 410, 148]
+	  ZOrder		  -142
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Reinterpret"
 	  SourceType		  "Xilinx Type Reinterpreter Block"
 	  infoedit		  "Changes signal type without altering the binary representation.   You can changed the signal between s"
@@ -24168,9 +26427,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Reinterpret2"
+	  SID			  "732"
 	  Ports			  [1, 1]
 	  Position		  [1945, 112, 1980, 128]
+	  ZOrder		  -143
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Reinterpret"
 	  SourceType		  "Xilinx Type Reinterpreter Block"
 	  infoedit		  "Changes signal type without altering the binary representation.   You can changed the signal between s"
@@ -24198,9 +26460,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Relational"
+	  SID			  "733"
 	  Ports			  [2, 1]
 	  Position		  [365, 414, 405, 481]
+	  ZOrder		  -144
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Relational"
 	  SourceType		  "Xilinx Arithmetic Relational Operator Block"
 	  mode			  "a>=b"
@@ -24226,9 +26491,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Relational1"
+	  SID			  "734"
 	  Ports			  [2, 1]
 	  Position		  [365, 509, 405, 576]
+	  ZOrder		  -145
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Relational"
 	  SourceType		  "Xilinx Arithmetic Relational Operator Block"
 	  mode			  "a=b"
@@ -24254,9 +26522,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Slice1"
+	  SID			  "735"
 	  Ports			  [1, 1]
 	  Position		  [1895, 111, 1925, 129]
+	  ZOrder		  -146
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Slice"
 	  SourceType		  "Xilinx Bit Slice Extractor Block"
 	  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type "
@@ -24286,9 +26557,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Slice15"
+	  SID			  "736"
 	  Ports			  [1, 1]
 	  Position		  [750, 230, 770, 240]
+	  ZOrder		  -147
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Slice"
 	  SourceType		  "Xilinx Bit Slice Extractor Block"
 	  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type "
@@ -24318,9 +26592,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Slice2"
+	  SID			  "737"
 	  Ports			  [1, 1]
 	  Position		  [1895, 51, 1925, 69]
+	  ZOrder		  -148
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Slice"
 	  SourceType		  "Xilinx Bit Slice Extractor Block"
 	  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type "
@@ -24350,9 +26627,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Slice3"
+	  SID			  "738"
 	  Ports			  [1, 1]
 	  Position		  [1880, 220, 1900, 230]
+	  ZOrder		  -149
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Slice"
 	  SourceType		  "Xilinx Bit Slice Extractor Block"
 	  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type "
@@ -24382,9 +26662,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Slice5"
+	  SID			  "739"
 	  Ports			  [1, 1]
 	  Position		  [1895, 81, 1925, 99]
+	  ZOrder		  -150
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Slice"
 	  SourceType		  "Xilinx Bit Slice Extractor Block"
 	  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type "
@@ -24414,35 +26697,44 @@ Library {
 	Block {
 	  BlockType		  Terminator
 	  Name			  "Terminator"
+	  SID			  "740"
 	  Position		  [1465, 220, 1485, 240]
+	  ZOrder		  -151
 	  ShowName		  off
 	}
 	Block {
 	  BlockType		  Terminator
 	  Name			  "Terminator1"
+	  SID			  "741"
 	  Position		  [755, 195, 775, 215]
+	  ZOrder		  -152
 	  ShowName		  off
 	}
 	Block {
 	  BlockType		  Terminator
 	  Name			  "Terminator4"
+	  SID			  "742"
 	  Position		  [1425, 675, 1445, 695]
+	  ZOrder		  -153
 	  ShowName		  off
 	}
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "acc"
+	  SID			  "743"
 	  Ports			  [3, 1]
 	  Position		  [1040, 262, 1170, 338]
+	  ZOrder		  -154
 	  MinAlgLoopOccurrences	  off
 	  PropExecContextOutsideSubsystem off
 	  RTWSystemCode		  "Auto"
 	  FunctionWithSeparateData off
 	  Opaque		  off
+	  RequestExecContextInheritance	off
 	  MaskHideContents	  off
 	  System {
 	    Name		    "acc"
-	    Location		    [650, 483, 1257, 867]
+	    Location		    [616, 364, 1271, 983]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -24458,29 +26750,38 @@ Library {
 	    Block {
 	      BlockType		      Inport
 	      Name		      "a"
+	      SID		      "744"
 	      Position		      [25, 138, 55, 152]
+	      ZOrder		      -1
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "b"
+	      SID		      "745"
 	      Position		      [25, 273, 55, 287]
+	      ZOrder		      -2
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "blank_b"
+	      SID		      "746"
 	      Position		      [25, 233, 55, 247]
+	      ZOrder		      -3
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "AddSub4"
+	      SID		      "747"
 	      Ports		      [2, 1]
 	      Position		      [300, 135, 350, 170]
+	      ZOrder		      -4
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/AddSub"
 	      SourceType	      "Xilinx Adder/Subtracter Block"
 	      mode		      "Addition"
@@ -24519,9 +26820,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "AddSub5"
+	      SID		      "748"
 	      Ports		      [2, 1]
 	      Position		      [300, 185, 350, 220]
+	      ZOrder		      -5
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/AddSub"
 	      SourceType	      "Xilinx Adder/Subtracter Block"
 	      mode		      "Addition"
@@ -24560,9 +26864,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Concat1v1"
+	      SID		      "749"
 	      Ports		      [2, 1]
 	      Position		      [415, 130, 455, 230]
+	      ZOrder		      -6
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Concat"
 	      SourceType	      "Xilinx Bus Concatenator Block"
 	      infoedit		      "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary poi"
@@ -24586,9 +26893,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Constant3"
+	      SID		      "750"
 	      Ports		      [0, 1]
 	      Position		      [70, 314, 85, 326]
+	      ZOrder		      -7
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Constant"
 	      SourceType	      "Xilinx Constant Block Block"
 	      const		      "0"
@@ -24625,9 +26935,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret"
+	      SID		      "751"
 	      Ports		      [1, 1]
 	      Position		      [245, 137, 280, 153]
+	      ZOrder		      -8
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -24655,9 +26968,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret1"
+	      SID		      "752"
 	      Ports		      [1, 1]
 	      Position		      [245, 187, 280, 203]
+	      ZOrder		      -9
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -24685,9 +27001,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret4"
+	      SID		      "753"
 	      Ports		      [1, 1]
 	      Position		      [245, 152, 280, 168]
+	      ZOrder		      -10
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -24715,9 +27034,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret5"
+	      SID		      "754"
 	      Ports		      [1, 1]
 	      Position		      [245, 202, 280, 218]
+	      ZOrder		      -11
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -24745,9 +27067,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret8"
+	      SID		      "755"
 	      Ports		      [1, 1]
 	      Position		      [375, 147, 395, 163]
+	      ZOrder		      -12
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -24775,9 +27100,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Reinterpret9"
+	      SID		      "756"
 	      Ports		      [1, 1]
 	      Position		      [375, 197, 395, 213]
+	      ZOrder		      -13
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Reinterpret"
 	      SourceType	      "Xilinx Type Reinterpreter Block"
 	      infoedit		      "Changes signal type without altering the binary representation.   You can changed the signal b"
@@ -24805,9 +27133,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice1"
+	      SID		      "757"
 	      Ports		      [1, 1]
 	      Position		      [175, 151, 225, 169]
+	      ZOrder		      -14
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -24837,9 +27168,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice15"
+	      SID		      "758"
 	      Ports		      [1, 1]
 	      Position		      [175, 136, 225, 154]
+	      ZOrder		      -15
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -24869,9 +27203,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice16"
+	      SID		      "759"
 	      Ports		      [1, 1]
 	      Position		      [175, 187, 225, 203]
+	      ZOrder		      -16
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -24901,9 +27238,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice2"
+	      SID		      "760"
 	      Ports		      [1, 1]
 	      Position		      [175, 202, 225, 218]
+	      ZOrder		      -17
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -24933,8 +27273,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "rd_addr_sel"
+	      SID		      "761"
 	      Ports		      [3, 1]
 	      Position		      [105, 216, 135, 344]
+	      ZOrder		      -18
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Mux"
 	      SourceType	      "Xilinx Bus Multiplexer Block"
 	      inputs		      "2"
@@ -24967,7 +27310,9 @@ Library {
 	    Block {
 	      BlockType		      Outport
 	      Name		      "Out"
+	      SID		      "762"
 	      Position		      [480, 173, 510, 187]
+	      ZOrder		      -19
 	      IconDisplay	      "Port number"
 	    }
 	    Line {
@@ -25099,31 +27444,52 @@ Library {
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "acc_ctrl"
+	  SID			  "763"
 	  Ports			  [4, 8]
 	  Position		  [1045, 104, 1170, 256]
+	  ZOrder		  -155
 	  MinAlgLoopOccurrences	  off
 	  PropExecContextOutsideSubsystem off
 	  RTWSystemCode		  "Auto"
 	  FunctionWithSeparateData off
 	  Opaque		  off
+	  RequestExecContextInheritance	off
 	  MaskHideContents	  off
-	  MaskDescription	  "QDR delay must be odd (9 is ok, 11 is ok, 10 is not)."
-	  MaskPromptString	  "delay qdr|delay_in_fifo|delay_adder"
-	  MaskStyleString	  "edit,edit,edit"
-	  MaskVariables		  "delay_qdr=@1;delay_in_fifo=@2;delay_adder=@3;"
-	  MaskTunableValueString  "on,on,on"
-	  MaskCallbackString	  "||"
-	  MaskEnableString	  "on,on,on"
-	  MaskVisibilityString	  "on,on,on"
-	  MaskToolTipString	  "on,on,on"
-	  MaskIconFrame		  on
-	  MaskIconOpaque	  on
-	  MaskIconRotate	  "none"
-	  MaskIconUnits		  "autoscale"
-	  MaskValueString	  "11|1|2"
+	  Object {
+	    $PropName		    "MaskObject"
+	    $ObjectID		    67
+	    $ClassName		    "Simulink.Mask"
+	    Description		    "QDR delay must be odd (9 is ok, 11 is ok, 10 is not)."
+	    Array {
+	      Type		      "Simulink.MaskParameter"
+	      Dimension		      3
+	      Object {
+		$ObjectID		68
+		Type			"edit"
+		Name			"delay_qdr"
+		Prompt			"delay qdr"
+		Value			"11"
+	      }
+	      Object {
+		$ObjectID		69
+		Type			"edit"
+		Name			"delay_in_fifo"
+		Prompt			"delay_in_fifo"
+		Value			"1"
+	      }
+	      Object {
+		$ObjectID		70
+		Type			"edit"
+		Name			"delay_adder"
+		Prompt			"delay_adder"
+		Value			"2"
+	      }
+	      PropName		      "Parameters"
+	    }
+	  }
 	  System {
 	    Name		    "acc_ctrl"
-	    Location		    [2, 70, 1367, 744]
+	    Location		    [12, 45, 1425, 954]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -25139,36 +27505,47 @@ Library {
 	    Block {
 	      BlockType		      Inport
 	      Name		      "input_burst_rdy"
+	      SID		      "764"
 	      Position		      [55, 213, 85, 227]
+	      ZOrder		      -1
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "acc_len"
+	      SID		      "765"
 	      Position		      [270, 693, 300, 707]
+	      ZOrder		      -2
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "output_fifo_full"
+	      SID		      "766"
 	      Position		      [645, 773, 675, 787]
+	      ZOrder		      -3
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "rst"
+	      SID		      "767"
 	      Position		      [420, 698, 450, 712]
+	      ZOrder		      -4
 	      Port		      "4"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Assert"
+	      SID		      "768"
 	      Ports		      [1, 1]
 	      Position		      [290, 397, 315, 413]
+	      ZOrder		      -5
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Assert"
 	      SourceType	      "Xilinx Assert Block"
 	      infoedit		      "Asserts a user-defined sample rate and/or type on a signal.<P><P>Hardware notes: In hardware t"
@@ -25202,9 +27579,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Concat"
+	      SID		      "769"
 	      Ports		      [2, 1]
 	      Position		      [870, 240, 905, 280]
+	      ZOrder		      -6
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Concat"
 	      SourceType	      "Xilinx Bus Concatenator Block"
 	      infoedit		      "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary poi"
@@ -25228,9 +27608,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Concat1"
+	      SID		      "770"
 	      Ports		      [2, 1]
 	      Position		      [1110, 725, 1145, 765]
+	      ZOrder		      -7
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Concat"
 	      SourceType	      "Xilinx Bus Concatenator Block"
 	      infoedit		      "Concatenates two or more inputs.  Output will be cast to an unsigned value with the binary poi"
@@ -25254,9 +27637,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Constant1"
+	      SID		      "771"
 	      Ports		      [0, 1]
 	      Position		      [980, 667, 1005, 683]
+	      ZOrder		      -8
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Constant"
 	      SourceType	      "Xilinx Constant Block Block"
 	      const		      "vector_len - 1"
@@ -25281,19 +27667,24 @@ Library {
 	      sggui_pos		      "461,565,414,344"
 	      block_type	      "constant"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "25,16,1,1,white,blue,0,a7d11b44,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 ],[0 0 26 26 ],[0.77 0.82 "
-	      "0.91]);\npatch([20 16 22 16 20 27 29 31 38 32 26 22 28 22 26 32 38 31 29 27 20 ],[3 7 13 19 23 23 21 23 23 17 2"
-	      "3 19 13 7 3 9 3 3 5 3 3 ],[0.98 0.96 0.92]);\nplot([0 55 55 0 0 ],[0 0 26 26 0 ]);\nfprintf('','COMMENT: end ic"
-	      "on graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'139263');\nfprin"
-	      "tf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "25,16,0,1,white,blue,0,7ecbd0de,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 25 25 0 0 ],[0 0 16 16 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 25 25 0 0 ],[0 0 16 16 0 ]);\npatch([7.55 10.44 12.44 14.44 16.44 12.44 9.55 7.55 ],[10.2"
+	      "2 10.22 12.22 10.22 12.22 12.22 12.22 10.22 ],[1 1 1 ]);\npatch([9.55 12.44 10.44 7.55 9.55 ],[8.22 8.22 10.22 "
+	      "10.22 8.22 ],[0.931 0.946 0.973 ]);\npatch([7.55 10.44 12.44 9.55 7.55 ],[6.22 6.22 8.22 8.22 6.22 ],[1 1 1 ]);"
+	      "\npatch([9.55 16.44 14.44 12.44 10.44 7.55 9.55 ],[4.22 4.22 6.22 4.22 6.22 6.22 4.22 ],[0.931 0.946 0.973 ]);\n"
+	      "fprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('"
+	      "output',1,'139263');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Constant3"
+	      SID		      "772"
 	      Ports		      [0, 1]
 	      Position		      [310, 182, 335, 198]
+	      ZOrder		      -9
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Constant"
 	      SourceType	      "Xilinx Constant Block Block"
 	      const		      "vector_len-1"
@@ -25318,19 +27709,24 @@ Library {
 	      sggui_pos		      "461,565,414,344"
 	      block_type	      "constant"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "25,16,1,1,white,blue,0,a7d11b44,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 ],[0 0 26 26 ],[0.77 0.82 "
-	      "0.91]);\npatch([20 16 22 16 20 27 29 31 38 32 26 22 28 22 26 32 38 31 29 27 20 ],[3 7 13 19 23 23 21 23 23 17 2"
-	      "3 19 13 7 3 9 3 3 5 3 3 ],[0.98 0.96 0.92]);\nplot([0 55 55 0 0 ],[0 0 26 26 0 ]);\nfprintf('','COMMENT: end ic"
-	      "on graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'139263');\nfprin"
-	      "tf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "25,16,0,1,white,blue,0,7ecbd0de,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 25 25 0 0 ],[0 0 16 16 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 25 25 0 0 ],[0 0 16 16 0 ]);\npatch([7.55 10.44 12.44 14.44 16.44 12.44 9.55 7.55 ],[10.2"
+	      "2 10.22 12.22 10.22 12.22 12.22 12.22 10.22 ],[1 1 1 ]);\npatch([9.55 12.44 10.44 7.55 9.55 ],[8.22 8.22 10.22 "
+	      "10.22 8.22 ],[0.931 0.946 0.973 ]);\npatch([7.55 10.44 12.44 9.55 7.55 ],[6.22 6.22 8.22 8.22 6.22 ],[1 1 1 ]);"
+	      "\npatch([9.55 16.44 14.44 12.44 10.44 7.55 9.55 ],[4.22 4.22 6.22 4.22 6.22 6.22 4.22 ],[0.931 0.946 0.973 ]);\n"
+	      "fprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('"
+	      "output',1,'139263');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay1"
+	      SID		      "773"
 	      Ports		      [1, 1]
 	      Position		      [1340, 611, 1365, 629]
+	      ZOrder		      -10
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -25359,9 +27755,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay2"
+	      SID		      "774"
 	      Ports		      [1, 1]
 	      Position		      [1465, 607, 1490, 623]
+	      ZOrder		      -11
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -25378,19 +27777,24 @@ Library {
 	      sggui_pos		      "20,20,348,254"
 	      block_type	      "delay"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "25,16,1,1,white,blue,0,36c42516,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 56 56 ],[0.77 0.82 "
-	      "0.91]);\npatch([15 6 19 6 15 30 34 38 54 41 29 20 32 20 29 41 54 38 34 30 15 ],[6 15 28 41 50 50 46 50 50 37 49"
-	      " 40 28 16 7 19 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 56 56 0 ]);\nfprintf('','COMMENT: end "
-	      "icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');disp('z^{-11}','texmode','on');\nfpri"
-	      "ntf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "25,16,1,1,white,blue,0,1a71059f,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 25 25 0 0 ],[0 0 16 16 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 25 25 0 0 ],[0 0 16 16 0 ]);\npatch([7.55 10.44 12.44 14.44 16.44 12.44 9.55 7.55 ],[10.2"
+	      "2 10.22 12.22 10.22 12.22 12.22 12.22 10.22 ],[1 1 1 ]);\npatch([9.55 12.44 10.44 7.55 9.55 ],[8.22 8.22 10.22 "
+	      "10.22 8.22 ],[0.931 0.946 0.973 ]);\npatch([7.55 10.44 12.44 9.55 7.55 ],[6.22 6.22 8.22 8.22 6.22 ],[1 1 1 ]);"
+	      "\npatch([9.55 16.44 14.44 12.44 10.44 7.55 9.55 ],[4.22 4.22 6.22 4.22 6.22 6.22 4.22 ],[0.931 0.946 0.973 ]);\n"
+	      "fprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\n\ncolor('black');disp('z^"
+	      "{-11}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay3"
+	      SID		      "775"
 	      Ports		      [1, 1]
 	      Position		      [1465, 682, 1490, 698]
+	      ZOrder		      -12
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -25407,19 +27811,24 @@ Library {
 	      sggui_pos		      "20,20,348,254"
 	      block_type	      "delay"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "25,16,1,1,white,blue,0,fc1feff4,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 56 56 ],[0.77 0.82 "
-	      "0.91]);\npatch([15 6 19 6 15 30 34 38 54 41 29 20 32 20 29 41 54 38 34 30 15 ],[6 15 28 41 50 50 46 50 50 37 49"
-	      " 40 28 16 7 19 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 56 56 0 ]);\nfprintf('','COMMENT: end "
-	      "icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');disp('z^{-10}','texmode','on');\nfpri"
-	      "ntf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "25,16,1,1,white,blue,0,8c471295,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 25 25 0 0 ],[0 0 16 16 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 25 25 0 0 ],[0 0 16 16 0 ]);\npatch([7.55 10.44 12.44 14.44 16.44 12.44 9.55 7.55 ],[10.2"
+	      "2 10.22 12.22 10.22 12.22 12.22 12.22 10.22 ],[1 1 1 ]);\npatch([9.55 12.44 10.44 7.55 9.55 ],[8.22 8.22 10.22 "
+	      "10.22 8.22 ],[0.931 0.946 0.973 ]);\npatch([7.55 10.44 12.44 9.55 7.55 ],[6.22 6.22 8.22 8.22 6.22 ],[1 1 1 ]);"
+	      "\npatch([9.55 16.44 14.44 12.44 10.44 7.55 9.55 ],[4.22 4.22 6.22 4.22 6.22 6.22 4.22 ],[0.931 0.946 0.973 ]);\n"
+	      "fprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\n\ncolor('black');disp('z^"
+	      "{-10}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay4"
+	      SID		      "776"
 	      Ports		      [1, 1]
 	      Position		      [1210, 733, 1245, 757]
+	      ZOrder		      -13
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -25448,9 +27857,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay6"
+	      SID		      "777"
 	      Ports		      [1, 1]
 	      Position		      [1210, 678, 1245, 702]
+	      ZOrder		      -14
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -25479,7 +27891,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From1"
+	      SID		      "778"
 	      Position		      [840, 683, 900, 697]
+	      ZOrder		      -15
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "new_acc"
@@ -25487,7 +27901,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From10"
+	      SID		      "779"
 	      Position		      [800, 243, 860, 257]
+	      ZOrder		      -16
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "half_sel"
@@ -25495,7 +27911,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From11"
+	      SID		      "780"
 	      Position		      [990, 728, 1050, 742]
+	      ZOrder		      -17
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "half_sel"
@@ -25503,7 +27921,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From12"
+	      SID		      "781"
 	      Position		      [240, 438, 300, 452]
+	      ZOrder		      -18
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "new_acc"
@@ -25511,7 +27931,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From13"
+	      SID		      "782"
 	      Position		      [1420, 78, 1480, 92]
+	      ZOrder		      -19
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rb_rd_en"
@@ -25519,7 +27941,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From14"
+	      SID		      "783"
 	      Position		      [1420, 63, 1480, 77]
+	      ZOrder		      -20
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "in_burst"
@@ -25527,7 +27951,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From15"
+	      SID		      "784"
 	      Position		      [1420, 93, 1480, 107]
+	      ZOrder		      -21
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "new_acc"
@@ -25535,7 +27961,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From16"
+	      SID		      "785"
 	      Position		      [1420, 108, 1480, 122]
+	      ZOrder		      -22
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "half_sel"
@@ -25543,7 +27971,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From17"
+	      SID		      "786"
 	      Position		      [275, 153, 335, 167]
+	      ZOrder		      -23
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rd_loc"
@@ -25551,7 +27981,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From18"
+	      SID		      "787"
 	      Position		      [65, 249, 95, 261]
+	      ZOrder		      -24
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rst"
@@ -25559,7 +27991,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From19"
+	      SID		      "788"
 	      Position		      [1400, 368, 1460, 382]
+	      ZOrder		      -25
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "in_burst"
@@ -25567,7 +28001,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From2"
+	      SID		      "789"
 	      Position		      [605, 253, 665, 267]
+	      ZOrder		      -26
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "end_of_vector"
@@ -25575,7 +28011,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From20"
+	      SID		      "790"
 	      Position		      [945, 453, 1005, 467]
+	      ZOrder		      -27
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "new_acc"
@@ -25583,7 +28021,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From21"
+	      SID		      "791"
 	      Position		      [1420, 123, 1480, 137]
+	      ZOrder		      -28
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rd_en"
@@ -25591,7 +28031,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From22"
+	      SID		      "792"
 	      Position		      [1075, 159, 1105, 171]
+	      ZOrder		      -29
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rst"
@@ -25599,7 +28041,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From23"
+	      SID		      "793"
 	      Position		      [1370, 398, 1430, 412]
+	      ZOrder		      -30
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "new_acc"
@@ -25607,7 +28051,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From24"
+	      SID		      "794"
 	      Position		      [1420, 138, 1480, 152]
+	      ZOrder		      -31
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rd_addr"
@@ -25615,7 +28061,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From25"
+	      SID		      "795"
 	      Position		      [1420, 153, 1480, 167]
+	      ZOrder		      -32
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "wr_addr"
@@ -25623,7 +28071,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From26"
+	      SID		      "796"
 	      Position		      [1420, 168, 1480, 182]
+	      ZOrder		      -33
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "wr_en"
@@ -25631,7 +28081,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From27"
+	      SID		      "797"
 	      Position		      [160, 618, 220, 632]
+	      ZOrder		      -34
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "new_acc"
@@ -25639,7 +28091,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From28"
+	      SID		      "798"
 	      Position		      [1370, 428, 1430, 442]
+	      ZOrder		      -35
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rd_en"
@@ -25647,7 +28101,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From29"
+	      SID		      "799"
 	      Position		      [1370, 443, 1430, 457]
+	      ZOrder		      -36
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "new_acc"
@@ -25655,7 +28111,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From3"
+	      SID		      "800"
 	      Position		      [665, 733, 725, 747]
+	      ZOrder		      -37
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "in_burst"
@@ -25663,7 +28121,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From30"
+	      SID		      "801"
 	      Position		      [1370, 458, 1430, 472]
+	      ZOrder		      -38
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rd_addr"
@@ -25671,7 +28131,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From31"
+	      SID		      "802"
 	      Position		      [605, 283, 665, 297]
+	      ZOrder		      -39
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rd_en"
@@ -25679,7 +28141,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From32"
+	      SID		      "803"
 	      Position		      [945, 468, 1005, 482]
+	      ZOrder		      -40
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "end_of_vector"
@@ -25687,7 +28151,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From33"
+	      SID		      "804"
 	      Position		      [605, 238, 665, 252]
+	      ZOrder		      -41
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "new_acc"
@@ -25695,7 +28161,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From34"
+	      SID		      "805"
 	      Position		      [1420, 183, 1480, 197]
+	      ZOrder		      -42
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rd_loc"
@@ -25703,7 +28171,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From35"
+	      SID		      "806"
 	      Position		      [365, 608, 425, 622]
+	      ZOrder		      -43
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "end_of_vector"
@@ -25711,7 +28181,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From36"
+	      SID		      "807"
 	      Position		      [780, 703, 840, 717]
+	      ZOrder		      -44
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rb_rd_en"
@@ -25719,7 +28191,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From37"
+	      SID		      "808"
 	      Position		      [585, 458, 645, 472]
+	      ZOrder		      -45
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rd_addr"
@@ -25727,7 +28201,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From38"
+	      SID		      "809"
 	      Position		      [260, 419, 290, 431]
+	      ZOrder		      -46
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rst"
@@ -25735,7 +28211,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From39"
+	      SID		      "810"
 	      Position		      [695, 792, 770, 808]
+	      ZOrder		      -47
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rb_not_done"
@@ -25743,7 +28221,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From4"
+	      SID		      "811"
 	      Position		      [160, 648, 220, 662]
+	      ZOrder		      -48
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "end_of_vector"
@@ -25751,7 +28231,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From40"
+	      SID		      "812"
 	      Position		      [1255, 598, 1315, 612]
+	      ZOrder		      -49
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rb_rd_en"
@@ -25759,7 +28241,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From41"
+	      SID		      "813"
 	      Position		      [455, 278, 515, 292]
+	      ZOrder		      -50
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rb_rd_en"
@@ -25767,7 +28251,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From42"
+	      SID		      "814"
 	      Position		      [665, 753, 725, 767]
+	      ZOrder		      -51
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rd_en"
@@ -25775,7 +28261,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From5"
+	      SID		      "815"
 	      Position		      [1370, 413, 1430, 427]
+	      ZOrder		      -52
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "end_of_vector"
@@ -25783,7 +28271,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From6"
+	      SID		      "816"
 	      Position		      [455, 258, 515, 272]
+	      ZOrder		      -53
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "in_burst"
@@ -25791,7 +28281,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From7"
+	      SID		      "817"
 	      Position		      [1155, 293, 1215, 307]
+	      ZOrder		      -54
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rb_addr"
@@ -25799,7 +28291,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From8"
+	      SID		      "818"
 	      Position		      [1155, 213, 1215, 227]
+	      ZOrder		      -55
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rb_rd_en"
@@ -25807,7 +28301,9 @@ Library {
 	    Block {
 	      BlockType		      From
 	      Name		      "From9"
+	      SID		      "819"
 	      Position		      [1155, 118, 1215, 132]
+	      ZOrder		      -56
 	      ShowName		      off
 	      CloseFcn		      "tagdialog Close"
 	      GotoTag		      "rb_rd_en"
@@ -25815,25 +28311,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out1"
+	      SID		      "820"
 	      Ports		      [1, 1]
 	      Position		      [1495, 416, 1535, 424]
+	      ZOrder		      -57
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -25846,25 +28348,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out10"
+	      SID		      "821"
 	      Ports		      [1, 1]
 	      Position		      [1495, 431, 1535, 439]
+	      ZOrder		      -58
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -25877,25 +28385,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out11"
+	      SID		      "822"
 	      Ports		      [1, 1]
 	      Position		      [1515, 126, 1555, 134]
+	      ZOrder		      -59
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -25908,25 +28422,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out12"
+	      SID		      "823"
 	      Ports		      [1, 1]
 	      Position		      [1515, 111, 1555, 119]
+	      ZOrder		      -60
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -25939,25 +28459,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out13"
+	      SID		      "824"
 	      Ports		      [1, 1]
 	      Position		      [1495, 461, 1535, 469]
+	      ZOrder		      -61
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -25970,25 +28496,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out14"
+	      SID		      "825"
 	      Ports		      [1, 1]
 	      Position		      [1515, 81, 1555, 89]
+	      ZOrder		      -62
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -26001,25 +28533,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out15"
+	      SID		      "826"
 	      Ports		      [1, 1]
 	      Position		      [1515, 66, 1555, 74]
+	      ZOrder		      -63
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -26032,25 +28570,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out16"
+	      SID		      "827"
 	      Ports		      [1, 1]
 	      Position		      [1515, 96, 1555, 104]
+	      ZOrder		      -64
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -26063,25 +28607,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out17"
+	      SID		      "828"
 	      Ports		      [1, 1]
 	      Position		      [1515, 186, 1555, 194]
+	      ZOrder		      -65
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -26094,25 +28644,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out19"
+	      SID		      "829"
 	      Ports		      [1, 1]
 	      Position		      [1515, 156, 1555, 164]
+	      ZOrder		      -66
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -26125,25 +28681,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out2"
+	      SID		      "830"
 	      Ports		      [1, 1]
 	      Position		      [1050, 871, 1090, 879]
+	      ZOrder		      -67
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -26156,25 +28718,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out22"
+	      SID		      "831"
 	      Ports		      [1, 1]
 	      Position		      [1515, 141, 1555, 149]
+	      ZOrder		      -68
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -26187,25 +28755,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out28"
+	      SID		      "832"
 	      Ports		      [1, 1]
 	      Position		      [1515, 171, 1555, 179]
+	      ZOrder		      -69
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -26218,25 +28792,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out3"
+	      SID		      "833"
 	      Ports		      [1, 1]
 	      Position		      [1495, 386, 1535, 394]
+	      ZOrder		      -70
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -26249,25 +28829,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out4"
+	      SID		      "834"
 	      Ports		      [1, 1]
 	      Position		      [1495, 371, 1535, 379]
+	      ZOrder		      -71
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -26280,25 +28866,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out5"
+	      SID		      "835"
 	      Ports		      [1, 1]
 	      Position		      [1495, 401, 1535, 409]
+	      ZOrder		      -72
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -26311,25 +28903,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out6"
+	      SID		      "836"
 	      Ports		      [1, 1]
 	      Position		      [1050, 841, 1090, 849]
+	      ZOrder		      -73
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -26342,25 +28940,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out7"
+	      SID		      "837"
 	      Ports		      [1, 1]
 	      Position		      [1050, 826, 1090, 834]
+	      ZOrder		      -74
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -26373,25 +28977,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out8"
+	      SID		      "838"
 	      Ports		      [1, 1]
 	      Position		      [1050, 856, 1090, 864]
+	      ZOrder		      -75
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -26404,25 +29014,31 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out9"
+	      SID		      "839"
 	      Ports		      [1, 1]
 	      Position		      [1495, 446, 1535, 454]
+	      ZOrder		      -76
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "20,20,336,384"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.8"
 	      "8 0.88 ]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5."
 	      "11 5.11 6.11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5"
@@ -26435,121 +29051,138 @@ Library {
 	    Block {
 	      BlockType		      Goto
 	      Name		      "Goto1"
+	      SID		      "840"
 	      Position		      [340, 593, 405, 607]
+	      ZOrder		      -77
 	      ShowName		      off
 	      GotoTag		      "vect_cnt"
-	      TagVisibility	      "local"
 	    }
 	    Block {
 	      BlockType		      Goto
 	      Name		      "Goto10"
+	      SID		      "841"
 	      Position		      [1235, 58, 1300, 72]
+	      ZOrder		      -78
 	      ShowName		      off
 	      GotoTag		      "wr_en"
-	      TagVisibility	      "local"
 	    }
 	    Block {
 	      BlockType		      Goto
 	      Name		      "Goto11"
+	      SID		      "842"
 	      Position		      [495, 698, 560, 712]
+	      ZOrder		      -79
 	      ShowName		      off
 	      GotoTag		      "rst"
-	      TagVisibility	      "local"
 	    }
 	    Block {
 	      BlockType		      Goto
 	      Name		      "Goto12"
+	      SID		      "843"
 	      Position		      [805, 193, 870, 207]
+	      ZOrder		      -80
 	      ShowName		      off
 	      GotoTag		      "rd_loc"
-	      TagVisibility	      "local"
 	    }
 	    Block {
 	      BlockType		      Goto
 	      Name		      "Goto13"
+	      SID		      "844"
 	      Position		      [440, 168, 505, 182]
+	      ZOrder		      -81
 	      ShowName		      off
 	      GotoTag		      "end_of_vector"
-	      TagVisibility	      "local"
 	    }
 	    Block {
 	      BlockType		      Goto
 	      Name		      "Goto14"
+	      SID		      "845"
 	      Position		      [1130, 668, 1195, 682]
+	      ZOrder		      -82
 	      ShowName		      off
 	      GotoTag		      "rb_not_done"
-	      TagVisibility	      "local"
 	    }
 	    Block {
 	      BlockType		      Goto
 	      Name		      "Goto2"
+	      SID		      "846"
 	      Position		      [1300, 778, 1365, 792]
+	      ZOrder		      -83
 	      ShowName		      off
 	      GotoTag		      "rb_rd_en"
-	      TagVisibility	      "local"
 	    }
 	    Block {
 	      BlockType		      Goto
 	      Name		      "Goto3"
+	      SID		      "847"
 	      Position		      [190, 218, 255, 232]
+	      ZOrder		      -84
 	      ShowName		      off
 	      GotoTag		      "in_burst"
-	      TagVisibility	      "local"
 	    }
 	    Block {
 	      BlockType		      Goto
 	      Name		      "Goto4"
+	      SID		      "848"
 	      Position		      [600, 628, 665, 642]
+	      ZOrder		      -85
 	      ShowName		      off
 	      GotoTag		      "new_acc"
-	      TagVisibility	      "local"
 	    }
 	    Block {
 	      BlockType		      Goto
 	      Name		      "Goto5"
+	      SID		      "849"
 	      Position		      [1300, 738, 1365, 752]
+	      ZOrder		      -86
 	      ShowName		      off
 	      GotoTag		      "rb_addr"
-	      TagVisibility	      "local"
 	    }
 	    Block {
 	      BlockType		      Goto
 	      Name		      "Goto6"
+	      SID		      "850"
 	      Position		      [435, 418, 500, 432]
+	      ZOrder		      -87
 	      ShowName		      off
 	      GotoTag		      "half_sel"
-	      TagVisibility	      "local"
 	    }
 	    Block {
 	      BlockType		      Goto
 	      Name		      "Goto7"
+	      SID		      "851"
 	      Position		      [1235, 83, 1300, 97]
+	      ZOrder		      -88
 	      ShowName		      off
 	      GotoTag		      "rd_en"
-	      TagVisibility	      "local"
 	    }
 	    Block {
 	      BlockType		      Goto
 	      Name		      "Goto8"
+	      SID		      "852"
 	      Position		      [1095, 343, 1160, 357]
+	      ZOrder		      -89
 	      ShowName		      off
 	      GotoTag		      "rd_addr"
-	      TagVisibility	      "local"
 	    }
 	    Block {
 	      BlockType		      Goto
 	      Name		      "Goto9"
+	      SID		      "853"
 	      Position		      [1095, 358, 1160, 372]
+	      ZOrder		      -90
 	      ShowName		      off
 	      GotoTag		      "wr_addr"
-	      TagVisibility	      "local"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Inverter"
+	      SID		      "854"
 	      Ports		      [1, 1]
 	      Position		      [745, 731, 770, 749]
+	      ZOrder		      -91
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Inverter"
 	      SourceType	      "Xilinx Inverter Block"
 	      infoedit		      "Bitwise logical negation (one's complement) operator."
@@ -26574,9 +29207,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Inverter1"
+	      SID		      "855"
 	      Ports		      [1, 1]
 	      Position		      [745, 771, 770, 789]
+	      ZOrder		      -92
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Inverter"
 	      SourceType	      "Xilinx Inverter Block"
 	      infoedit		      "Bitwise logical negation (one's complement) operator."
@@ -26601,9 +29237,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Inverter2"
+	      SID		      "856"
 	      Ports		      [1, 1]
 	      Position		      [1185, 156, 1210, 174]
+	      ZOrder		      -93
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Inverter"
 	      SourceType	      "Xilinx Inverter Block"
 	      infoedit		      "Bitwise logical negation (one's complement) operator."
@@ -26628,10 +29267,13 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Inverter3"
+	      SID		      "857"
 	      Ports		      [1, 1]
 	      Position		      [335, 371, 360, 389]
-	      Orientation	      "left"
+	      ZOrder		      -94
+	      BlockMirror	      on
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Inverter"
 	      SourceType	      "Xilinx Inverter Block"
 	      infoedit		      "Bitwise logical negation (one's complement) operator."
@@ -26656,9 +29298,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Inverter4"
+	      SID		      "858"
 	      Ports		      [1, 1]
 	      Position		      [1410, 681, 1435, 699]
+	      ZOrder		      -95
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Inverter"
 	      SourceType	      "Xilinx Inverter Block"
 	      infoedit		      "Bitwise logical negation (one's complement) operator."
@@ -26683,9 +29328,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Inverter5"
+	      SID		      "859"
 	      Ports		      [1, 1]
 	      Position		      [1065, 727, 1090, 743]
+	      ZOrder		      -96
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Inverter"
 	      SourceType	      "Xilinx Inverter Block"
 	      infoedit		      "Bitwise logical negation (one's complement) operator."
@@ -26710,9 +29358,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Inverter6"
+	      SID		      "860"
 	      Ports		      [1, 1]
 	      Position		      [1185, 456, 1210, 474]
+	      ZOrder		      -97
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Inverter"
 	      SourceType	      "Xilinx Inverter Block"
 	      infoedit		      "Bitwise logical negation (one's complement) operator."
@@ -26737,9 +29388,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Inverter7"
+	      SID		      "861"
 	      Ports		      [1, 1]
 	      Position		      [530, 276, 555, 294]
+	      ZOrder		      -98
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Inverter"
 	      SourceType	      "Xilinx Inverter Block"
 	      infoedit		      "Bitwise logical negation (one's complement) operator."
@@ -26764,9 +29418,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Inverter8"
+	      SID		      "862"
 	      Ports		      [1, 1]
 	      Position		      [745, 751, 770, 769]
+	      ZOrder		      -99
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Inverter"
 	      SourceType	      "Xilinx Inverter Block"
 	      infoedit		      "Bitwise logical negation (one's complement) operator."
@@ -26791,9 +29448,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical1"
+	      SID		      "863"
 	      Ports		      [4, 1]
 	      Position		      [790, 728, 825, 812]
+	      ZOrder		      -100
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -26824,9 +29484,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical10"
+	      SID		      "864"
 	      Ports		      [2, 1]
 	      Position		      [965, 131, 1000, 164]
+	      ZOrder		      -101
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "OR"
@@ -26857,9 +29520,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical11"
+	      SID		      "865"
 	      Ports		      [2, 1]
 	      Position		      [575, 257, 600, 293]
+	      ZOrder		      -102
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -26890,9 +29556,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical2"
+	      SID		      "866"
 	      Ports		      [2, 1]
 	      Position		      [680, 239, 700, 266]
+	      ZOrder		      -103
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "OR"
@@ -26923,9 +29592,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical3"
+	      SID		      "867"
 	      Ports		      [2, 1]
 	      Position		      [530, 641, 565, 674]
+	      ZOrder		      -104
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "OR"
@@ -26956,9 +29628,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical4"
+	      SID		      "868"
 	      Ports		      [2, 1]
 	      Position		      [1390, 597, 1435, 628]
+	      ZOrder		      -105
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "OR"
@@ -26989,9 +29664,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical5"
+	      SID		      "869"
 	      Ports		      [2, 1]
 	      Position		      [860, 704, 880, 731]
+	      ZOrder		      -106
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "OR"
@@ -27022,9 +29700,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical6"
+	      SID		      "870"
 	      Ports		      [2, 1]
 	      Position		      [1240, 101, 1275, 134]
+	      ZOrder		      -107
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "OR"
@@ -27055,9 +29736,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical7"
+	      SID		      "871"
 	      Ports		      [2, 1]
 	      Position		      [680, 269, 700, 296]
+	      ZOrder		      -108
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "OR"
@@ -27088,9 +29772,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical8"
+	      SID		      "872"
 	      Ports		      [2, 1]
 	      Position		      [1230, 141, 1265, 174]
+	      ZOrder		      -109
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -27121,9 +29808,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical9"
+	      SID		      "873"
 	      Ports		      [2, 1]
 	      Position		      [455, 631, 490, 664]
+	      ZOrder		      -110
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -27154,9 +29844,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Register1"
+	      SID		      "874"
 	      Ports		      [3, 1]
 	      Position		      [1120, 446, 1165, 484]
+	      ZOrder		      -111
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Register"
 	      SourceType	      "Xilinx Register Block"
 	      init		      "0"
@@ -27183,9 +29876,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Register4"
+	      SID		      "875"
 	      Ports		      [3, 1]
 	      Position		      [335, 397, 395, 453]
+	      ZOrder		      -112
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Register"
 	      SourceType	      "Xilinx Register Block"
 	      init		      "0"
@@ -27212,9 +29908,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Relational"
+	      SID		      "876"
 	      Ports		      [2, 1]
 	      Position		      [1030, 662, 1085, 718]
+	      ZOrder		      -113
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Relational"
 	      SourceType	      "Xilinx Arithmetic Relational Operator Block"
 	      mode		      "a>=b"
@@ -27241,9 +29940,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Relational2"
+	      SID		      "877"
 	      Ports		      [2, 1]
 	      Position		      [360, 627, 415, 683]
+	      ZOrder		      -114
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Relational"
 	      SourceType	      "Xilinx Arithmetic Relational Operator Block"
 	      mode		      "a>=b"
@@ -27270,9 +29972,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Relational3"
+	      SID		      "878"
 	      Ports		      [2, 1]
 	      Position		      [355, 147, 410, 203]
+	      ZOrder		      -115
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Relational"
 	      SourceType	      "Xilinx Arithmetic Relational Operator Block"
 	      mode		      "a>=b"
@@ -27299,9 +30004,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice"
+	      SID		      "879"
 	      Ports		      [1, 1]
 	      Position		      [1065, 749, 1090, 761]
+	      ZOrder		      -116
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -27319,19 +30027,24 @@ Library {
 	      sggui_pos		      "20,20,460,380"
 	      block_type	      "slice"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "25,12,1,1,white,blue,0,b1026674,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 30 30 ],[0.77 0.82 "
-	      "0.91]);\npatch([22 17 24 17 22 30 32 34 42 35 29 24 30 24 29 35 42 34 32 30 22 ],[3 8 15 22 27 27 25 27 27 20 2"
-	      "6 21 15 9 4 10 3 3 5 3 3 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 30 30 0 ]);\nfprintf('','COMMENT: end i"
-	      "con graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'[a:b]');\nfprin"
-	      "tf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "25,12,1,1,white,blue,0,1fd851a7,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 25 25 0 0 ],[0 0 12 12 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 25 25 0 0 ],[0 0 12 12 0 ]);\npatch([9.775 11.22 12.22 13.22 14.22 12.22 10.775 9.775 ],["
+	      "7.11 7.11 8.11 7.11 8.11 8.11 8.11 7.11 ],[1 1 1 ]);\npatch([10.775 12.22 11.22 9.775 10.775 ],[6.11 6.11 7.11 "
+	      "7.11 6.11 ],[0.931 0.946 0.973 ]);\npatch([9.775 11.22 12.22 10.775 9.775 ],[5.11 5.11 6.11 6.11 5.11 ],[1 1 1 "
+	      "]);\npatch([10.775 14.22 13.22 12.22 11.22 9.775 10.775 ],[4.11 4.11 5.11 4.11 5.11 5.11 4.11 ],[0.931 0.946 0."
+	      "973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolor('black');p"
+	      "ort_label('output',1,'[a:b]');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice1"
+	      SID		      "880"
 	      Ports		      [1, 1]
 	      Position		      [1065, 779, 1090, 791]
+	      ZOrder		      -117
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -27361,9 +30074,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice3"
+	      SID		      "881"
 	      Ports		      [1, 1]
 	      Position		      [810, 264, 835, 276]
+	      ZOrder		      -118
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -27393,9 +30109,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice4"
+	      SID		      "882"
 	      Ports		      [1, 1]
 	      Position		      [810, 214, 835, 226]
+	      ZOrder		      -119
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -27425,14 +30144,18 @@ Library {
 	    Block {
 	      BlockType		      Terminator
 	      Name		      "Terminator4"
+	      SID		      "883"
 	      Position		      [855, 455, 875, 475]
+	      ZOrder		      -120
 	      ShowName		      off
 	    }
 	    Block {
 	      BlockType		      Scope
 	      Name		      "acc_debug"
+	      SID		      "884"
 	      Ports		      [9]
 	      Position		      [1580, 66, 1605, 194]
+	      ZOrder		      -121
 	      Floating		      off
 	      Location		      [1, 45, 1921, 1101]
 	      Open		      off
@@ -27450,6 +30173,7 @@ Library {
 		axes8			"wr_en"
 		axes9			"vector_position"
 	      }
+	      ShowLegends	      off
 	      TimeRange		      "10000"
 	      YMin		      "0~-1~-1~0.95~0~500~500~0~-5"
 	      YMax		      "1~1~1~1.05~1~1100~1100~1~5"
@@ -27461,8 +30185,10 @@ Library {
 	    Block {
 	      BlockType		      Scope
 	      Name		      "blank_debug"
+	      SID		      "885"
 	      Ports		      [7]
 	      Position		      [1550, 367, 1580, 473]
+	      ZOrder		      -122
 	      Floating		      off
 	      Location		      [1, 45, 1921, 1101]
 	      Open		      off
@@ -27478,6 +30204,7 @@ Library {
 		axes6			"new_acc (aligned)"
 		axes7			"wr_addr (aligned)"
 	      }
+	      ShowLegends	      off
 	      TimeRange		      "10000"
 	      YMin		      "0~1~-1~-1~0~-1~50"
 	      YMax		      "1~1~1~1~1~1~250"
@@ -27489,8 +30216,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "delay_adder"
+	      SID		      "886"
 	      Ports		      [1, 1]
 	      Position		      [1035, 248, 1065, 272]
+	      ZOrder		      -123
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -27507,18 +30237,23 @@ Library {
 	      sggui_pos		      "20,20,348,254"
 	      block_type	      "delay"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,24,1,1,white,blue,0,0a7a6cf1,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 56 56 ],[0.77 0.82 "
-	      "0.91]);\npatch([15 6 19 6 15 30 34 38 54 41 29 20 32 20 29 41 54 38 34 30 15 ],[6 15 28 41 50 50 46 50 50 37 49"
-	      " 40 28 16 7 19 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 56 56 0 ]);\nfprintf('','COMMENT: end "
-	      "icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');disp('z^{-2}','texmode','on');\nfprin"
-	      "tf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "30,24,1,1,white,blue,0,85ce9542,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 24 24 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 30 30 0 0 ],[0 0 24 24 0 ]);\npatch([8.325 12.66 15.66 18.66 21.66 15.66 11.325 8.325 ],["
+	      "15.33 15.33 18.33 15.33 18.33 18.33 18.33 15.33 ],[1 1 1 ]);\npatch([11.325 15.66 12.66 8.325 11.325 ],[12.33 1"
+	      "2.33 15.33 15.33 12.33 ],[0.931 0.946 0.973 ]);\npatch([8.325 12.66 15.66 11.325 8.325 ],[9.33 9.33 12.33 12.33"
+	      " 9.33 ],[1 1 1 ]);\npatch([11.325 21.66 18.66 15.66 12.66 8.325 11.325 ],[6.33 6.33 9.33 6.33 9.33 9.33 6.33 ],"
+	      "[0.931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\n\n"
+	      "color('black');disp('z^{-2}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "delay_blank_qdr"
+	      SID		      "887"
 	      Ports		      [1, 1]
 	      Position		      [1235, 453, 1265, 477]
+	      ZOrder		      -124
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -27535,18 +30270,23 @@ Library {
 	      sggui_pos		      "20,20,348,254"
 	      block_type	      "delay"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,24,1,1,white,blue,0,36c42516,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 56 56 ],[0.77 0.82 "
-	      "0.91]);\npatch([15 6 19 6 15 30 34 38 54 41 29 20 32 20 29 41 54 38 34 30 15 ],[6 15 28 41 50 50 46 50 50 37 49"
-	      " 40 28 16 7 19 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 56 56 0 ]);\nfprintf('','COMMENT: end "
-	      "icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');disp('z^{-11}','texmode','on');\nfpri"
-	      "ntf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "30,24,1,1,white,blue,0,1a71059f,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 24 24 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 30 30 0 0 ],[0 0 24 24 0 ]);\npatch([8.325 12.66 15.66 18.66 21.66 15.66 11.325 8.325 ],["
+	      "15.33 15.33 18.33 15.33 18.33 18.33 18.33 15.33 ],[1 1 1 ]);\npatch([11.325 15.66 12.66 8.325 11.325 ],[12.33 1"
+	      "2.33 15.33 15.33 12.33 ],[0.931 0.946 0.973 ]);\npatch([8.325 12.66 15.66 11.325 8.325 ],[9.33 9.33 12.33 12.33"
+	      " 9.33 ],[1 1 1 ]);\npatch([11.325 21.66 18.66 15.66 12.66 8.325 11.325 ],[6.33 6.33 9.33 6.33 9.33 9.33 6.33 ],"
+	      "[0.931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\n\n"
+	      "color('black');disp('z^{-11}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "delay_even_addr"
+	      SID		      "888"
 	      Ports		      [1, 1]
 	      Position		      [925, 248, 945, 272]
+	      ZOrder		      -125
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -27575,8 +30315,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "delay_even_addr1"
+	      SID		      "889"
 	      Ports		      [1, 1]
 	      Position		      [1035, 448, 1055, 472]
+	      ZOrder		      -126
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -27605,8 +30348,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "delay_even_addr2"
+	      SID		      "890"
 	      Ports		      [1, 1]
 	      Position		      [1035, 463, 1055, 487]
+	      ZOrder		      -127
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -27635,8 +30381,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "delay_for_even_op"
+	      SID		      "891"
 	      Ports		      [1, 1]
 	      Position		      [915, 143, 935, 167]
+	      ZOrder		      -128
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -27665,8 +30414,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "delay_qdr"
+	      SID		      "892"
 	      Ports		      [1, 1]
 	      Position		      [970, 248, 1000, 272]
+	      ZOrder		      -129
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -27683,18 +30435,23 @@ Library {
 	      sggui_pos		      "20,20,348,254"
 	      block_type	      "delay"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,24,1,1,white,blue,0,36c42516,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 56 56 ],[0.77 0.82 "
-	      "0.91]);\npatch([15 6 19 6 15 30 34 38 54 41 29 20 32 20 29 41 54 38 34 30 15 ],[6 15 28 41 50 50 46 50 50 37 49"
-	      " 40 28 16 7 19 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 56 56 0 ]);\nfprintf('','COMMENT: end "
-	      "icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');disp('z^{-11}','texmode','on');\nfpri"
-	      "ntf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "30,24,1,1,white,blue,0,1a71059f,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 24 24 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 30 30 0 0 ],[0 0 24 24 0 ]);\npatch([8.325 12.66 15.66 18.66 21.66 15.66 11.325 8.325 ],["
+	      "15.33 15.33 18.33 15.33 18.33 18.33 18.33 15.33 ],[1 1 1 ]);\npatch([11.325 15.66 12.66 8.325 11.325 ],[12.33 1"
+	      "2.33 15.33 15.33 12.33 ],[0.931 0.946 0.973 ]);\npatch([8.325 12.66 15.66 11.325 8.325 ],[9.33 9.33 12.33 12.33"
+	      " 9.33 ],[1 1 1 ]);\npatch([11.325 21.66 18.66 15.66 12.66 8.325 11.325 ],[6.33 6.33 9.33 6.33 9.33 9.33 6.33 ],"
+	      "[0.931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\n\n"
+	      "color('black');disp('z^{-11}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "delay_rd_align"
+	      SID		      "893"
 	      Ports		      [1, 1]
 	      Position		      [1020, 138, 1050, 162]
+	      ZOrder		      -130
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -27711,18 +30468,23 @@ Library {
 	      sggui_pos		      "20,20,348,255"
 	      block_type	      "delay"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,24,1,1,white,blue,0,fc1feff4,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 56 56 ],[0.77 0.82 "
-	      "0.91]);\npatch([15 6 19 6 15 30 34 38 54 41 29 20 32 20 29 41 54 38 34 30 15 ],[6 15 28 41 50 50 46 50 50 37 49"
-	      " 40 28 16 7 19 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 56 56 0 ]);\nfprintf('','COMMENT: end "
-	      "icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');disp('z^{-10}','texmode','on');\nfpri"
-	      "ntf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "30,24,1,1,white,blue,0,8c471295,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 24 24 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 30 30 0 0 ],[0 0 24 24 0 ]);\npatch([8.325 12.66 15.66 18.66 21.66 15.66 11.325 8.325 ],["
+	      "15.33 15.33 18.33 15.33 18.33 18.33 18.33 15.33 ],[1 1 1 ]);\npatch([11.325 15.66 12.66 8.325 11.325 ],[12.33 1"
+	      "2.33 15.33 15.33 12.33 ],[0.931 0.946 0.973 ]);\npatch([8.325 12.66 15.66 11.325 8.325 ],[9.33 9.33 12.33 12.33"
+	      " 9.33 ],[1 1 1 ]);\npatch([11.325 21.66 18.66 15.66 12.66 8.325 11.325 ],[6.33 6.33 9.33 6.33 9.33 9.33 6.33 ],"
+	      "[0.931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\n\n"
+	      "color('black');disp('z^{-10}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "delay_rd_align1"
+	      SID		      "894"
 	      Ports		      [1, 1]
 	      Position		      [1020, 68, 1050, 92]
+	      ZOrder		      -131
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -27739,18 +30501,23 @@ Library {
 	      sggui_pos		      "20,20,348,254"
 	      block_type	      "delay"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,24,1,1,white,blue,0,36c42516,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 56 56 ],[0.77 0.82 "
-	      "0.91]);\npatch([15 6 19 6 15 30 34 38 54 41 29 20 32 20 29 41 54 38 34 30 15 ],[6 15 28 41 50 50 46 50 50 37 49"
-	      " 40 28 16 7 19 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 56 56 0 ]);\nfprintf('','COMMENT: end "
-	      "icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');disp('z^{-11}','texmode','on');\nfpri"
-	      "ntf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "30,24,1,1,white,blue,0,1a71059f,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 24 24 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 30 30 0 0 ],[0 0 24 24 0 ]);\npatch([8.325 12.66 15.66 18.66 21.66 15.66 11.325 8.325 ],["
+	      "15.33 15.33 18.33 15.33 18.33 18.33 18.33 15.33 ],[1 1 1 ]);\npatch([11.325 15.66 12.66 8.325 11.325 ],[12.33 1"
+	      "2.33 15.33 15.33 12.33 ],[0.931 0.946 0.973 ]);\npatch([8.325 12.66 15.66 11.325 8.325 ],[9.33 9.33 12.33 12.33"
+	      " 9.33 ],[1 1 1 ]);\npatch([11.325 21.66 18.66 15.66 12.66 8.325 11.325 ],[6.33 6.33 9.33 6.33 9.33 9.33 6.33 ],"
+	      "[0.931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\n\n"
+	      "color('black');disp('z^{-11}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "delay_rd_wr_align1"
+	      SID		      "895"
 	      Ports		      [1, 1]
 	      Position		      [1115, 68, 1145, 92]
+	      ZOrder		      -132
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -27767,18 +30534,23 @@ Library {
 	      sggui_pos		      "20,20,348,254"
 	      block_type	      "delay"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,24,1,1,white,blue,0,0a7a6cf1,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 56 56 ],[0.77 0.82 "
-	      "0.91]);\npatch([15 6 19 6 15 30 34 38 54 41 29 20 32 20 29 41 54 38 34 30 15 ],[6 15 28 41 50 50 46 50 50 37 49"
-	      " 40 28 16 7 19 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 56 56 0 ]);\nfprintf('','COMMENT: end "
-	      "icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');disp('z^{-2}','texmode','on');\nfprin"
-	      "tf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "30,24,1,1,white,blue,0,85ce9542,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 24 24 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 30 30 0 0 ],[0 0 24 24 0 ]);\npatch([8.325 12.66 15.66 18.66 21.66 15.66 11.325 8.325 ],["
+	      "15.33 15.33 18.33 15.33 18.33 18.33 18.33 15.33 ],[1 1 1 ]);\npatch([11.325 15.66 12.66 8.325 11.325 ],[12.33 1"
+	      "2.33 15.33 15.33 12.33 ],[0.931 0.946 0.973 ]);\npatch([8.325 12.66 15.66 11.325 8.325 ],[9.33 9.33 12.33 12.33"
+	      " 9.33 ],[1 1 1 ]);\npatch([11.325 21.66 18.66 15.66 12.66 8.325 11.325 ],[6.33 6.33 9.33 6.33 9.33 9.33 6.33 ],"
+	      "[0.931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\n\n"
+	      "color('black');disp('z^{-2}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "delay_wr_align"
+	      SID		      "896"
 	      Ports		      [1, 1]
 	      Position		      [1450, 455, 1475, 475]
+	      ZOrder		      -133
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -27795,18 +30567,23 @@ Library {
 	      sggui_pos		      "20,20,348,254"
 	      block_type	      "delay"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "25,20,1,1,white,blue,0,36c42516,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 56 56 ],[0.77 0.82 "
-	      "0.91]);\npatch([15 6 19 6 15 30 34 38 54 41 29 20 32 20 29 41 54 38 34 30 15 ],[6 15 28 41 50 50 46 50 50 37 49"
-	      " 40 28 16 7 19 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 56 56 0 ]);\nfprintf('','COMMENT: end "
-	      "icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');disp('z^{-11}','texmode','on');\nfpri"
-	      "ntf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "25,20,1,1,white,blue,0,1a71059f,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 25 25 0 0 ],[0 0 20 20 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 25 25 0 0 ],[0 0 20 20 0 ]);\npatch([7.55 10.44 12.44 14.44 16.44 12.44 9.55 7.55 ],[12.2"
+	      "2 12.22 14.22 12.22 14.22 14.22 14.22 12.22 ],[1 1 1 ]);\npatch([9.55 12.44 10.44 7.55 9.55 ],[10.22 10.22 12.2"
+	      "2 12.22 10.22 ],[0.931 0.946 0.973 ]);\npatch([7.55 10.44 12.44 9.55 7.55 ],[8.22 8.22 10.22 10.22 8.22 ],[1 1 "
+	      "1 ]);\npatch([9.55 16.44 14.44 12.44 10.44 7.55 9.55 ],[6.22 6.22 8.22 6.22 8.22 8.22 6.22 ],[0.931 0.946 0.973"
+	      " ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\n\ncolor('black');di"
+	      "sp('z^{-11}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "delay_wr_align1"
+	      SID		      "897"
 	      Ports		      [1, 1]
 	      Position		      [1450, 408, 1475, 432]
+	      ZOrder		      -134
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -27823,18 +30600,23 @@ Library {
 	      sggui_pos		      "20,20,348,254"
 	      block_type	      "delay"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "25,24,1,1,white,blue,0,36c42516,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 56 56 ],[0.77 0.82 "
-	      "0.91]);\npatch([15 6 19 6 15 30 34 38 54 41 29 20 32 20 29 41 54 38 34 30 15 ],[6 15 28 41 50 50 46 50 50 37 49"
-	      " 40 28 16 7 19 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 56 56 0 ]);\nfprintf('','COMMENT: end "
-	      "icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');disp('z^{-11}','texmode','on');\nfpri"
-	      "ntf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "25,24,1,1,white,blue,0,1a71059f,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 25 25 0 0 ],[0 0 24 24 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 25 25 0 0 ],[0 0 24 24 0 ]);\npatch([5.325 9.66 12.66 15.66 18.66 12.66 8.325 5.325 ],[15"
+	      ".33 15.33 18.33 15.33 18.33 18.33 18.33 15.33 ],[1 1 1 ]);\npatch([8.325 12.66 9.66 5.325 8.325 ],[12.33 12.33 "
+	      "15.33 15.33 12.33 ],[0.931 0.946 0.973 ]);\npatch([5.325 9.66 12.66 8.325 5.325 ],[9.33 9.33 12.33 12.33 9.33 ]"
+	      ",[1 1 1 ]);\npatch([8.325 18.66 15.66 12.66 9.66 5.325 8.325 ],[6.33 6.33 9.33 6.33 9.33 9.33 6.33 ],[0.931 0.9"
+	      "46 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\n\ncolor('bl"
+	      "ack');disp('z^{-11}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "delay_wr_align2"
+	      SID		      "898"
 	      Ports		      [1, 1]
 	      Position		      [1450, 423, 1475, 447]
+	      ZOrder		      -135
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -27851,18 +30633,23 @@ Library {
 	      sggui_pos		      "20,20,348,254"
 	      block_type	      "delay"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "25,24,1,1,white,blue,0,36c42516,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 56 56 ],[0.77 0.82 "
-	      "0.91]);\npatch([15 6 19 6 15 30 34 38 54 41 29 20 32 20 29 41 54 38 34 30 15 ],[6 15 28 41 50 50 46 50 50 37 49"
-	      " 40 28 16 7 19 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 56 56 0 ]);\nfprintf('','COMMENT: end "
-	      "icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');disp('z^{-11}','texmode','on');\nfpri"
-	      "ntf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "25,24,1,1,white,blue,0,1a71059f,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 25 25 0 0 ],[0 0 24 24 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 25 25 0 0 ],[0 0 24 24 0 ]);\npatch([5.325 9.66 12.66 15.66 18.66 12.66 8.325 5.325 ],[15"
+	      ".33 15.33 18.33 15.33 18.33 18.33 18.33 15.33 ],[1 1 1 ]);\npatch([8.325 12.66 9.66 5.325 8.325 ],[12.33 12.33 "
+	      "15.33 15.33 12.33 ],[0.931 0.946 0.973 ]);\npatch([5.325 9.66 12.66 8.325 5.325 ],[9.33 9.33 12.33 12.33 9.33 ]"
+	      ",[1 1 1 ]);\npatch([8.325 18.66 15.66 12.66 9.66 5.325 8.325 ],[6.33 6.33 9.33 6.33 9.33 9.33 6.33 ],[0.931 0.9"
+	      "46 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\n\ncolor('bl"
+	      "ack');disp('z^{-11}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "delay_wr_align3"
+	      SID		      "899"
 	      Ports		      [1, 1]
 	      Position		      [1450, 438, 1475, 462]
+	      ZOrder		      -136
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -27879,19 +30666,24 @@ Library {
 	      sggui_pos		      "20,20,348,254"
 	      block_type	      "delay"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "25,24,1,1,white,blue,0,36c42516,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 56 56 ],[0.77 0.82 "
-	      "0.91]);\npatch([15 6 19 6 15 30 34 38 54 41 29 20 32 20 29 41 54 38 34 30 15 ],[6 15 28 41 50 50 46 50 50 37 49"
-	      " 40 28 16 7 19 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 56 56 0 ]);\nfprintf('','COMMENT: end "
-	      "icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');disp('z^{-11}','texmode','on');\nfpri"
-	      "ntf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "25,24,1,1,white,blue,0,1a71059f,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 25 25 0 0 ],[0 0 24 24 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 25 25 0 0 ],[0 0 24 24 0 ]);\npatch([5.325 9.66 12.66 15.66 18.66 12.66 8.325 5.325 ],[15"
+	      ".33 15.33 18.33 15.33 18.33 18.33 18.33 15.33 ],[1 1 1 ]);\npatch([8.325 12.66 9.66 5.325 8.325 ],[12.33 12.33 "
+	      "15.33 15.33 12.33 ],[0.931 0.946 0.973 ]);\npatch([5.325 9.66 12.66 8.325 5.325 ],[9.33 9.33 12.33 12.33 9.33 ]"
+	      ",[1 1 1 ]);\npatch([8.325 18.66 15.66 12.66 9.66 5.325 8.325 ],[6.33 6.33 9.33 6.33 9.33 9.33 6.33 ],[0.931 0.9"
+	      "46 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\n\ncolor('bl"
+	      "ack');disp('z^{-11}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "ease_timing1"
+	      SID		      "900"
 	      Ports		      [1, 1]
 	      Position		      [325, 663, 340, 677]
+	      ZOrder		      -137
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -27920,35 +30712,40 @@ Library {
 	    Block {
 	      BlockType		      SubSystem
 	      Name		      "pulse_ext"
+	      SID		      "901"
 	      Ports		      [2, 1]
 	      Position		      [125, 215, 160, 235]
+	      ZOrder		      -138
 	      AncestorBlock	      "casper_library_misc/pulse_ext"
+	      LibraryVersion	      "*"
 	      MinAlgLoopOccurrences   off
 	      PropExecContextOutsideSubsystem off
 	      RTWSystemCode	      "Auto"
 	      FunctionWithSeparateData off
 	      Opaque		      off
+	      RequestExecContextInheritance off
 	      MaskHideContents	      off
-	      MaskType		      "pulse_ext"
-	      MaskDescription	      "Extends a boolean signal to be high for the specified number of clocks after\nthe last h"
-	      "igh input."
-	      MaskHelp		      "eval('xlWeb(''http://casper.berkeley.edu/wiki/Pulse_ext'')')"
-	      MaskPromptString	      "Length of Pulse"
-	      MaskStyleString	      "edit"
-	      MaskVariables	      "pulse_len=@1;"
-	      MaskTunableValueString  "on"
-	      MaskEnableString	      "on"
-	      MaskVisibilityString    "on"
-	      MaskToolTipString	      "on"
-	      MaskInitialization      "bits = ceil(log2(pulse_len+1));"
-	      MaskIconFrame	      on
-	      MaskIconOpaque	      on
-	      MaskIconRotate	      "none"
-	      MaskIconUnits	      "autoscale"
-	      MaskValueString	      "burst_len"
+	      Object {
+		$PropName		"MaskObject"
+		$ObjectID		71
+		$ClassName		"Simulink.Mask"
+		Type			"pulse_ext"
+		Description		"Extends a boolean signal to be high for the specified number of clocks after\nthe last high input."
+		Help			"eval('xlWeb(''http://casper.berkeley.edu/wiki/Pulse_ext'')')"
+		Initialization		"bits = ceil(log2(pulse_len+1));"
+		Object {
+		  $PropName		  "Parameters"
+		  $ObjectID		  72
+		  $ClassName		  "Simulink.MaskParameter"
+		  Type			  "edit"
+		  Name			  "pulse_len"
+		  Prompt		  "Length of Pulse"
+		  Value			  "burst_len"
+		}
+	      }
 	      System {
 		Name			"pulse_ext"
-		Location		[445, 409, 1165, 745]
+		Location		[411, 290, 1179, 861]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -27961,25 +30758,33 @@ Library {
 		TiledPageScale		1
 		ShowPageBoundaries	off
 		ZoomFactor		"100"
+		SIDHighWatermark	"13"
 		Block {
 		  BlockType		  Inport
 		  Name			  "in"
+		  SID			  "901:1"
 		  Position		  [15, 98, 45, 112]
+		  ZOrder		  -1
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Inport
 		  Name			  "rst"
+		  SID			  "901:2"
 		  Position		  [15, 68, 45, 82]
+		  ZOrder		  -2
 		  Port			  "2"
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Constant1"
+		  SID			  "901:3"
 		  Ports			  [0, 1]
 		  Position		  [140, 83, 160, 97]
+		  ZOrder		  -3
 		  ShowName		  off
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "pulse_len"
@@ -28004,19 +30809,24 @@ Library {
 		  sggui_pos		  "20,20,414,344"
 		  block_type		  "constant"
 		  block_version		  "9.1.01"
-		  sg_icon_stat		  "20,14,1,1,white,blue,0,636e1b21,right"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 ],[0 0 26 26 ],[0.77 0.82 0.91]);"
-		  "\npatch([20 16 22 16 20 27 29 31 38 32 26 22 28 22 26 32 38 31 29 27 20 ],[3 7 13 19 23 23 21 23 23 17 23 19 13 7 "
-		  "3 9 3 3 5 3 3 ],[0.98 0.96 0.92]);\nplot([0 55 55 0 0 ],[0 0 26 26 0 ]);\nfprintf('','COMMENT: end icon graphics')"
-		  ";\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'16');\nfprintf('','COMMENT: end "
-		  "icon text');\n"
+		  sg_icon_stat		  "20,14,0,1,white,blue,0,eafdfd08,right,,[ ],[ ]"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 20 20 0 0 ],[0 0 14 14 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 20 20 0 0 ],[0 0 14 14 0 ]);\npatch([5.55 8.44 10.44 12.44 14.44 10.44 7.55 5.55 ],[9.22 9.22 11.22"
+		  " 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([7.55 10.44 8.44 5.55 7.55 ],[7.22 7.22 9.22 9.22 7.22 ],[0.931 0"
+		  ".946 0.973 ]);\npatch([5.55 8.44 10.44 7.55 5.55 ],[5.22 5.22 7.22 7.22 5.22 ],[1 1 1 ]);\npatch([7.55 14.44 12.44"
+		  " 10.44 8.44 5.55 7.55 ],[3.22 3.22 5.22 3.22 5.22 5.22 3.22 ],[0.931 0.946 0.973 ]);\nfprintf('','COMMENT: end ico"
+		  "n graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'16');\nfprintf('','C"
+		  "OMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Constant5"
+		  SID			  "901:4"
 		  Ports			  [0, 1]
 		  Position		  [215, 154, 235, 176]
+		  ZOrder		  -4
 		  ShowName		  off
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "pulse_len"
@@ -28041,18 +30851,23 @@ Library {
 		  sggui_pos		  "20,20,414,344"
 		  block_type		  "constant"
 		  block_version		  "9.1.01"
-		  sg_icon_stat		  "20,22,1,1,white,blue,0,636e1b21,right"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 ],[0 0 26 26 ],[0.77 0.82 0.91]);"
-		  "\npatch([20 16 22 16 20 27 29 31 38 32 26 22 28 22 26 32 38 31 29 27 20 ],[3 7 13 19 23 23 21 23 23 17 23 19 13 7 "
-		  "3 9 3 3 5 3 3 ],[0.98 0.96 0.92]);\nplot([0 55 55 0 0 ],[0 0 26 26 0 ]);\nfprintf('','COMMENT: end icon graphics')"
-		  ";\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'16');\nfprintf('','COMMENT: end "
-		  "icon text');\n"
+		  sg_icon_stat		  "20,22,0,1,white,blue,0,eafdfd08,right,,[ ],[ ]"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 20 20 0 0 ],[0 0 22 22 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 20 20 0 0 ],[0 0 22 22 0 ]);\npatch([5.55 8.44 10.44 12.44 14.44 10.44 7.55 5.55 ],[13.22 13.22 15."
+		  "22 13.22 15.22 15.22 15.22 13.22 ],[1 1 1 ]);\npatch([7.55 10.44 8.44 5.55 7.55 ],[11.22 11.22 13.22 13.22 11.22 ]"
+		  ",[0.931 0.946 0.973 ]);\npatch([5.55 8.44 10.44 7.55 5.55 ],[9.22 9.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([7.55 "
+		  "14.44 12.44 10.44 8.44 5.55 7.55 ],[7.22 7.22 9.22 7.22 9.22 9.22 7.22 ],[0.931 0.946 0.973 ]);\nfprintf('','COMME"
+		  "NT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'16');\nfp"
+		  "rintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Counter3"
+		  SID			  "901:5"
 		  Ports			  [4, 1]
 		  Position		  [185, 70, 235, 125]
+		  ZOrder		  -5
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Counter"
 		  SourceType		  "Xilinx Counter Block"
 		  infoedit		  "Hardware notes: Free running counters are the least expensive in hardware.  A count limited counter i"
@@ -28080,36 +30895,45 @@ Library {
 		  sggui_pos		  "20,20,348,618"
 		  block_type		  "counter"
 		  block_version		  "9.1.01"
-		  sg_icon_stat		  "50,55,1,1,white,blue,0,a6c633f8,right"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 ],[0 0 55 55 ],[0.77 0.82 0.91]);"
-		  "\npatch([11 3 15 3 11 24 28 32 46 35 24 16 28 16 24 35 46 32 28 24 11 ],[8 16 28 40 48 48 44 48 48 37 48 40 28 16 "
-		  "8 19 8 8 12 8 8 ],[0.98 0.96 0.92]);\nplot([0 50 50 0 0 ],[0 0 55 55 0 ]);\nfprintf('','COMMENT: end icon graphics"
-		  "');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('input',1,'load');\ncolor('black');port_la"
-		  "bel('input',2,'din');\ncolor('black');port_label('input',3,'rst');\ncolor('black');port_label('input',4,'en');\nco"
-		  "lor('black');port_label('output',1,'out');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_icon_stat		  "50,55,4,1,white,blue,0,cf0879bb,right,,[ ],[ ]"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 55 55 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 50 50 0 0 ],[0 0 55 55 0 ]);\npatch([9.425 19.54 26.54 33.54 40.54 26.54 16.425 9.425 ],[34.77 34.7"
+		  "7 41.77 34.77 41.77 41.77 41.77 34.77 ],[1 1 1 ]);\npatch([16.425 26.54 19.54 9.425 16.425 ],[27.77 27.77 34.77 34"
+		  ".77 27.77 ],[0.931 0.946 0.973 ]);\npatch([9.425 19.54 26.54 16.425 9.425 ],[20.77 20.77 27.77 27.77 20.77 ],[1 1 "
+		  "1 ]);\npatch([16.425 40.54 33.54 26.54 19.54 9.425 16.425 ],[13.77 13.77 20.77 13.77 20.77 20.77 13.77 ],[0.931 0."
+		  "946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');"
+		  "port_label('input',1,'load');\ncolor('black');port_label('input',2,'din');\ncolor('black');port_label('input',3,'r"
+		  "st');\ncolor('black');port_label('input',4,'en');\n\ncolor('black');disp('{\\fontsize{14}\\bf++}','texmode','on');"
+		  "\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Gateway Out1"
+		  SID			  "901:6"
 		  Ports			  [1, 1]
 		  Position		  [400, 26, 440, 34]
+		  ZOrder		  -6
 		  ShowName		  off
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Gateway Out"
 		  SourceType		  "Xilinx Gateway Out Block"
 		  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, "
 		  "or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, dep"
 		  "ending on how they are configured."
+		  inherit_from_input	  off
 		  hdl_port		  off
 		  timing_constraint	  "None"
 		  locs_specified	  off
 		  LOCs			  "{}"
+		  UseAsDAC		  off
+		  DACChannel		  "'1'"
 		  xl_use_area		  off
 		  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 		  has_advanced_control	  "0"
 		  sggui_pos		  "20,20,336,384"
 		  block_type		  "gatewayout"
 		  block_version		  "10.1.3"
-		  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+		  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 "
 		  "]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6."
 		  "11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0"
@@ -28122,25 +30946,31 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Gateway Out2"
+		  SID			  "901:7"
 		  Ports			  [1, 1]
 		  Position		  [400, 16, 440, 24]
+		  ZOrder		  -7
 		  ShowName		  off
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Gateway Out"
 		  SourceType		  "Xilinx Gateway Out Block"
 		  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, "
 		  "or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, dep"
 		  "ending on how they are configured."
+		  inherit_from_input	  off
 		  hdl_port		  off
 		  timing_constraint	  "None"
 		  locs_specified	  off
 		  LOCs			  "{}"
+		  UseAsDAC		  off
+		  DACChannel		  "'1'"
 		  xl_use_area		  off
 		  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 		  has_advanced_control	  "0"
 		  sggui_pos		  "20,20,336,384"
 		  block_type		  "gatewayout"
 		  block_version		  "10.1.3"
-		  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+		  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 "
 		  "]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6."
 		  "11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0"
@@ -28153,25 +30983,31 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Gateway Out3"
+		  SID			  "901:8"
 		  Ports			  [1, 1]
 		  Position		  [400, 36, 440, 44]
+		  ZOrder		  -8
 		  ShowName		  off
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Gateway Out"
 		  SourceType		  "Xilinx Gateway Out Block"
 		  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, "
 		  "or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, dep"
 		  "ending on how they are configured."
+		  inherit_from_input	  off
 		  hdl_port		  off
 		  timing_constraint	  "None"
 		  locs_specified	  off
 		  LOCs			  "{}"
+		  UseAsDAC		  off
+		  DACChannel		  "'1'"
 		  xl_use_area		  off
 		  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 		  has_advanced_control	  "0"
 		  sggui_pos		  "20,20,336,384"
 		  block_type		  "gatewayout"
 		  block_version		  "10.1.3"
-		  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+		  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 "
 		  "]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6."
 		  "11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0"
@@ -28184,25 +31020,31 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Gateway Out31"
+		  SID			  "901:9"
 		  Ports			  [1, 1]
 		  Position		  [400, 46, 440, 54]
+		  ZOrder		  -9
 		  ShowName		  off
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Gateway Out"
 		  SourceType		  "Xilinx Gateway Out Block"
 		  infoedit		  "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, double, "
 		  "or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are discarded, dep"
 		  "ending on how they are configured."
+		  inherit_from_input	  off
 		  hdl_port		  off
 		  timing_constraint	  "None"
 		  locs_specified	  off
 		  LOCs			  "{}"
+		  UseAsDAC		  off
+		  DACChannel		  "'1'"
 		  xl_use_area		  off
 		  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 		  has_advanced_control	  "0"
 		  sggui_pos		  "20,20,336,384"
 		  block_type		  "gatewayout"
 		  block_version		  "10.1.3"
-		  sg_icon_stat		  "40,8,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+		  sg_icon_stat		  "40,8,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 8 8 0 ],[0.88 0.88 0.88 "
 		  "]);\nplot([0 40 40 0 0 ],[0 0 8 8 0 ]);\npatch([17.775 19.22 20.22 21.22 22.22 20.22 18.775 17.775 ],[5.11 5.11 6."
 		  "11 5.11 6.11 6.11 6.11 5.11 ],[1 1 1 ]);\npatch([18.775 20.22 19.22 17.775 18.775 ],[4.11 4.11 5.11 5.11 4.11 ],[0"
@@ -28215,8 +31057,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical1"
+		  SID			  "901:10"
 		  Ports			  [2, 1]
 		  Position		  [340, 132, 385, 163]
+		  ZOrder		  -10
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "OR"
@@ -28247,8 +31092,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Relational5"
+		  SID			  "901:11"
 		  Ports			  [2, 1]
 		  Position		  [260, 133, 305, 177]
+		  ZOrder		  -11
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Relational"
 		  SourceType		  "Xilinx Arithmetic Relational Operator Block"
 		  mode			  "a!=b"
@@ -28274,8 +31122,10 @@ Library {
 		Block {
 		  BlockType		  Scope
 		  Name			  "input_debug"
+		  SID			  "901:12"
 		  Ports			  [4]
 		  Position		  [455, 16, 480, 54]
+		  ZOrder		  -12
 		  Floating		  off
 		  Location		  [1, 52, 1681, 1019]
 		  Open			  off
@@ -28288,6 +31138,7 @@ Library {
 		    axes3		    "cnt"
 		    axes4		    "fetch"
 		  }
+		  ShowLegends		  off
 		  YMin			  "12000~0~-5~-5"
 		  YMax			  "13300~1~5~5"
 		  SaveName		  "ScopeData4"
@@ -28298,7 +31149,9 @@ Library {
 		Block {
 		  BlockType		  Outport
 		  Name			  "out"
+		  SID			  "901:13"
 		  Position		  [420, 143, 450, 157]
+		  ZOrder		  -13
 		  IconDisplay		  "Port number"
 		}
 		Line {
@@ -28420,35 +31273,40 @@ Library {
 	    Block {
 	      BlockType		      SubSystem
 	      Name		      "pulse_ext1"
+	      SID		      "902"
 	      Ports		      [1, 1]
 	      Position		      [1120, 155, 1155, 175]
+	      ZOrder		      -139
 	      AncestorBlock	      "casper_library_misc/pulse_ext"
+	      LibraryVersion	      "*"
 	      MinAlgLoopOccurrences   off
 	      PropExecContextOutsideSubsystem off
 	      RTWSystemCode	      "Auto"
 	      FunctionWithSeparateData off
 	      Opaque		      off
+	      RequestExecContextInheritance off
 	      MaskHideContents	      off
-	      MaskType		      "pulse_ext"
-	      MaskDescription	      "Extends a boolean signal to be high for the specified number of clocks after\nthe last h"
-	      "igh input."
-	      MaskHelp		      "eval('xlWeb(''http://casper.berkeley.edu/wiki/Pulse_ext'')')"
-	      MaskPromptString	      "Length of Pulse"
-	      MaskStyleString	      "edit"
-	      MaskVariables	      "pulse_len=@1;"
-	      MaskTunableValueString  "on"
-	      MaskEnableString	      "on"
-	      MaskVisibilityString    "on"
-	      MaskToolTipString	      "on"
-	      MaskInitialization      "bits = ceil(log2(pulse_len+1));"
-	      MaskIconFrame	      on
-	      MaskIconOpaque	      on
-	      MaskIconRotate	      "none"
-	      MaskIconUnits	      "autoscale"
-	      MaskValueString	      "delay_qdr-delay_in_fifo"
+	      Object {
+		$PropName		"MaskObject"
+		$ObjectID		73
+		$ClassName		"Simulink.Mask"
+		Type			"pulse_ext"
+		Description		"Extends a boolean signal to be high for the specified number of clocks after\nthe last high input."
+		Help			"eval('xlWeb(''http://casper.berkeley.edu/wiki/Pulse_ext'')')"
+		Initialization		"bits = ceil(log2(pulse_len+1));"
+		Object {
+		  $PropName		  "Parameters"
+		  $ObjectID		  74
+		  $ClassName		  "Simulink.MaskParameter"
+		  Type			  "edit"
+		  Name			  "pulse_len"
+		  Prompt		  "Length of Pulse"
+		  Value			  "delay_qdr-delay_in_fifo"
+		}
+	      }
 	      System {
 		Name			"pulse_ext1"
-		Location		[445, 409, 1165, 745]
+		Location		[411, 290, 1179, 861]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -28461,18 +31319,24 @@ Library {
 		TiledPageScale		1
 		ShowPageBoundaries	off
 		ZoomFactor		"100"
+		SIDHighWatermark	"8"
 		Block {
 		  BlockType		  Inport
 		  Name			  "in"
+		  SID			  "902:1"
 		  Position		  [15, 98, 45, 112]
+		  ZOrder		  -1
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Constant5"
+		  SID			  "902:2"
 		  Ports			  [0, 1]
 		  Position		  [215, 154, 235, 176]
+		  ZOrder		  -2
 		  ShowName		  off
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Constant"
 		  SourceType		  "Xilinx Constant Block Block"
 		  const			  "pulse_len+1"
@@ -28497,18 +31361,23 @@ Library {
 		  sggui_pos		  "20,20,414,344"
 		  block_type		  "constant"
 		  block_version		  "9.1.01"
-		  sg_icon_stat		  "20,22,1,1,white,blue,0,7157ff2b,right"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 ],[0 0 26 26 ],[0.77 0.82 0.91]);"
-		  "\npatch([20 16 22 16 20 27 29 31 38 32 26 22 28 22 26 32 38 31 29 27 20 ],[3 7 13 19 23 23 21 23 23 17 23 19 13 7 "
-		  "3 9 3 3 5 3 3 ],[0.98 0.96 0.92]);\nplot([0 55 55 0 0 ],[0 0 26 26 0 ]);\nfprintf('','COMMENT: end icon graphics')"
-		  ";\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'11');\nfprintf('','COMMENT: end "
-		  "icon text');\n"
+		  sg_icon_stat		  "20,22,0,1,white,blue,0,997df0ab,right,,[ ],[ ]"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 20 20 0 0 ],[0 0 22 22 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 20 20 0 0 ],[0 0 22 22 0 ]);\npatch([5.55 8.44 10.44 12.44 14.44 10.44 7.55 5.55 ],[13.22 13.22 15."
+		  "22 13.22 15.22 15.22 15.22 13.22 ],[1 1 1 ]);\npatch([7.55 10.44 8.44 5.55 7.55 ],[11.22 11.22 13.22 13.22 11.22 ]"
+		  ",[0.931 0.946 0.973 ]);\npatch([5.55 8.44 10.44 7.55 5.55 ],[9.22 9.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([7.55 "
+		  "14.44 12.44 10.44 8.44 5.55 7.55 ],[7.22 7.22 9.22 7.22 9.22 9.22 7.22 ],[0.931 0.946 0.973 ]);\nfprintf('','COMME"
+		  "NT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'11');\nfp"
+		  "rintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Counter3"
+		  SID			  "902:3"
 		  Ports			  [2, 1]
 		  Position		  [185, 90, 235, 145]
+		  ZOrder		  -3
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Counter"
 		  SourceType		  "Xilinx Counter Block"
 		  infoedit		  "Hardware notes: Free running counters are the least expensive in hardware.  A count limited counter i"
@@ -28536,18 +31405,24 @@ Library {
 		  sggui_pos		  "20,20,348,618"
 		  block_type		  "counter"
 		  block_version		  "9.1.01"
-		  sg_icon_stat		  "50,55,1,1,white,blue,0,46c73e85,right"
-		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 ],[0 0 55 55 ],[0.77 0.82 0.91]);"
-		  "\npatch([11 3 15 3 11 24 28 32 46 35 24 16 28 16 24 35 46 32 28 24 11 ],[8 16 28 40 48 48 44 48 48 37 48 40 28 16 "
-		  "8 19 8 8 12 8 8 ],[0.98 0.96 0.92]);\nplot([0 50 50 0 0 ],[0 0 55 55 0 ]);\nfprintf('','COMMENT: end icon graphics"
-		  "');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('input',1,'rst');\ncolor('black');port_lab"
-		  "el('input',2,'en');\ncolor('black');port_label('output',1,'out');\nfprintf('','COMMENT: end icon text');\n"
+		  sg_icon_stat		  "50,55,2,1,white,blue,0,ae3608d6,right,,[ ],[ ]"
+		  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 55 55 0 ],[0.77 0.82 0.9"
+		  "1 ]);\nplot([0 50 50 0 0 ],[0 0 55 55 0 ]);\npatch([9.425 19.54 26.54 33.54 40.54 26.54 16.425 9.425 ],[34.77 34.7"
+		  "7 41.77 34.77 41.77 41.77 41.77 34.77 ],[1 1 1 ]);\npatch([16.425 26.54 19.54 9.425 16.425 ],[27.77 27.77 34.77 34"
+		  ".77 27.77 ],[0.931 0.946 0.973 ]);\npatch([9.425 19.54 26.54 16.425 9.425 ],[20.77 20.77 27.77 27.77 20.77 ],[1 1 "
+		  "1 ]);\npatch([16.425 40.54 33.54 26.54 19.54 9.425 16.425 ],[13.77 13.77 20.77 13.77 20.77 20.77 13.77 ],[0.931 0."
+		  "946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');"
+		  "port_label('input',1,'rst');\ncolor('black');port_label('input',2,'en');\n\ncolor('black');disp('{\\fontsize{14}\\"
+		  "bf++}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical"
+		  SID			  "902:4"
 		  Ports			  [2, 1]
 		  Position		  [370, 147, 415, 178]
+		  ZOrder		  -4
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -28578,8 +31453,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical1"
+		  SID			  "902:5"
 		  Ports			  [2, 1]
 		  Position		  [455, 142, 500, 173]
+		  ZOrder		  -5
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "OR"
@@ -28610,8 +31488,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Register"
+		  SID			  "902:6"
 		  Ports			  [2, 1]
 		  Position		  [175, 212, 235, 268]
+		  ZOrder		  -6
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Register"
 		  SourceType		  "Xilinx Register Block"
 		  init			  "0"
@@ -28637,8 +31518,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Relational5"
+		  SID			  "902:7"
 		  Ports			  [2, 1]
 		  Position		  [260, 133, 305, 177]
+		  ZOrder		  -7
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Relational"
 		  SourceType		  "Xilinx Arithmetic Relational Operator Block"
 		  mode			  "a!=b"
@@ -28664,7 +31548,9 @@ Library {
 		Block {
 		  BlockType		  Outport
 		  Name			  "out"
+		  SID			  "902:8"
 		  Position		  [580, 153, 610, 167]
+		  ZOrder		  -8
 		  IconDisplay		  "Port number"
 		}
 		Line {
@@ -28747,8 +31633,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "rb_addr"
+	      SID		      "903"
 	      Ports		      [2, 1]
 	      Position		      [915, 675, 975, 735]
+	      ZOrder		      -140
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Counter"
 	      SourceType	      "Xilinx Counter Block"
 	      infoedit		      "Hardware notes: Free running counters are the least expensive in hardware.  A count limited co"
@@ -28776,19 +31665,23 @@ Library {
 	      sggui_pos		      "20,20,348,618"
 	      block_type	      "counter"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "60,60,1,1,white,blue,0,46c73e85,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 60 60 ],[0.77 0.82 "
-	      "0.91]);\npatch([14 4 18 4 14 30 34 38 55 42 29 20 35 20 29 42 55 38 34 30 14 ],[6 16 30 44 54 54 50 54 54 41 54"
-	      " 45 30 15 6 19 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 60 60 0 ]);\nfprintf('','COMMENT: end "
-	      "icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('input',1,'rst');\ncolor('"
-	      "black');port_label('input',2,'en');\ncolor('black');port_label('output',1,'out');\nfprintf('','COMMENT: end ico"
-	      "n text');\n"
+	      sg_icon_stat	      "60,60,2,1,white,blue,0,ae3608d6,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 60 60 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 60 60 0 0 ],[0 0 60 60 0 ]);\npatch([12.2 23.76 31.76 39.76 47.76 31.76 20.2 12.2 ],[38.8"
+	      "8 38.88 46.88 38.88 46.88 46.88 46.88 38.88 ],[1 1 1 ]);\npatch([20.2 31.76 23.76 12.2 20.2 ],[30.88 30.88 38.8"
+	      "8 38.88 30.88 ],[0.931 0.946 0.973 ]);\npatch([12.2 23.76 31.76 20.2 12.2 ],[22.88 22.88 30.88 30.88 22.88 ],[1"
+	      " 1 1 ]);\npatch([20.2 47.76 39.76 31.76 23.76 12.2 20.2 ],[14.88 14.88 22.88 14.88 22.88 22.88 14.88 ],[0.931 0"
+	      ".946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('blac"
+	      "k');port_label('input',1,'rst');\ncolor('black');port_label('input',2,'en');\n\ncolor('black');disp('{\\fontsiz"
+	      "e{14}\\bf++}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Scope
 	      Name		      "rb_debug"
+	      SID		      "904"
 	      Ports		      [4]
 	      Position		      [1115, 823, 1140, 882]
+	      ZOrder		      -141
 	      Floating		      off
 	      Location		      [1, 52, 1681, 1019]
 	      Open		      off
@@ -28801,6 +31694,7 @@ Library {
 		axes3			"cnt_inc"
 		axes4			"fifo_full"
 	      }
+	      ShowLegends	      off
 	      TimeRange		      "10000"
 	      YMin		      "0~0~0~0"
 	      YMax		      "1~1000~1~1"
@@ -28812,32 +31706,35 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "rd_addr"
+	      SID		      "905"
 	      Tag		      "xps:sw_reg"
 	      Ports		      [1, 1]
 	      Position		      [720, 450, 820, 480]
+	      ZOrder		      -142
 	      BackgroundColor	      "[1.000000, 1.000000, 0.000000]"
+	      AttributesFormatString  "1output"
+	      LibraryVersion	      "1.521"
 	      SourceBlock	      "xps_library/software register"
-	      SourceType	      ""
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
+	      SourceType	      "swreg"
+	      mode		      "one value"
 	      io_dir		      "To Processor"
-	      arith_type	      "Unsigned"
-	      bitwidth		      "32"
-	      bin_pt		      "0"
+	      io_delay		      "0"
 	      sample_period	      "1"
-	      gw_name		      "casper_library_accumulators_qdr_vacc_acc_ctrl_rd_addr_user_data_in"
+	      names		      "reg"
+	      bitwidths		      "32"
+	      arith_types	      "0"
+	      bin_pts		      "0"
+	      sim_port		      on
+	      show_format	      off
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "rd_addr_cnt"
+	      SID		      "906"
 	      Ports		      [2, 1]
 	      Position		      [715, 240, 775, 300]
+	      ZOrder		      -143
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Counter"
 	      SourceType	      "Xilinx Counter Block"
 	      infoedit		      "Hardware notes: Free running counters are the least expensive in hardware.  A count limited co"
@@ -28865,19 +31762,24 @@ Library {
 	      sggui_pos		      "20,20,348,618"
 	      block_type	      "counter"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "60,60,1,1,white,blue,0,46c73e85,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 60 60 ],[0.77 0.82 "
-	      "0.91]);\npatch([14 4 18 4 14 30 34 38 55 42 29 20 35 20 29 42 55 38 34 30 14 ],[6 16 30 44 54 54 50 54 54 41 54"
-	      " 45 30 15 6 19 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 60 60 0 ]);\nfprintf('','COMMENT: end "
-	      "icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('input',1,'rst');\ncolor('"
-	      "black');port_label('input',2,'en');\ncolor('black');port_label('output',1,'out');\nfprintf('','COMMENT: end ico"
-	      "n text');\n"
+	      sg_icon_stat	      "60,60,2,1,white,blue,0,ae3608d6,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 60 60 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 60 60 0 0 ],[0 0 60 60 0 ]);\npatch([12.2 23.76 31.76 39.76 47.76 31.76 20.2 12.2 ],[38.8"
+	      "8 38.88 46.88 38.88 46.88 46.88 46.88 38.88 ],[1 1 1 ]);\npatch([20.2 31.76 23.76 12.2 20.2 ],[30.88 30.88 38.8"
+	      "8 38.88 30.88 ],[0.931 0.946 0.973 ]);\npatch([12.2 23.76 31.76 20.2 12.2 ],[22.88 22.88 30.88 30.88 22.88 ],[1"
+	      " 1 1 ]);\npatch([20.2 47.76 39.76 31.76 23.76 12.2 20.2 ],[14.88 14.88 22.88 14.88 22.88 22.88 14.88 ],[0.931 0"
+	      ".946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('blac"
+	      "k');port_label('input',1,'rst');\ncolor('black');port_label('input',2,'en');\n\ncolor('black');disp('{\\fontsiz"
+	      "e{14}\\bf++}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "rd_addr_sel"
+	      SID		      "907"
 	      Ports		      [3, 1]
 	      Position		      [1240, 196, 1270, 324]
+	      ZOrder		      -144
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Mux"
 	      SourceType	      "Xilinx Bus Multiplexer Block"
 	      inputs		      "2"
@@ -28910,8 +31812,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "rd_nwr"
+	      SID		      "908"
 	      Ports		      [3, 1]
 	      Position		      [1110, 196, 1140, 324]
+	      ZOrder		      -145
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Mux"
 	      SourceType	      "Xilinx Bus Multiplexer Block"
 	      inputs		      "2"
@@ -28944,8 +31849,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "reg_del"
+	      SID		      "909"
 	      Ports		      [1, 1]
 	      Position		      [665, 453, 690, 477]
+	      ZOrder		      -146
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -28974,8 +31882,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "vect_cnt"
+	      SID		      "910"
 	      Ports		      [2, 1]
 	      Position		      [240, 610, 300, 670]
+	      ZOrder		      -147
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Counter"
 	      SourceType	      "Xilinx Counter Block"
 	      infoedit		      "Hardware notes: Free running counters are the least expensive in hardware.  A count limited co"
@@ -29003,66 +31914,84 @@ Library {
 	      sggui_pos		      "20,20,348,618"
 	      block_type	      "counter"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "60,60,1,1,white,blue,0,46c73e85,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 60 60 ],[0.77 0.82 "
-	      "0.91]);\npatch([14 4 18 4 14 30 34 38 55 42 29 20 35 20 29 42 55 38 34 30 14 ],[6 16 30 44 54 54 50 54 54 41 54"
-	      " 45 30 15 6 19 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 60 60 0 ]);\nfprintf('','COMMENT: end "
-	      "icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('input',1,'rst');\ncolor('"
-	      "black');port_label('input',2,'en');\ncolor('black');port_label('output',1,'out');\nfprintf('','COMMENT: end ico"
-	      "n text');\n"
+	      sg_icon_stat	      "60,60,2,1,white,blue,0,ae3608d6,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 60 60 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 60 60 0 0 ],[0 0 60 60 0 ]);\npatch([12.2 23.76 31.76 39.76 47.76 31.76 20.2 12.2 ],[38.8"
+	      "8 38.88 46.88 38.88 46.88 46.88 46.88 38.88 ],[1 1 1 ]);\npatch([20.2 31.76 23.76 12.2 20.2 ],[30.88 30.88 38.8"
+	      "8 38.88 30.88 ],[0.931 0.946 0.973 ]);\npatch([12.2 23.76 31.76 20.2 12.2 ],[22.88 22.88 30.88 30.88 22.88 ],[1"
+	      " 1 1 ]);\npatch([20.2 47.76 39.76 31.76 23.76 12.2 20.2 ],[14.88 14.88 22.88 14.88 22.88 22.88 14.88 ],[0.931 0"
+	      ".946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('blac"
+	      "k');port_label('input',1,'rst');\ncolor('black');port_label('input',2,'en');\n\ncolor('black');disp('{\\fontsiz"
+	      "e{14}\\bf++}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "rd_en"
+	      SID		      "911"
 	      Position		      [1330, 113, 1360, 127]
+	      ZOrder		      -148
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "wr_en"
+	      SID		      "912"
 	      Position		      [1330, 73, 1360, 87]
+	      ZOrder		      -149
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "address"
+	      SID		      "913"
 	      Position		      [1330, 253, 1360, 267]
+	      ZOrder		      -150
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "fifo_rd_en"
+	      SID		      "914"
 	      Position		      [1325, 153, 1355, 167]
+	      ZOrder		      -151
 	      Port		      "4"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "RB_done"
+	      SID		      "915"
 	      Position		      [1510, 683, 1540, 697]
+	      ZOrder		      -152
 	      Port		      "5"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "rb_en"
+	      SID		      "916"
 	      Position		      [1510, 608, 1540, 622]
+	      ZOrder		      -153
 	      Port		      "6"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "blank"
+	      SID		      "917"
 	      Position		      [1300, 458, 1330, 472]
+	      ZOrder		      -154
 	      Port		      "7"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "new_acc"
+	      SID		      "918"
 	      Position		      [615, 653, 645, 667]
+	      ZOrder		      -155
 	      Port		      "8"
 	      IconDisplay	      "Port number"
 	    }
@@ -30036,16 +32965,20 @@ Library {
 	      DstPort		      4
 	    }
 	    Annotation {
+	      SID		      "919"
 	      Position		      [1566, 396]
 	    }
 	    Annotation {
+	      SID		      "920"
 	      Position		      [1587, 76]
 	    }
 	    Annotation {
+	      SID		      "921"
 	      Name		      "extend the pulse to\nburst_length"
 	      Position		      [141, 192]
 	    }
 	    Annotation {
+	      SID		      "922"
 	      Name		      "This block waits for a signal from the\nfifo input block that there is sufficient data\nto begin a"
 	      "n accumulate operation.\n\nIt then begins reading data out of the QDR and\nthen begins reading from the FIFO to"
 	      " ensure\nthat the data appears at the ACC block aligned.\n\nThis operation continues so long as there is\nsuffi"
@@ -30054,35 +32987,42 @@ Library {
 	      DropShadow	      on
 	    }
 	    Annotation {
+	      SID		      "923"
 	      Name		      "keep track of which half we're writing,\nand which half of memory \nheld the last accumulation."
 	      Position		      [377, 344]
 	      DropShadow	      on
 	    }
 	    Annotation {
+	      SID		      "924"
 	      Position		      [1601, 89]
 	    }
 	    Annotation {
+	      SID		      "925"
 	      Name		      "delay rb_done signal by\none less clock so that the last\ndata that is clocked into\nthe output bu"
 	      "ffer is tagged with RB_done"
 	      Position		      [1659, 693]
 	    }
 	    Annotation {
+	      SID		      "926"
 	      Name		      "Control the readback of the \nprevious accumulation."
 	      Position		      [939, 633]
 	      DropShadow	      on
 	    }
 	    Annotation {
+	      SID		      "927"
 	      Name		      "Control the blanking of the\nadders here (when starting a \nnew accumulation, add zero\nto first i"
 	      "ncomming vector)."
 	      Position		      [1129, 408]
 	      DropShadow	      on
 	    }
 	    Annotation {
+	      SID		      "928"
 	      Name		      "Calculate the address during ordinary \naccumulation operation."
 	      Position		      [744, 133]
 	      DropShadow	      on
 	    }
 	    Annotation {
+	      SID		      "929"
 	      Name		      "Decide when to start a new accumulation."
 	      Position		      [302, 549]
 	      DropShadow	      on
@@ -30092,8 +33032,10 @@ Library {
 	Block {
 	  BlockType		  Scope
 	  Name			  "acc_debug"
+	  SID			  "930"
 	  Ports			  [10]
 	  Position		  [1450, 425, 1485, 580]
+	  ZOrder		  -156
 	  Floating		  off
 	  Location		  [1, 44, 1921, 1101]
 	  Open			  off
@@ -30112,6 +33054,7 @@ Library {
 	    axes9		    "qdr_addr (aligned for writes)"
 	    axes10		    "new_acc"
 	  }
+	  ShowLegends		  off
 	  TimeRange		  "57000"
 	  YMin			  "0~0~0~0~0~0~0~0~0~0"
 	  YMax			  "90000~10000~12500~1~1~1~1~1~1250~1"
@@ -30123,9 +33066,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "delay"
+	  SID			  "931"
 	  Ports			  [1, 1]
 	  Position		  [605, 167, 620, 183]
+	  ZOrder		  -157
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -30153,9 +33099,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "delay1"
+	  SID			  "932"
 	  Ports			  [1, 1]
 	  Position		  [605, 212, 620, 228]
+	  ZOrder		  -158
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -30183,9 +33132,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "delay2"
+	  SID			  "933"
 	  Ports			  [1, 1]
 	  Position		  [600, 437, 615, 453]
+	  ZOrder		  -159
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -30213,11 +33165,17 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "fifo_in"
+	  SID			  "934"
 	  Ports			  [4, 4]
 	  Position		  [650, 163, 730, 277]
+	  ZOrder		  -160
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/FIFO"
 	  SourceType		  "Xilinx FIFO Block Block"
+	  mem_type		  "Block RAM"
 	  performance_options	  "Standard_FIFO"
+	  infoedit1		  "Available only for V4, V5, V6, V7, K7, A7 and Zynq devices."
+	  embedded_registers	  off
 	  depth			  "1K"
 	  percent_nbits		  "2"
 	  rst			  on
@@ -30229,7 +33187,6 @@ Library {
 	  use_almost_full	  off
 	  almost_full_thresh	  "14"
 	  dbl_ovrd		  off
-	  mem_type		  "Block RAM"
 	  xl_use_area		  off
 	  xl_area		  "[0,0,0,0,0,0,0]"
 	  explicit_period	  "off"
@@ -30252,11 +33209,17 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "fifo_out"
+	  SID			  "935"
 	  Ports			  [4, 4]
 	  Position		  [1780, 153, 1860, 267]
+	  ZOrder		  -161
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/FIFO"
 	  SourceType		  "Xilinx FIFO Block Block"
+	  mem_type		  "Block RAM"
 	  performance_options	  "Standard_FIFO"
+	  infoedit1		  "Available only for V4, V5, V6, V7, K7, A7 and Zynq devices."
+	  embedded_registers	  off
 	  depth			  "1K"
 	  percent_nbits		  "2"
 	  rst			  on
@@ -30268,7 +33231,6 @@ Library {
 	  use_almost_full	  off
 	  almost_full_thresh	  "14"
 	  dbl_ovrd		  off
-	  mem_type		  "Block RAM"
 	  xl_use_area		  off
 	  xl_area		  "[0,0,0,0,0,0,0]"
 	  explicit_period	  "off"
@@ -30291,8 +33253,10 @@ Library {
 	Block {
 	  BlockType		  Scope
 	  Name			  "in_buf_debug"
+	  SID			  "936"
 	  Ports			  [5]
 	  Position		  [915, 58, 940, 132]
+	  ZOrder		  -162
 	  Floating		  off
 	  Location		  [5, 52, 1685, 1019]
 	  Open			  off
@@ -30306,6 +33270,7 @@ Library {
 	    axes4		    "fifo_rd_en"
 	    axes5		    "rst"
 	  }
+	  ShowLegends		  off
 	  YMin			  "7.6~-1~-1~-1~-1"
 	  YMax			  "8.4~1~1~1~1"
 	  SaveName		  "ScopeData2"
@@ -30316,8 +33281,10 @@ Library {
 	Block {
 	  BlockType		  Scope
 	  Name			  "input_debug"
+	  SID			  "937"
 	  Ports			  [4]
 	  Position		  [635, 61, 660, 99]
+	  ZOrder		  -163
 	  Floating		  off
 	  Location		  [5, 34, 1689, 1035]
 	  Open			  off
@@ -30330,6 +33297,7 @@ Library {
 	    axes3		    "valid_data"
 	    axes4		    "rst"
 	  }
+	  ShowLegends		  off
 	  YMin			  "12000~0~-5~-5"
 	  YMax			  "13300~1~5~5"
 	  SaveName		  "ScopeData1"
@@ -30340,8 +33308,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "make_odd_delay"
+	  SID			  "938"
 	  Ports			  [1, 1]
 	  Position		  [1455, 148, 1480, 172]
+	  ZOrder		  -164
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -30369,8 +33340,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "make_odd_delay1"
+	  SID			  "939"
 	  Ports			  [1, 1]
 	  Position		  [1455, 183, 1480, 207]
+	  ZOrder		  -165
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -30398,246 +33372,179 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "negedge_delay"
+	  SID			  "940"
 	  Ports			  [1, 1]
 	  Position		  [1105, 806, 1140, 824]
+	  ZOrder		  -166
+	  LibraryVersion	  "1.43"
 	  SourceBlock		  "casper_library_misc/negedge_delay"
 	  SourceType		  "negedge_delay"
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
 	  pulse_len		  "2^23"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "negedge_delay1"
+	  SID			  "941"
 	  Ports			  [1, 1]
 	  Position		  [1105, 786, 1140, 804]
+	  ZOrder		  -167
+	  LibraryVersion	  "1.43"
 	  SourceBlock		  "casper_library_misc/negedge_delay"
 	  SourceType		  "negedge_delay"
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
 	  pulse_len		  "2^23"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "negedge_delay10"
+	  SID			  "942"
 	  Ports			  [1, 1]
 	  Position		  [1105, 606, 1140, 624]
+	  ZOrder		  -168
+	  LibraryVersion	  "1.43"
 	  SourceBlock		  "casper_library_misc/negedge_delay"
 	  SourceType		  "negedge_delay"
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
 	  pulse_len		  "2^23"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "negedge_delay11"
+	  SID			  "943"
 	  Ports			  [1, 1]
 	  Position		  [1105, 586, 1140, 604]
+	  ZOrder		  -169
+	  LibraryVersion	  "1.43"
 	  SourceBlock		  "casper_library_misc/negedge_delay"
 	  SourceType		  "negedge_delay"
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
 	  pulse_len		  "2^23"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "negedge_delay12"
+	  SID			  "944"
 	  Ports			  [1, 1]
 	  Position		  [1105, 566, 1140, 584]
+	  ZOrder		  -170
+	  LibraryVersion	  "1.43"
 	  SourceBlock		  "casper_library_misc/negedge_delay"
 	  SourceType		  "negedge_delay"
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
 	  pulse_len		  "2^23"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "negedge_delay13"
+	  SID			  "945"
 	  Ports			  [1, 1]
 	  Position		  [1105, 546, 1140, 564]
+	  ZOrder		  -171
+	  LibraryVersion	  "1.43"
 	  SourceBlock		  "casper_library_misc/negedge_delay"
 	  SourceType		  "negedge_delay"
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
 	  pulse_len		  "2^23"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "negedge_delay2"
+	  SID			  "946"
 	  Ports			  [1, 1]
 	  Position		  [1105, 766, 1140, 784]
+	  ZOrder		  -172
+	  LibraryVersion	  "1.43"
 	  SourceBlock		  "casper_library_misc/negedge_delay"
 	  SourceType		  "negedge_delay"
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
 	  pulse_len		  "2^23"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "negedge_delay3"
+	  SID			  "947"
 	  Ports			  [1, 1]
 	  Position		  [1105, 746, 1140, 764]
+	  ZOrder		  -173
+	  LibraryVersion	  "1.43"
 	  SourceBlock		  "casper_library_misc/negedge_delay"
 	  SourceType		  "negedge_delay"
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
 	  pulse_len		  "2^23"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "negedge_delay4"
+	  SID			  "948"
 	  Ports			  [1, 1]
 	  Position		  [1105, 726, 1140, 744]
+	  ZOrder		  -174
+	  LibraryVersion	  "1.43"
 	  SourceBlock		  "casper_library_misc/negedge_delay"
 	  SourceType		  "negedge_delay"
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
 	  pulse_len		  "2^23"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "negedge_delay5"
+	  SID			  "949"
 	  Ports			  [1, 1]
 	  Position		  [1105, 706, 1140, 724]
+	  ZOrder		  -175
+	  LibraryVersion	  "1.43"
 	  SourceBlock		  "casper_library_misc/negedge_delay"
 	  SourceType		  "negedge_delay"
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
 	  pulse_len		  "2^23"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "negedge_delay6"
+	  SID			  "950"
 	  Ports			  [1, 1]
 	  Position		  [1105, 686, 1140, 704]
+	  ZOrder		  -176
+	  LibraryVersion	  "1.43"
 	  SourceBlock		  "casper_library_misc/negedge_delay"
 	  SourceType		  "negedge_delay"
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
 	  pulse_len		  "2^23"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "negedge_delay7"
+	  SID			  "951"
 	  Ports			  [1, 1]
 	  Position		  [1105, 666, 1140, 684]
+	  ZOrder		  -177
+	  LibraryVersion	  "1.43"
 	  SourceBlock		  "casper_library_misc/negedge_delay"
 	  SourceType		  "negedge_delay"
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
 	  pulse_len		  "2^23"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "negedge_delay8"
+	  SID			  "952"
 	  Ports			  [1, 1]
 	  Position		  [1105, 646, 1140, 664]
+	  ZOrder		  -178
+	  LibraryVersion	  "1.43"
 	  SourceBlock		  "casper_library_misc/negedge_delay"
 	  SourceType		  "negedge_delay"
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
 	  pulse_len		  "2^23"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "negedge_delay9"
+	  SID			  "953"
 	  Ports			  [1, 1]
 	  Position		  [1105, 626, 1140, 644]
+	  ZOrder		  -179
+	  LibraryVersion	  "1.43"
 	  SourceBlock		  "casper_library_misc/negedge_delay"
 	  SourceType		  "negedge_delay"
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
 	  pulse_len		  "2^23"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "out_valid_delay"
+	  SID			  "954"
 	  Ports			  [1, 1]
 	  Position		  [2015, 183, 2040, 197]
+	  ZOrder		  -180
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -30665,8 +33572,10 @@ Library {
 	Block {
 	  BlockType		  Scope
 	  Name			  "output_debug"
+	  SID			  "955"
 	  Ports			  [7]
 	  Position		  [1750, 348, 1780, 472]
+	  ZOrder		  -181
 	  Floating		  off
 	  Location		  [6, 52, 1686, 1019]
 	  Open			  off
@@ -30682,6 +33591,7 @@ Library {
 	    axes6		    "output afull"
 	    axes7		    "qdr_valid"
 	  }
+	  ShowLegends		  off
 	  YMin			  "0~0~0~0~0~0~0"
 	  YMax			  "4.5e+009~1~1250~1~1~1~1"
 	  SaveName		  "ScopeData3"
@@ -30692,20 +33602,15 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "qdr"
+	  SID			  "956"
 	  Tag			  "xps:qdr"
 	  Ports			  [5, 5]
 	  Position		  [1320, 138, 1435, 322]
+	  ZOrder		  -182
 	  BackgroundColor	  "[1.000000, 1.000000, 0.000000]"
+	  LibraryVersion	  "1.521"
 	  SourceBlock		  "xps_library/qdr"
 	  SourceType		  "qdr"
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
 	  which_qdr		  "qdr0"
 	  qdr_awidth		  "13"
 	  use_sniffer		  off
@@ -30713,9 +33618,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "qdr_del_comp"
+	  SID			  "957"
 	  Ports			  [1, 1]
 	  Position		  [1610, 388, 1625, 402]
+	  ZOrder		  -183
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -30743,9 +33651,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "qdr_del_comp1"
+	  SID			  "958"
 	  Ports			  [1, 1]
 	  Position		  [1610, 418, 1625, 432]
+	  ZOrder		  -184
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -30773,9 +33684,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "qdr_del_comp2"
+	  SID			  "959"
 	  Ports			  [1, 1]
 	  Position		  [1315, 428, 1330, 442]
+	  ZOrder		  -185
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -30803,9 +33717,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "qdr_del_comp3"
+	  SID			  "960"
 	  Ports			  [1, 1]
 	  Position		  [1315, 443, 1330, 457]
+	  ZOrder		  -186
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -30833,9 +33750,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "qdr_del_comp4"
+	  SID			  "961"
 	  Ports			  [1, 1]
 	  Position		  [1315, 533, 1330, 547]
+	  ZOrder		  -187
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -30863,9 +33783,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "qdr_del_comp5"
+	  SID			  "962"
 	  Ports			  [1, 1]
 	  Position		  [1315, 488, 1330, 502]
+	  ZOrder		  -188
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -30893,9 +33816,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "qdr_del_comp6"
+	  SID			  "963"
 	  Ports			  [1, 1]
 	  Position		  [1315, 518, 1330, 532]
+	  ZOrder		  -189
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -30923,9 +33849,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "qdr_del_comp7"
+	  SID			  "964"
 	  Ports			  [1, 1]
 	  Position		  [1315, 503, 1330, 517]
+	  ZOrder		  -190
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -30953,9 +33882,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "qdr_del_comp8"
+	  SID			  "965"
 	  Ports			  [1, 1]
 	  Position		  [1315, 563, 1330, 577]
+	  ZOrder		  -191
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -30983,8 +33915,10 @@ Library {
 	Block {
 	  BlockType		  Scope
 	  Name			  "rd_wr_debug"
+	  SID			  "966"
 	  Ports			  [3]
 	  Position		  [1310, 21, 1335, 59]
+	  ZOrder		  -192
 	  Floating		  off
 	  Location		  [6, 34, 1690, 1035]
 	  Open			  off
@@ -30996,6 +33930,7 @@ Library {
 	    axes2		    "wr_en"
 	    axes3		    "addr"
 	  }
+	  ShowLegends		  off
 	  YMin			  "0~0~0"
 	  YMax			  "1~1~1050"
 	  DataFormat		  "StructureWithTime"
@@ -31005,8 +33940,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "rst_delay"
+	  SID			  "967"
 	  Ports			  [1, 1]
 	  Position		  [1680, 243, 1705, 267]
+	  ZOrder		  -193
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -31034,8 +33972,11 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "stat_del"
+	  SID			  "968"
 	  Ports			  [1, 1]
 	  Position		  [1235, 673, 1260, 697]
+	  ZOrder		  -194
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -31063,9 +34004,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "stat_del1"
+	  SID			  "969"
 	  Ports			  [1, 1]
 	  Position		  [1065, 808, 1080, 822]
+	  ZOrder		  -195
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -31093,9 +34037,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "stat_del10"
+	  SID			  "970"
 	  Ports			  [1, 1]
 	  Position		  [1065, 628, 1080, 642]
+	  ZOrder		  -196
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -31123,9 +34070,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "stat_del11"
+	  SID			  "971"
 	  Ports			  [1, 1]
 	  Position		  [1065, 608, 1080, 622]
+	  ZOrder		  -197
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -31153,9 +34103,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "stat_del12"
+	  SID			  "972"
 	  Ports			  [1, 1]
 	  Position		  [1065, 588, 1080, 602]
+	  ZOrder		  -198
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -31183,9 +34136,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "stat_del13"
+	  SID			  "973"
 	  Ports			  [1, 1]
 	  Position		  [1065, 568, 1080, 582]
+	  ZOrder		  -199
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -31213,9 +34169,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "stat_del14"
+	  SID			  "974"
 	  Ports			  [1, 1]
 	  Position		  [1065, 548, 1080, 562]
+	  ZOrder		  -200
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -31243,9 +34202,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "stat_del15"
+	  SID			  "975"
 	  Ports			  [1, 1]
 	  Position		  [1965, 498, 1980, 512]
+	  ZOrder		  -201
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -31273,9 +34235,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "stat_del2"
+	  SID			  "976"
 	  Ports			  [1, 1]
 	  Position		  [1065, 788, 1080, 802]
+	  ZOrder		  -202
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -31303,9 +34268,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "stat_del3"
+	  SID			  "977"
 	  Ports			  [1, 1]
 	  Position		  [1065, 768, 1080, 782]
+	  ZOrder		  -203
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -31333,9 +34301,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "stat_del4"
+	  SID			  "978"
 	  Ports			  [1, 1]
 	  Position		  [1065, 748, 1080, 762]
+	  ZOrder		  -204
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -31363,9 +34334,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "stat_del5"
+	  SID			  "979"
 	  Ports			  [1, 1]
 	  Position		  [1065, 728, 1080, 742]
+	  ZOrder		  -205
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -31393,9 +34367,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "stat_del6"
+	  SID			  "980"
 	  Ports			  [1, 1]
 	  Position		  [1065, 708, 1080, 722]
+	  ZOrder		  -206
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -31423,9 +34400,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "stat_del7"
+	  SID			  "981"
 	  Ports			  [1, 1]
 	  Position		  [1065, 688, 1080, 702]
+	  ZOrder		  -207
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -31453,9 +34433,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "stat_del8"
+	  SID			  "982"
 	  Ports			  [1, 1]
 	  Position		  [1065, 668, 1080, 682]
+	  ZOrder		  -208
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -31483,9 +34466,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "stat_del9"
+	  SID			  "983"
 	  Ports			  [1, 1]
 	  Position		  [1065, 648, 1080, 662]
+	  ZOrder		  -209
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -31513,33 +34499,36 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "status"
+	  SID			  "984"
 	  Tag			  "xps:sw_reg"
 	  Ports			  [1, 1]
 	  Position		  [1290, 670, 1390, 700]
+	  ZOrder		  -210
 	  BackgroundColor	  "[1.000000, 1.000000, 0.000000]"
+	  AttributesFormatString  "1output"
+	  LibraryVersion	  "1.521"
 	  SourceBlock		  "xps_library/software register"
-	  SourceType		  ""
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
+	  SourceType		  "swreg"
+	  mode			  "one value"
 	  io_dir		  "To Processor"
-	  arith_type		  "Unsigned"
-	  bitwidth		  "32"
-	  bin_pt		  "0"
+	  io_delay		  "0"
 	  sample_period		  "1"
-	  gw_name		  "casper_library_accumulators_qdr_vacc_status_user_data_in"
+	  names			  "reg"
+	  bitwidths		  "32"
+	  arith_types		  "0"
+	  bin_pts		  "0"
+	  sim_port		  on
+	  show_format		  off
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "sync_count"
+	  SID			  "985"
 	  Ports			  [2, 1]
 	  Position		  [295, 411, 340, 449]
+	  ZOrder		  -211
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Counter"
 	  SourceType		  "Xilinx Counter Block"
 	  infoedit		  "Hardware notes: Free running counters are the least expensive in hardware.  A count limited counter is"
@@ -31567,18 +34556,23 @@ Library {
 	  sggui_pos		  "20,20,348,619"
 	  block_type		  "counter"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "45,38,2,1,white,blue,0,46c73e85,right"
-	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 60 60 ],[0.77 0.82 0.91]);\n"
-	  "patch([14 4 18 4 14 30 34 38 55 42 29 20 35 20 29 42 55 38 34 30 14 ],[6 16 30 44 54 54 50 54 54 41 54 45 30 15 6 1"
-	  "9 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 60 60 0 ]);\nfprintf('','COMMENT: end icon graphics');\n"
-	  "fprintf('','COMMENT: begin icon text');\ncolor('black');port_label('input',1,'rst');\ncolor('black');port_label('in"
-	  "put',2,'en');\ncolor('black');port_label('output',1,'out');\nfprintf('','COMMENT: end icon text');\n"
+	  sg_icon_stat		  "45,38,2,1,white,blue,0,ae3608d6,right,,[ ],[ ]"
+	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 45 45 0 0 ],[0 0 38 38 0 ],[0.77 0.82 0.91"
+	  " ]);\nplot([0 45 45 0 0 ],[0 0 38 38 0 ]);\npatch([10.875 18.1 23.1 28.1 33.1 23.1 15.875 10.875 ],[24.55 24.55 29."
+	  "55 24.55 29.55 29.55 29.55 24.55 ],[1 1 1 ]);\npatch([15.875 23.1 18.1 10.875 15.875 ],[19.55 19.55 24.55 24.55 19."
+	  "55 ],[0.931 0.946 0.973 ]);\npatch([10.875 18.1 23.1 15.875 10.875 ],[14.55 14.55 19.55 19.55 14.55 ],[1 1 1 ]);\np"
+	  "atch([15.875 33.1 28.1 23.1 18.1 10.875 15.875 ],[9.55 9.55 14.55 9.55 14.55 14.55 9.55 ],[0.931 0.946 0.973 ]);\nf"
+	  "printf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('input"
+	  "',1,'rst');\ncolor('black');port_label('input',2,'en');\n\ncolor('black');disp('{\\fontsize{14}\\bf++}','texmode','"
+	  "on');\nfprintf('','COMMENT: end icon text');"
 	}
 	Block {
 	  BlockType		  Scope
 	  Name			  "sync_debug"
+	  SID			  "986"
 	  Ports			  [4]
 	  Position		  [670, 361, 695, 399]
+	  ZOrder		  -212
 	  Floating		  off
 	  Location		  [6, 52, 1686, 1019]
 	  Open			  off
@@ -31591,6 +34585,7 @@ Library {
 	    axes3		    "resync (rst)"
 	    axes4		    "data_in"
 	  }
+	  ShowLegends		  off
 	  YMin			  "-1~0~-1~0"
 	  YMax			  "1~1000~1~10000"
 	  SaveName		  "ScopeData2"
@@ -31601,48 +34596,62 @@ Library {
 	Block {
 	  BlockType		  Outport
 	  Name			  "new_acc (ASYNC)"
+	  SID			  "987"
 	  Position		  [2010, 498, 2040, 512]
+	  ZOrder		  -213
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Outport
 	  Name			  "data_out"
+	  SID			  "988"
 	  Position		  [2060, 113, 2090, 127]
+	  ZOrder		  -214
 	  Port			  "2"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Outport
 	  Name			  "oob_data_out"
+	  SID			  "989"
 	  Position		  [2060, 83, 2090, 97]
+	  ZOrder		  -215
 	  Port			  "3"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Outport
 	  Name			  "valid"
+	  SID			  "990"
 	  Position		  [2060, 183, 2090, 197]
+	  ZOrder		  -216
 	  Port			  "4"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Outport
 	  Name			  "error"
+	  SID			  "991"
 	  Position		  [2020, 403, 2050, 417]
+	  ZOrder		  -217
 	  Port			  "5"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Outport
 	  Name			  "RB_done"
+	  SID			  "992"
 	  Position		  [2060, 53, 2090, 67]
+	  ZOrder		  -218
 	  Port			  "6"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Outport
 	  Name			  "fifo_afull"
+	  SID			  "993"
 	  Position		  [810, 193, 840, 207]
+	  ZOrder		  -219
 	  Port			  "7"
 	  IconDisplay		  "Port number"
 	}
@@ -33011,22 +36020,27 @@ Library {
 	  DstPort		  1
 	}
 	Annotation {
+	  SID			  "994"
 	  Position		  [1789, 410]
 	}
 	Annotation {
+	  SID			  "995"
 	  Name			  "updated QDR has delay 10.\nNeed to add one more cycle delay\nto keep it an odd number for acc_ctl logic."
 	  Position		  [1385, 364]
 	}
 	Annotation {
+	  SID			  "996"
 	  Name			  "FIFO has delay 1"
 	  Position		  [682, 310]
 	}
 	Annotation {
+	  SID			  "997"
 	  Name			  "acc takes in a 36-bit unsigned \nnumber, representing:\n32-bit + 4-bit and \nincurs a two clock-cycle del"
 	  "ay"
 	  Position		  [1107, 380]
 	}
 	Annotation {
+	  SID			  "998"
 	  Position		  [1471, 477]
 	}
       }
@@ -33034,8 +36048,10 @@ Library {
     Block {
       BlockType		      SubSystem
       Name		      "simple_bram_vacc"
+      SID		      "999"
       Ports		      [2, 2]
       Position		      [25, 21, 100, 59]
+      ZOrder		      -5
       BackgroundColor	      "[0.500000, 1.000000, 0.500000]"
       UserDataPersistent      on
       UserData		      "DataTag2"
@@ -33044,28 +36060,62 @@ Library {
       RTWSystemCode	      "Auto"
       FunctionWithSeparateData off
       Opaque		      off
+      RequestExecContextInheritance off
       MaskHideContents	      off
-      MaskType		      "simple_bram_vacc"
-      MaskDescription	      "This simple vector accumulator is based on a shift register. It outputs its previous accu"
-      "mulated vector after a new_acc pulse is received."
-      MaskPromptString	      "Vector length:|Output type:|Bit width (output):|Binary point (output):"
-      MaskStyleString	      "edit,popup(Signed|Unsigned),edit,edit"
-      MaskVariables	      "vec_len=@1;arith_type=&2;n_bits=@3;bin_pt=@4;"
-      MaskTunableValueString  "on,on,on,on"
-      MaskCallbackString      "|||"
-      MaskEnableString	      "on,on,on,on"
-      MaskVisibilityString    "on,on,on,on"
-      MaskToolTipString	      "on,on,on,on"
-      MaskInitialization      "simple_bram_vacc_init(gcb, ...\n    'vec_len', vec_len, ...\n    'arith_type', arith_ty"
-      "pe, ...\n    'n_bits', n_bits, ...\n    'bin_pt', bin_pt);"
-      MaskIconFrame	      on
-      MaskIconOpaque	      on
-      MaskIconRotate	      "none"
-      MaskIconUnits	      "autoscale"
-      MaskValueString	      "8|Signed|32|0"
+      Object {
+	$PropName		"MaskObject"
+	$ObjectID		75
+	$ClassName		"Simulink.Mask"
+	Type			"simple_bram_vacc"
+	Description		"This simple vector accumulator is based on a shift register. It outputs its previous accumulated vector"
+	" after a new_acc pulse is received."
+	Initialization		"simple_bram_vacc_init(gcb, ...\n    'vec_len', vec_len, ...\n    'arith_type', arith_type, ...\n    "
+	"'n_bits', n_bits, ...\n    'bin_pt', bin_pt);"
+	Array {
+	  Type			  "Simulink.MaskParameter"
+	  Dimension		  4
+	  Object {
+	    $ObjectID		    76
+	    Type		    "edit"
+	    Name		    "vec_len"
+	    Prompt		    "Vector length:"
+	    Value		    "8"
+	  }
+	  Object {
+	    $ObjectID		    77
+	    Type		    "popup"
+	    Array {
+	      Type		      "Cell"
+	      Dimension		      2
+	      Cell		      "Signed"
+	      Cell		      "Unsigned"
+	      PropName		      "TypeOptions"
+	    }
+	    Name		    "arith_type"
+	    Prompt		    "Output type:"
+	    Value		    "Signed"
+	    Evaluate		    "off"
+	  }
+	  Object {
+	    $ObjectID		    78
+	    Type		    "edit"
+	    Name		    "n_bits"
+	    Prompt		    "Bit width (output):"
+	    Value		    "32"
+	  }
+	  Object {
+	    $ObjectID		    79
+	    Type		    "edit"
+	    Name		    "bin_pt"
+	    Prompt		    "Binary point (output):"
+	    Value		    "0"
+	  }
+	  PropName		  "Parameters"
+	}
+      }
       System {
 	Name			"simple_bram_vacc"
-	Location		[290, 77, 730, 233]
+	Location		[0, 27, 1920, 1200]
 	Open			off
 	ModelBrowserVisibility	off
 	ModelBrowserWidth	200
@@ -33077,26 +36127,33 @@ Library {
 	TiledPaperMargins	[0.500000, 0.500000, 0.500000, 0.500000]
 	TiledPageScale		1
 	ShowPageBoundaries	off
-	ZoomFactor		"100"
+	ZoomFactor		"200"
 	Block {
 	  BlockType		  Inport
 	  Name			  "new_acc"
+	  SID			  "1000"
 	  Position		  [15, 68, 45, 82]
+	  ZOrder		  -1
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Inport
 	  Name			  "din"
+	  SID			  "1001"
 	  Position		  [205, 68, 235, 82]
+	  ZOrder		  -2
 	  Port			  "2"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "Adder"
+	  SID			  "1002"
 	  Ports			  [2, 1]
 	  Position		  [255, 67, 285, 103]
+	  ZOrder		  -3
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/AddSub"
 	  SourceType		  "Xilinx Adder/Subtracter Block"
 	  mode			  "Addition"
@@ -33118,25 +36175,28 @@ Library {
 	  xl_area		  "[0, 0, 0, 0, 0, 0, 0]"
 	  use_rpm		  "on"
 	  has_advanced_control	  "0"
-	  sggui_pos		  "0,0,419,344"
+	  sggui_pos		  "-9,19,419,344"
 	  block_type		  "addsub"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "30,36,2,1,white,blue,0,4922a24f,right,"
-	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 1 1 0 ],[0 0 1 1 ],[0.77 0.82 0.91]);\npat"
-	  "ch([0.233333 0.0666667 0.3 0.0666667 0.233333 0.5 0.566667 0.633333 0.9 0.666667 0.466667 0.3 0.5 0.3 0.466667 0.66"
-	  "6667 0.9 0.633333 0.566667 0.5 0.233333 ],[0.166667 0.305556 0.5 0.694444 0.833333 0.833333 0.777778 0.833333 0.833"
-	  "333 0.638889 0.805556 0.666667 0.5 0.333333 0.194444 0.361111 0.166667 0.166667 0.222222 0.166667 0.166667 ],[0.98 "
-	  "0.96 0.92]);\nplot([0 1 1 0 0 ],[0 0 1 1 0 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: beg"
-	  "in icon text');\ncolor('black');port_label('input',1,'a');\ncolor('black');port_label('input',2,'b');\ncolor('black"
-	  "');port_label('output',1,'\\bf{a + b}','texmode','on');\ncolor('black');disp('\\newline\\bf{}\\newlinez^{-2}','texm"
-	  "ode','on');\nfprintf('','COMMENT: end icon text');\n"
+	  sg_icon_stat		  "30,36,2,1,white,blue,0,dcac4ee3,right,,[ ],[ ]"
+	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 0 ],[0 0 58 58 0 ],[0.77 0.82 0.91"
+	  " ]);\nplot([0 60 60 0 0 ],[0 0 58 58 0 ]);\npatch([12.2 23.76 31.76 39.76 47.76 31.76 20.2 12.2 ],[37.88 37.88 45.8"
+	  "8 37.88 45.88 45.88 45.88 37.88 ],[1 1 1 ]);\npatch([20.2 31.76 23.76 12.2 20.2 ],[29.88 29.88 37.88 37.88 29.88 ],"
+	  "[0.931 0.946 0.973 ]);\npatch([12.2 23.76 31.76 20.2 12.2 ],[21.88 21.88 29.88 29.88 21.88 ],[1 1 1 ]);\npatch([20."
+	  "2 47.76 39.76 31.76 23.76 12.2 20.2 ],[13.88 13.88 21.88 13.88 21.88 21.88 13.88 ],[0.931 0.946 0.973 ]);\nfprintf("
+	  "'','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('input',1,'a'"
+	  ");\ncolor('black');port_label('input',2,'b');\ncolor('black');port_label('output',1,'\\bf{a + b}','texmode','on');\n"
+	  "fprintf('','COMMENT: end icon text');"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "Constant"
+	  SID			  "1003"
 	  Ports			  [0, 1]
 	  Position		  [110, 107, 140, 123]
+	  ZOrder		  -4
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Constant"
 	  SourceType		  "Xilinx Constant Block Block"
 	  const			  "0"
@@ -33161,13 +36221,14 @@ Library {
 	  sggui_pos		  "-1,-1,-1,-1"
 	  block_type		  "constant"
 	  block_version		  "10.1.3"
-	  sg_icon_stat		  "30,16,0,1,white,blue,0,bf4ddd8b,right,"
-	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 1 1 0 ],[0 0 1 1 ],[0.77 0.82 0.91]);\npat"
-	  "ch([0.366667 0.266667 0.4 0.266667 0.366667 0.5 0.533333 0.566667 0.733333 0.6 0.5 0.433333 0.566667 0.433333 0.5 0"
-	  ".6 0.733333 0.566667 0.533333 0.5 0.366667 ],[0.125 0.3125 0.5625 0.8125 1 1 0.9375 1 1 0.75 0.9375 0.8125 0.5625 0"
-	  ".3125 0.1875 0.375 0.125 0.125 0.1875 0.125 0.125 ],[0.98 0.96 0.92]);\nplot([0 1 1 0 0 ],[0 0 1 1 0 ]);\nfprintf('"
-	  "','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('output',1,'0'"
-	  ");\nfprintf('','COMMENT: end icon text');\n"
+	  sg_icon_stat		  "30,16,0,1,white,blue,0,bf4ddd8b,right,,[ ],[ ]"
+	  sg_mask_display	  "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 0 ],[0 0 26 26 0 ],[0.77 0.82 0.91"
+	  " ]);\nplot([0 55 55 0 0 ],[0 0 26 26 0 ]);\npatch([20.325 24.66 27.66 30.66 33.66 27.66 23.325 20.325 ],[16.33 16.3"
+	  "3 19.33 16.33 19.33 19.33 19.33 16.33 ],[1 1 1 ]);\npatch([23.325 27.66 24.66 20.325 23.325 ],[13.33 13.33 16.33 16"
+	  ".33 13.33 ],[0.931 0.946 0.973 ]);\npatch([20.325 24.66 27.66 23.325 20.325 ],[10.33 10.33 13.33 13.33 10.33 ],[1 1"
+	  " 1 ]);\npatch([23.325 33.66 30.66 27.66 24.66 20.325 23.325 ],[7.33 7.33 10.33 7.33 10.33 10.33 7.33 ],[0.931 0.946"
+	  " 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port"
+	  "_label('output',1,'1');\nfprintf('','COMMENT: end icon text');"
 	  sg_list_contents	  "{'table'=>{'carry'=>'popup(0|1|CIN|~SIGN(P or PCIN)|~SIGN(A*B or A:B)|~SIGND(A*B or A:B))','inp"
 	  "1'=>'popup(0|P|A:B|A*B|C|P+C|A:B+C)','inp2'=>'popup(0|PCIN|P|C|PCIN>>17|P>>17)','opselect'=>'popup(C + A*B|PCIN + A"
 	  "*B|P + A*B|A * B|C + A:B|C - A:B|C|Custom)','userSelections'=>{'carry'=>'CIN','inp1'=>'P','inp2'=>'PCIN>>17','opsel"
@@ -33176,9 +36237,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Mux"
+	  SID			  "1004"
 	  Ports			  [3, 1]
 	  Position		  [160, 62, 185, 128]
+	  ZOrder		  -5
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Mux"
 	  SourceType		  "Xilinx Bus Multiplexer Block"
 	  inputs		  "2"
@@ -33210,37 +36274,51 @@ Library {
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "delay_bram"
+	  SID			  "1005"
 	  Ports			  [1, 1]
 	  Position		  [305, 65, 345, 105]
+	  ZOrder		  -6
 	  BackgroundColor	  "gray"
 	  MinAlgLoopOccurrences	  off
 	  PropExecContextOutsideSubsystem off
 	  RTWSystemCode		  "Auto"
 	  FunctionWithSeparateData off
 	  Opaque		  off
+	  RequestExecContextInheritance	off
 	  MaskHideContents	  off
-	  MaskType		  "delay_bram"
-	  MaskDescription	  "A delay block that uses BRAM for its storage."
-	  MaskHelp		  "eval('xlWeb(''http://casper.berkeley.edu/wiki/Delay_bram'')')"
-	  MaskPromptString	  "Delay By:|BRAM Latency"
-	  MaskStyleString	  "edit,edit"
-	  MaskVariables		  "DelayLen=@1;bram_latency=@2;"
-	  MaskTunableValueString  "on,on"
-	  MaskCallbackString	  "|"
-	  MaskEnableString	  "on,on"
-	  MaskVisibilityString	  "on,on"
-	  MaskToolTipString	  "on,on"
-	  MaskInitialization	  "if (DelayLen <= bram_latency)\n	error('delay value must be greater than BRAM Latency');\nend\n"
-	  "BitWidth = max(ceil(log2(DelayLen)), 2);"
-	  MaskSelfModifiable	  on
-	  MaskIconFrame		  on
-	  MaskIconOpaque	  on
-	  MaskIconRotate	  "none"
-	  MaskIconUnits		  "autoscale"
-	  MaskValueString	  "vec_len - 2|2"
+	  Object {
+	    $PropName		    "MaskObject"
+	    $ObjectID		    80
+	    $ClassName		    "Simulink.Mask"
+	    Type		    "delay_bram"
+	    Description		    "A delay block that uses BRAM for its storage."
+	    Help		    "eval('xlWeb(''http://casper.berkeley.edu/wiki/Delay_bram'')')"
+	    Initialization	    "if (DelayLen <= bram_latency)\n	error('delay value must be greater than BRAM Latency');\nend\n"
+	    "BitWidth = max(ceil(log2(DelayLen)), 2);"
+	    SelfModifiable	    "on"
+	    Array {
+	      Type		      "Simulink.MaskParameter"
+	      Dimension		      2
+	      Object {
+		$ObjectID		81
+		Type			"edit"
+		Name			"DelayLen"
+		Prompt			"Delay By:"
+		Value			"vec_len - 2"
+	      }
+	      Object {
+		$ObjectID		82
+		Type			"edit"
+		Name			"bram_latency"
+		Prompt			"BRAM Latency"
+		Value			"2"
+	      }
+	      PropName		      "Parameters"
+	    }
+	  }
 	  System {
 	    Name		    "delay_bram"
-	    Location		    [137, 87, 917, 538]
+	    Location		    [103, 45, 931, 731]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -33253,17 +36331,23 @@ Library {
 	    TiledPageScale	    1
 	    ShowPageBoundaries	    off
 	    ZoomFactor		    "100"
+	    SIDHighWatermark	    "5"
 	    Block {
 	      BlockType		      Inport
 	      Name		      "In1"
+	      SID		      "1005:1"
 	      Position		      [285, 128, 315, 142]
+	      ZOrder		      -1
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Constant2"
+	      SID		      "1005:2"
 	      Ports		      [0, 1]
 	      Position		      [320, 143, 355, 167]
+	      ZOrder		      -2
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Constant"
 	      SourceType	      "Xilinx Constant Block Block"
 	      const		      "1"
@@ -33300,8 +36384,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Counter"
+	      SID		      "1005:3"
 	      Ports		      [0, 1]
 	      Position		      [310, 70, 350, 110]
+	      ZOrder		      -3
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Counter"
 	      SourceType	      "Xilinx Counter Block"
 	      infoedit		      "Hardware notes: Free running counters are the least expensive in hardware.  A count limited co"
@@ -33329,18 +36416,23 @@ Library {
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "counter"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,40,0,1,white,blue,0,335d209d,right,"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 1 1 0 ],[0 0 1 1 ],[0.77 0.82 0.91"
-	      "]);\npatch([0.25 0.075 0.3 0.075 0.25 0.525 0.6 0.675 0.95 0.725 0.5 0.35 0.6 0.35 0.5 0.725 0.95 0.675 0.6 0.5"
-	      "25 0.25 ],[0.1 0.275 0.5 0.725 0.9 0.9 0.825 0.9 0.9 0.675 0.9 0.75 0.5 0.25 0.1 0.325 0.1 0.1 0.175 0.1 0.1 ],"
-	      "[0.98 0.96 0.92]);\nplot([0 1 1 0 0 ],[0 0 1 1 0 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','CO"
-	      "MMENT: begin icon text');\ncolor('black');port_label('output',1,'out');\nfprintf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "40,40,0,1,white,blue,0,4b061529,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 40 40 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 40 40 0 0 ],[0 0 40 40 0 ]);\npatch([8.875 16.1 21.1 26.1 31.1 21.1 13.875 8.875 ],[25.55"
+	      " 25.55 30.55 25.55 30.55 30.55 30.55 25.55 ],[1 1 1 ]);\npatch([13.875 21.1 16.1 8.875 13.875 ],[20.55 20.55 25"
+	      ".55 25.55 20.55 ],[0.931 0.946 0.973 ]);\npatch([8.875 16.1 21.1 13.875 8.875 ],[15.55 15.55 20.55 20.55 15.55 "
+	      "],[1 1 1 ]);\npatch([13.875 31.1 26.1 21.1 16.1 8.875 13.875 ],[10.55 10.55 15.55 10.55 15.55 15.55 10.55 ],[0."
+	      "931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\n\ncolo"
+	      "r('black');disp('{\\fontsize{14}\\bf\\lceil++\\rceil}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Single Port RAM"
+	      SID		      "1005:4"
 	      Ports		      [3, 1]
 	      Position		      [370, 108, 435, 162]
+	      ZOrder		      -4
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Single Port RAM"
 	      SourceType	      "Xilinx Single Port Random Access Memory Block"
 	      depth		      "2^BitWidth"
@@ -33353,27 +36445,29 @@ Library {
 	      latency		      "bram_latency"
 	      dbl_ovrd		      off
 	      optimize		      "Area"
-	      use_rpm		      off
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "spram"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "65,54,3,1,white,blue,0,f2d5aa4c,right,"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 1 1 0 ],[0 0 1 1 ],[0.77 0.82 0.91"
-	      "]);\npatch([0.276923 0.138462 0.338462 0.138462 0.276923 0.492308 0.553846 0.615385 0.846154 0.661538 0.476923 "
-	      "0.353846 0.569231 0.353846 0.476923 0.661538 0.846154 0.615385 0.553846 0.492308 0.276923 ],[0.111111 0.277778 "
-	      "0.518519 0.759259 0.925926 0.925926 0.851852 0.925926 0.925926 0.703704 0.925926 0.777778 0.518519 0.259259 0.1"
-	      "11111 0.333333 0.111111 0.111111 0.185185 0.111111 0.111111 ],[0.98 0.96 0.92]);\nplot([0 1 1 0 0 ],[0 0 1 1 0 "
-	      "]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_la"
-	      "bel('input',1,'addr');\ncolor('black');port_label('input',2,'data');\ncolor('black');port_label('input',3,'we')"
-	      ";\ncolor('black');disp('z^{-2}','texmode','on');\nfprintf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "65,54,3,1,white,blue,0,558c5cad,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 65 65 0 0 ],[0 0 54 54 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 65 65 0 0 ],[0 0 54 54 0 ]);\npatch([16.425 26.54 33.54 40.54 47.54 33.54 23.425 16.425 ]"
+	      ",[34.77 34.77 41.77 34.77 41.77 41.77 41.77 34.77 ],[1 1 1 ]);\npatch([23.425 33.54 26.54 16.425 23.425 ],[27.7"
+	      "7 27.77 34.77 34.77 27.77 ],[0.931 0.946 0.973 ]);\npatch([16.425 26.54 33.54 23.425 16.425 ],[20.77 20.77 27.7"
+	      "7 27.77 20.77 ],[1 1 1 ]);\npatch([23.425 47.54 40.54 33.54 26.54 16.425 23.425 ],[13.77 13.77 20.77 13.77 20.7"
+	      "7 20.77 13.77 ],[0.931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin i"
+	      "con text');\ncolor('black');port_label('input',1,'addr');\ncolor('black');port_label('input',2,'data');\ncolor("
+	      "'black');port_label('input',3,'we');\n\ncolor('black');disp('z^{-2}','texmode','on');\nfprintf('','COMMENT: end"
+	      " icon text');"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "Out1"
+	      SID		      "1005:5"
 	      Position		      [455, 128, 485, 142]
+	      ZOrder		      -5
 	      IconDisplay	      "Port number"
 	    }
 	    Line {
@@ -33405,34 +36499,39 @@ Library {
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "pulse_ext"
+	  SID			  "1006"
 	  Ports			  [1, 1]
 	  Position		  [70, 66, 105, 84]
+	  ZOrder		  -7
 	  MinAlgLoopOccurrences	  off
 	  PropExecContextOutsideSubsystem off
 	  RTWSystemCode		  "Auto"
 	  FunctionWithSeparateData off
 	  Opaque		  off
+	  RequestExecContextInheritance	off
 	  MaskHideContents	  off
-	  MaskType		  "pulse_ext"
-	  MaskDescription	  "Extends a boolean signal to be high for the specified number of clocks after\nthe last high inpu"
-	  "t."
-	  MaskHelp		  "eval('xlWeb(''http://casper.berkeley.edu/wiki/Pulse_ext'')')"
-	  MaskPromptString	  "Length of Pulse"
-	  MaskStyleString	  "edit"
-	  MaskVariables		  "pulse_len=@1;"
-	  MaskTunableValueString  "on"
-	  MaskEnableString	  "on"
-	  MaskVisibilityString	  "on"
-	  MaskToolTipString	  "on"
-	  MaskInitialization	  "bits = ceil(log2(pulse_len+1));"
-	  MaskIconFrame		  on
-	  MaskIconOpaque	  on
-	  MaskIconRotate	  "none"
-	  MaskIconUnits		  "autoscale"
-	  MaskValueString	  "vec_len"
+	  Object {
+	    $PropName		    "MaskObject"
+	    $ObjectID		    83
+	    $ClassName		    "Simulink.Mask"
+	    Type		    "pulse_ext"
+	    Description		    "Extends a boolean signal to be high for the specified number of clocks after\nthe last high inp"
+	    "ut."
+	    Help		    "eval('xlWeb(''http://casper.berkeley.edu/wiki/Pulse_ext'')')"
+	    Initialization	    "bits = ceil(log2(pulse_len+1));"
+	    Object {
+	      $PropName		      "Parameters"
+	      $ObjectID		      84
+	      $ClassName	      "Simulink.MaskParameter"
+	      Type		      "edit"
+	      Name		      "pulse_len"
+	      Prompt		      "Length of Pulse"
+	      Value		      "vec_len"
+	    }
+	  }
 	  System {
 	    Name		    "pulse_ext"
-	    Location		    [690, 701, 1252, 951]
+	    Location		    [656, 582, 1266, 1067]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -33448,14 +36547,19 @@ Library {
 	    Block {
 	      BlockType		      Inport
 	      Name		      "in"
+	      SID		      "1007"
 	      Position		      [20, 43, 50, 57]
+	      ZOrder		      -1
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Constant5"
+	      SID		      "1008"
 	      Ports		      [0, 1]
 	      Position		      [145, 109, 215, 141]
+	      ZOrder		      -2
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Constant"
 	      SourceType	      "Xilinx Constant Block Block"
 	      const		      "pulse_len"
@@ -33481,18 +36585,22 @@ Library {
 	      block_type	      "constant"
 	      block_version	      "10.1.3"
 	      sg_icon_stat	      "70,32,0,1,white,blue,0,7a8c02d8,right,"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 1 1 0 ],[0 0 1 1 ],[0.77 0.82 0.91"
-	      "]);\npatch([0.371429 0.3 0.4 0.3 0.371429 0.485714 0.514286 0.542857 0.671429 0.571429 0.471429 0.4 0.5 0.4 0.4"
-	      "71429 0.571429 0.671429 0.542857 0.514286 0.485714 0.371429 ],[0.09375 0.25 0.46875 0.6875 0.84375 0.84375 0.78"
-	      "125 0.84375 0.84375 0.625 0.84375 0.6875 0.46875 0.25 0.09375 0.3125 0.09375 0.09375 0.15625 0.09375 0.09375 ],"
-	      "[0.98 0.96 0.92]);\nplot([0 1 1 0 0 ],[0 0 1 1 0 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','CO"
-	      "MMENT: begin icon text');\ncolor('black');port_label('output',1,'8');\nfprintf('','COMMENT: end icon text');\n"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 55 55 0 0 ],[0 0 26 26 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 55 55 0 0 ],[0 0 26 26 0 ]);\npatch([20.325 24.66 27.66 30.66 33.66 27.66 23.325 20.325 ]"
+	      ",[16.33 16.33 19.33 16.33 19.33 19.33 19.33 16.33 ],[1 1 1 ]);\npatch([23.325 27.66 24.66 20.325 23.325 ],[13.3"
+	      "3 13.33 16.33 16.33 13.33 ],[0.931 0.946 0.973 ]);\npatch([20.325 24.66 27.66 23.325 20.325 ],[10.33 10.33 13.3"
+	      "3 13.33 10.33 ],[1 1 1 ]);\npatch([23.325 33.66 30.66 27.66 24.66 20.325 23.325 ],[7.33 7.33 10.33 7.33 10.33 1"
+	      "0.33 7.33 ],[0.931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon "
+	      "text');\ncolor('black');port_label('output',1,'1');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Counter3"
+	      SID		      "1009"
 	      Ports		      [2, 1]
 	      Position		      [165, 35, 215, 90]
+	      ZOrder		      -3
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Counter"
 	      SourceType	      "Xilinx Counter Block"
 	      infoedit		      "Hardware notes: Free running counters are the least expensive in hardware.  A count limited co"
@@ -33520,20 +36628,24 @@ Library {
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "counter"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "50,55,2,1,white,blue,0,d605779c,right,"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 1 1 0 ],[0 0 1 1 ],[0.77 0.82 0.91"
-	      "]);\npatch([0.22 0.06 0.3 0.06 0.22 0.48 0.56 0.64 0.92 0.7 0.48 0.32 0.56 0.32 0.48 0.7 0.92 0.64 0.56 0.48 0."
-	      "22 ],[0.145455 0.290909 0.509091 0.727273 0.872727 0.872727 0.8 0.872727 0.872727 0.672727 0.872727 0.727273 0."
-	      "509091 0.290909 0.145455 0.345455 0.145455 0.145455 0.218182 0.145455 0.145455 ],[0.98 0.96 0.92]);\nplot([0 1 "
-	      "1 0 0 ],[0 0 1 1 0 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncol"
-	      "or('black');port_label('input',1,'rst');\ncolor('black');port_label('input',2,'en');\ncolor('black');port_label"
-	      "('output',1,'out');\nfprintf('','COMMENT: end icon text');\n"
+	      sg_icon_stat	      "50,55,2,1,white,blue,0,ae3608d6,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 50 50 0 0 ],[0 0 55 55 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 50 50 0 0 ],[0 0 55 55 0 ]);\npatch([9.425 19.54 26.54 33.54 40.54 26.54 16.425 9.425 ],["
+	      "34.77 34.77 41.77 34.77 41.77 41.77 41.77 34.77 ],[1 1 1 ]);\npatch([16.425 26.54 19.54 9.425 16.425 ],[27.77 2"
+	      "7.77 34.77 34.77 27.77 ],[0.931 0.946 0.973 ]);\npatch([9.425 19.54 26.54 16.425 9.425 ],[20.77 20.77 27.77 27."
+	      "77 20.77 ],[1 1 1 ]);\npatch([16.425 40.54 33.54 26.54 19.54 9.425 16.425 ],[13.77 13.77 20.77 13.77 20.77 20.7"
+	      "7 13.77 ],[0.931 0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon te"
+	      "xt');\ncolor('black');port_label('input',1,'rst');\ncolor('black');port_label('input',2,'en');\n\ncolor('black'"
+	      ");disp('{\\fontsize{14}\\bf++}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Relational5"
+	      SID		      "1010"
 	      Ports		      [2, 1]
 	      Position		      [240, 93, 285, 137]
+	      ZOrder		      -4
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Relational"
 	      SourceType	      "Xilinx Arithmetic Relational Operator Block"
 	      mode		      "a!=b"
@@ -33559,18 +36671,21 @@ Library {
 	    Block {
 	      BlockType		      SubSystem
 	      Name		      "posedge"
+	      SID		      "1011"
 	      Tag		      "Rising Edge Detector"
 	      Ports		      [1, 1]
 	      Position		      [85, 37, 130, 63]
+	      ZOrder		      -5
 	      MinAlgLoopOccurrences   off
 	      PropExecContextOutsideSubsystem off
 	      RTWSystemCode	      "Auto"
 	      FunctionWithSeparateData off
 	      Opaque		      off
+	      RequestExecContextInheritance off
 	      MaskHideContents	      off
 	      System {
 		Name			"posedge"
-		Location		[2, 82, 1014, 732]
+		Location		[12, 45, 1072, 930]
 		Open			off
 		ModelBrowserVisibility	off
 		ModelBrowserWidth	200
@@ -33586,14 +36701,19 @@ Library {
 		Block {
 		  BlockType		  Inport
 		  Name			  "In"
+		  SID			  "1012"
 		  Position		  [25, 43, 55, 57]
+		  ZOrder		  -1
 		  IconDisplay		  "Port number"
 		}
 		Block {
 		  BlockType		  Reference
 		  Name			  "Delay"
+		  SID			  "1013"
 		  Ports			  [1, 1]
 		  Position		  [75, 27, 120, 73]
+		  ZOrder		  -2
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Delay"
 		  SourceType		  "Xilinx Delay Block"
 		  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -33621,8 +36741,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Inverter"
+		  SID			  "1014"
 		  Ports			  [1, 1]
 		  Position		  [150, 33, 200, 67]
+		  ZOrder		  -3
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Inverter"
 		  SourceType		  "Xilinx Inverter Block"
 		  infoedit		  "Bitwise logical negation (one's complement) operator."
@@ -33647,8 +36770,11 @@ Library {
 		Block {
 		  BlockType		  Reference
 		  Name			  "Logical"
+		  SID			  "1015"
 		  Ports			  [2, 1]
 		  Position		  [225, 29, 285, 116]
+		  ZOrder		  -4
+		  LibraryVersion	  "1.2"
 		  SourceBlock		  "xbsIndex_r4/Logical"
 		  SourceType		  "Xilinx Logical Block Block"
 		  logical_function	  "AND"
@@ -33679,7 +36805,9 @@ Library {
 		Block {
 		  BlockType		  Outport
 		  Name			  "Out"
+		  SID			  "1016"
 		  Position		  [305, 63, 335, 77]
+		  ZOrder		  -5
 		  IconDisplay		  "Port number"
 		}
 		Line {
@@ -33721,7 +36849,9 @@ Library {
 	    Block {
 	      BlockType		      Outport
 	      Name		      "out"
+	      SID		      "1017"
 	      Position		      [325, 108, 355, 122]
+	      ZOrder		      -6
 	      IconDisplay	      "Port number"
 	    }
 	    Line {
@@ -33770,13 +36900,17 @@ Library {
 	Block {
 	  BlockType		  Outport
 	  Name			  "dout"
+	  SID			  "1018"
 	  Position		  [385, 43, 415, 57]
+	  ZOrder		  -8
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Outport
 	  Name			  "valid"
+	  SID			  "1019"
 	  Position		  [385, 13, 415, 27]
+	  ZOrder		  -9
 	  Port			  "2"
 	  IconDisplay		  "Port number"
 	}
@@ -33843,32 +36977,36 @@ Library {
     Block {
       BlockType		      SubSystem
       Name		      "vacc_tvg"
+      SID		      "1020"
       Ports		      [4, 3]
       Position		      [25, 86, 140, 164]
+      ZOrder		      -6
       AttributesFormatString  "Vector Length: 139264"
       MinAlgLoopOccurrences   off
       PropExecContextOutsideSubsystem off
       RTWSystemCode	      "Auto"
       FunctionWithSeparateData off
       Opaque		      off
+      RequestExecContextInheritance off
       MaskHideContents	      off
-      MaskPromptString	      "Number of Vectors"
-      MaskStyleString	      "edit"
-      MaskVariables	      "len=@1;"
-      MaskTunableValueString  "on"
-      MaskEnableString	      "on"
-      MaskVisibilityString    "on"
-      MaskToolTipString	      "on"
-      MaskInitialization      "fmtstr = sprintf('Vector Length: %d', len);\nset_param(gcb, 'AttributesFormatString', f"
-      "mtstr);\n"
-      MaskIconFrame	      on
-      MaskIconOpaque	      on
-      MaskIconRotate	      "none"
-      MaskIconUnits	      "autoscale"
-      MaskValueString	      "139264"
+      Object {
+	$PropName		"MaskObject"
+	$ObjectID		85
+	$ClassName		"Simulink.Mask"
+	Initialization		"fmtstr = sprintf('Vector Length: %d', len);\nset_param(gcb, 'AttributesFormatString', fmtstr);\n"
+	Object {
+	  $PropName		  "Parameters"
+	  $ObjectID		  86
+	  $ClassName		  "Simulink.MaskParameter"
+	  Type			  "edit"
+	  Name			  "len"
+	  Prompt		  "Number of Vectors"
+	  Value			  "139264"
+	}
+      }
       System {
 	Name			"vacc_tvg"
-	Location		[2, 74, 1375, 748]
+	Location		[12, 45, 1433, 954]
 	Open			off
 	ModelBrowserVisibility	off
 	ModelBrowserWidth	200
@@ -33884,35 +37022,46 @@ Library {
 	Block {
 	  BlockType		  Inport
 	  Name			  "tvg_sel"
+	  SID			  "1021"
 	  Position		  [65, 618, 95, 632]
+	  ZOrder		  -1
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Inport
 	  Name			  "sync_in"
+	  SID			  "1022"
 	  Position		  [545, 53, 575, 67]
+	  ZOrder		  -2
 	  Port			  "2"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Inport
 	  Name			  "data_in"
+	  SID			  "1023"
 	  Position		  [545, 133, 575, 147]
+	  ZOrder		  -3
 	  Port			  "3"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Inport
 	  Name			  "valid_in"
+	  SID			  "1024"
 	  Position		  [545, 223, 575, 237]
+	  ZOrder		  -4
 	  Port			  "4"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay"
+	  SID			  "1025"
 	  Ports			  [1, 1]
 	  Position		  [195, 287, 230, 313]
+	  ZOrder		  -5
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -33940,9 +37089,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay1"
+	  SID			  "1026"
 	  Ports			  [1, 1]
 	  Position		  [185, 325, 210, 345]
+	  ZOrder		  -6
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -33970,9 +37122,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay10"
+	  SID			  "1027"
 	  Ports			  [1, 1]
 	  Position		  [675, 275, 700, 295]
+	  ZOrder		  -7
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -34000,9 +37155,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay2"
+	  SID			  "1028"
 	  Ports			  [1, 1]
 	  Position		  [185, 375, 210, 395]
+	  ZOrder		  -8
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -34030,9 +37188,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay3"
+	  SID			  "1029"
 	  Ports			  [1, 1]
 	  Position		  [185, 430, 210, 450]
+	  ZOrder		  -9
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -34060,9 +37221,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay4"
+	  SID			  "1030"
 	  Ports			  [1, 1]
 	  Position		  [675, 50, 700, 70]
+	  ZOrder		  -10
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -34090,9 +37254,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay5"
+	  SID			  "1031"
 	  Ports			  [1, 1]
 	  Position		  [675, 130, 700, 150]
+	  ZOrder		  -11
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -34120,9 +37287,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay6"
+	  SID			  "1032"
 	  Ports			  [1, 1]
 	  Position		  [675, 220, 700, 240]
+	  ZOrder		  -12
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -34150,9 +37320,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay7"
+	  SID			  "1033"
 	  Ports			  [1, 1]
 	  Position		  [1020, 95, 1045, 115]
+	  ZOrder		  -13
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -34180,9 +37353,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay8"
+	  SID			  "1034"
 	  Ports			  [1, 1]
 	  Position		  [1020, 135, 1045, 155]
+	  ZOrder		  -14
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -34210,9 +37386,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Delay9"
+	  SID			  "1035"
 	  Ports			  [1, 1]
 	  Position		  [1020, 175, 1045, 195]
+	  ZOrder		  -15
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Delay"
 	  SourceType		  "Xilinx Delay Block"
 	  infoedit		  "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flop."
@@ -34240,7 +37419,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From"
+	  SID			  "1036"
 	  Position		  [515, 33, 585, 47]
+	  ZOrder		  -16
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "valid_sel"
@@ -34248,7 +37429,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From1"
+	  SID			  "1037"
 	  Position		  [515, 113, 585, 127]
+	  ZOrder		  -17
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "data_sel"
@@ -34256,7 +37439,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From2"
+	  SID			  "1038"
 	  Position		  [515, 203, 585, 217]
+	  ZOrder		  -18
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "valid_sel"
@@ -34264,7 +37449,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From3"
+	  SID			  "1039"
 	  Position		  [1045, 298, 1115, 312]
+	  ZOrder		  -19
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "inj_vector"
@@ -34272,7 +37459,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From4"
+	  SID			  "1040"
 	  Position		  [570, 278, 640, 292]
+	  ZOrder		  -20
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "inj_counter"
@@ -34280,7 +37469,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From5"
+	  SID			  "1041"
 	  Position		  [85, 293, 155, 307]
+	  ZOrder		  -21
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "enable"
@@ -34288,7 +37479,9 @@ Library {
 	Block {
 	  BlockType		  From
 	  Name			  "From6"
+	  SID			  "1042"
 	  Position		  [290, 73, 360, 87]
+	  ZOrder		  -22
 	  ShowName		  off
 	  CloseFcn		  "tagdialog Close"
 	  GotoTag		  "rst"
@@ -34296,57 +37489,66 @@ Library {
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto"
+	  SID			  "1043"
 	  Position		  [255, 616, 335, 634]
+	  ZOrder		  -23
 	  ShowName		  off
 	  GotoTag		  "data_sel"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto1"
+	  SID			  "1044"
 	  Position		  [255, 591, 335, 609]
+	  ZOrder		  -24
 	  ShowName		  off
 	  GotoTag		  "valid_sel"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto2"
+	  SID			  "1045"
 	  Position		  [255, 566, 335, 584]
+	  ZOrder		  -25
 	  ShowName		  off
 	  GotoTag		  "inj_vector"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto3"
+	  SID			  "1046"
 	  Position		  [255, 541, 335, 559]
+	  ZOrder		  -26
 	  ShowName		  off
 	  GotoTag		  "inj_counter"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto4"
+	  SID			  "1047"
 	  Position		  [255, 641, 335, 659]
+	  ZOrder		  -27
 	  ShowName		  off
 	  GotoTag		  "enable"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Goto
 	  Name			  "Goto5"
+	  SID			  "1048"
 	  Position		  [255, 516, 335, 534]
+	  ZOrder		  -28
 	  ShowName		  off
 	  GotoTag		  "rst"
-	  TagVisibility		  "local"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "Mux1"
+	  SID			  "1049"
 	  Ports			  [3, 1]
 	  Position		  [605, 196, 625, 264]
+	  ZOrder		  -29
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Mux"
 	  SourceType		  "Xilinx Bus Multiplexer Block"
 	  inputs		  "2"
@@ -34378,9 +37580,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Mux2"
+	  SID			  "1050"
 	  Ports			  [3, 1]
 	  Position		  [605, 106, 625, 174]
+	  ZOrder		  -30
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Mux"
 	  SourceType		  "Xilinx Bus Multiplexer Block"
 	  inputs		  "2"
@@ -34412,9 +37617,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Mux3"
+	  SID			  "1051"
 	  Ports			  [3, 1]
 	  Position		  [605, 26, 625, 94]
+	  ZOrder		  -31
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Mux"
 	  SourceType		  "Xilinx Bus Multiplexer Block"
 	  inputs		  "2"
@@ -34446,9 +37654,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Slice1"
+	  SID			  "1052"
 	  Ports			  [1, 1]
 	  Position		  [150, 541, 200, 559]
+	  ZOrder		  -32
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Slice"
 	  SourceType		  "Xilinx Bit Slice Extractor Block"
 	  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type "
@@ -34478,9 +37689,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Slice3"
+	  SID			  "1053"
 	  Ports			  [1, 1]
 	  Position		  [150, 566, 200, 584]
+	  ZOrder		  -33
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Slice"
 	  SourceType		  "Xilinx Bit Slice Extractor Block"
 	  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type "
@@ -34510,9 +37724,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Slice4"
+	  SID			  "1054"
 	  Ports			  [1, 1]
 	  Position		  [150, 591, 200, 609]
+	  ZOrder		  -34
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Slice"
 	  SourceType		  "Xilinx Bit Slice Extractor Block"
 	  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type "
@@ -34542,9 +37759,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Slice5"
+	  SID			  "1055"
 	  Ports			  [1, 1]
 	  Position		  [150, 616, 200, 634]
+	  ZOrder		  -35
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Slice"
 	  SourceType		  "Xilinx Bit Slice Extractor Block"
 	  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type "
@@ -34574,9 +37794,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Slice6"
+	  SID			  "1056"
 	  Ports			  [1, 1]
 	  Position		  [150, 641, 200, 659]
+	  ZOrder		  -36
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Slice"
 	  SourceType		  "Xilinx Bit Slice Extractor Block"
 	  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type "
@@ -34606,9 +37829,12 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "Slice7"
+	  SID			  "1057"
 	  Ports			  [1, 1]
 	  Position		  [150, 516, 200, 534]
+	  ZOrder		  -37
 	  ShowName		  off
+	  LibraryVersion	  "1.2"
 	  SourceBlock		  "xbsIndex_r4/Slice"
 	  SourceType		  "Xilinx Bit Slice Extractor Block"
 	  infoedit		  "Extracts a given range of bits from each input sample and presents it at the output.  The output type "
@@ -34638,23 +37864,28 @@ Library {
 	Block {
 	  BlockType		  Terminator
 	  Name			  "Terminator5"
+	  SID			  "1058"
 	  Position		  [410, 354, 430, 366]
+	  ZOrder		  -38
 	  ShowName		  off
 	}
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "generate_pulses"
+	  SID			  "1059"
 	  Ports			  [4, 2]
 	  Position		  [275, 313, 390, 372]
+	  ZOrder		  -39
 	  MinAlgLoopOccurrences	  off
 	  PropExecContextOutsideSubsystem off
 	  RTWSystemCode		  "Auto"
 	  FunctionWithSeparateData off
 	  Opaque		  off
+	  RequestExecContextInheritance	off
 	  MaskHideContents	  off
 	  System {
 	    Name		    "generate_pulses"
-	    Location		    [2, 82, 1430, 864]
+	    Location		    [12, 45, 1488, 1062]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -34670,53 +37901,67 @@ Library {
 	    Block {
 	      BlockType		      Inport
 	      Name		      "run"
+	      SID		      "1060"
 	      Position		      [15, 508, 45, 522]
+	      ZOrder		      -1
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "num_pulses"
+	      SID		      "1061"
 	      Position		      [15, 553, 45, 567]
+	      ZOrder		      -2
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "num_per_group"
+	      SID		      "1062"
 	      Position		      [20, 373, 50, 387]
+	      ZOrder		      -3
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "group period"
+	      SID		      "1063"
 	      Position		      [20, 188, 50, 202]
+	      ZOrder		      -4
 	      Port		      "4"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out1"
+	      SID		      "1064"
 	      Ports		      [1, 1]
 	      Position		      [1030, 423, 1060, 437]
+	      ZOrder		      -5
 	      NamePlacement	      "alternate"
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,14,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "30,14,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 14 14 0 ],[0.88 0"
 	      ".88 0.88 ]);\nplot([0 30 30 0 0 ],[0 0 14 14 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[9"
 	      ".22 9.22 11.22 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[7.22 7.22 9.22"
@@ -34729,26 +37974,32 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out2"
+	      SID		      "1065"
 	      Ports		      [1, 1]
 	      Position		      [755, 63, 785, 77]
+	      ZOrder		      -6
 	      NamePlacement	      "alternate"
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,14,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "30,14,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 14 14 0 ],[0.88 0"
 	      ".88 0.88 ]);\nplot([0 30 30 0 0 ],[0 0 14 14 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[9"
 	      ".22 9.22 11.22 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[7.22 7.22 9.22"
@@ -34761,26 +38012,32 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out3"
+	      SID		      "1066"
 	      Ports		      [1, 1]
 	      Position		      [755, 33, 785, 47]
+	      ZOrder		      -7
 	      NamePlacement	      "alternate"
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,14,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "30,14,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 14 14 0 ],[0.88 0"
 	      ".88 0.88 ]);\nplot([0 30 30 0 0 ],[0 0 14 14 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[9"
 	      ".22 9.22 11.22 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[7.22 7.22 9.22"
@@ -34793,26 +38050,32 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out4"
+	      SID		      "1067"
 	      Ports		      [1, 1]
 	      Position		      [1030, 393, 1060, 407]
+	      ZOrder		      -8
 	      NamePlacement	      "alternate"
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,14,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "30,14,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 14 14 0 ],[0.88 0"
 	      ".88 0.88 ]);\nplot([0 30 30 0 0 ],[0 0 14 14 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[9"
 	      ".22 9.22 11.22 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[7.22 7.22 9.22"
@@ -34825,26 +38088,32 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out5"
+	      SID		      "1068"
 	      Ports		      [1, 1]
 	      Position		      [1030, 408, 1060, 422]
+	      ZOrder		      -9
 	      NamePlacement	      "alternate"
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,14,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "30,14,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 14 14 0 ],[0.88 0"
 	      ".88 0.88 ]);\nplot([0 30 30 0 0 ],[0 0 14 14 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[9"
 	      ".22 9.22 11.22 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[7.22 7.22 9.22"
@@ -34857,26 +38126,32 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out6"
+	      SID		      "1069"
 	      Ports		      [1, 1]
 	      Position		      [1030, 378, 1060, 392]
+	      ZOrder		      -10
 	      NamePlacement	      "alternate"
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,14,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "30,14,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 14 14 0 ],[0.88 0"
 	      ".88 0.88 ]);\nplot([0 30 30 0 0 ],[0 0 14 14 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[9"
 	      ".22 9.22 11.22 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[7.22 7.22 9.22"
@@ -34889,26 +38164,32 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out7"
+	      SID		      "1070"
 	      Ports		      [1, 1]
 	      Position		      [755, 48, 785, 62]
+	      ZOrder		      -11
 	      NamePlacement	      "alternate"
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,14,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "30,14,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 14 14 0 ],[0.88 0"
 	      ".88 0.88 ]);\nplot([0 30 30 0 0 ],[0 0 14 14 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[9"
 	      ".22 9.22 11.22 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[7.22 7.22 9.22"
@@ -34921,26 +38202,32 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out8"
+	      SID		      "1071"
 	      Ports		      [1, 1]
 	      Position		      [755, 18, 785, 32]
+	      ZOrder		      -12
 	      NamePlacement	      "alternate"
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,14,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "30,14,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 14 14 0 ],[0.88 0"
 	      ".88 0.88 ]);\nplot([0 30 30 0 0 ],[0 0 14 14 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[9"
 	      ".22 9.22 11.22 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[7.22 7.22 9.22"
@@ -34953,9 +38240,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical1"
+	      SID		      "1072"
 	      Ports		      [2, 1]
 	      Position		      [940, 511, 960, 544]
+	      ZOrder		      -13
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -34986,9 +38276,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical2"
+	      SID		      "1073"
 	      Ports		      [3, 1]
 	      Position		      [605, 329, 625, 361]
+	      ZOrder		      -14
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -35019,9 +38312,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical3"
+	      SID		      "1074"
 	      Ports		      [2, 1]
 	      Position		      [380, 511, 400, 544]
+	      ZOrder		      -15
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -35052,9 +38348,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical4"
+	      SID		      "1075"
 	      Ports		      [2, 1]
 	      Position		      [490, 137, 510, 168]
+	      ZOrder		      -16
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "OR"
@@ -35085,8 +38384,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Relational"
+	      SID		      "1076"
 	      Ports		      [2, 1]
 	      Position		      [305, 552, 330, 583]
+	      ZOrder		      -17
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Relational"
 	      SourceType	      "Xilinx Arithmetic Relational Operator Block"
 	      mode		      "a>=b"
@@ -35112,8 +38414,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Relational1"
+	      SID		      "1077"
 	      Ports		      [2, 1]
 	      Position		      [440, 187, 465, 218]
+	      ZOrder		      -18
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Relational"
 	      SourceType	      "Xilinx Arithmetic Relational Operator Block"
 	      mode		      "a=b"
@@ -35139,8 +38444,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Relational2"
+	      SID		      "1078"
 	      Ports		      [2, 1]
 	      Position		      [550, 372, 575, 403]
+	      ZOrder		      -19
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Relational"
 	      SourceType	      "Xilinx Arithmetic Relational Operator Block"
 	      mode		      "a>b"
@@ -35166,8 +38474,10 @@ Library {
 	    Block {
 	      BlockType		      Scope
 	      Name		      "Scope1"
+	      SID		      "1079"
 	      Ports		      [4]
 	      Position		      [820, 13, 855, 82]
+	      ZOrder		      -20
 	      Floating		      off
 	      Location		      [6, 49, 1030, 743]
 	      Open		      off
@@ -35180,6 +38490,7 @@ Library {
 		axes3			"pulse_cnt_en"
 		axes4			"total_cnt_en"
 	      }
+	      ShowLegends	      off
 	      YMin		      "0~-1~0~0"
 	      YMax		      "1~1~1~1"
 	      DataFormat	      "StructureWithTime"
@@ -35189,8 +38500,10 @@ Library {
 	    Block {
 	      BlockType		      Scope
 	      Name		      "Scope2"
+	      SID		      "1080"
 	      Ports		      [4]
 	      Position		      [1095, 373, 1130, 442]
+	      ZOrder		      -21
 	      Floating		      off
 	      Location		      [6, 49, 1030, 743]
 	      Open		      off
@@ -35203,6 +38516,7 @@ Library {
 		axes3			"group_cnt"
 		axes4			"total_pulse_cnt"
 	      }
+	      ShowLegends	      off
 	      YMin		      "0.95~0~-1~-5"
 	      YMax		      "1.05~1~1~5"
 	      SaveName		      "ScopeData1"
@@ -35213,9 +38527,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Slice6"
+	      SID		      "1081"
 	      Ports		      [1, 1]
 	      Position		      [830, 513, 860, 527]
+	      ZOrder		      -22
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Slice"
 	      SourceType	      "Xilinx Bit Slice Extractor Block"
 	      infoedit		      "Extracts a given range of bits from each input sample and presents it at the output.  The outp"
@@ -35245,22 +38562,17 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "edge1"
+	      SID		      "1082"
 	      Ports		      [1, 1]
 	      Position		      [875, 511, 910, 529]
+	      ZOrder		      -23
 	      BackgroundColor	      "[0.501961, 1.000000, 0.501961]"
 	      AttributesFormatString  "both edges\nactive high"
+	      LibraryVersion	      "1.43"
 	      UserDataPersistent      on
 	      UserData		      "DataTag3"
 	      SourceBlock	      "casper_library_misc/edge_detect"
 	      SourceType	      "edge_detect"
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
 	      edge		      "Both"
 	      polarity		      "Active High"
 	      x_in		      "[0 0.08 0.08 0.16 0.16 0.24 0.24 0.32 0.32 0.4]"
@@ -35271,8 +38583,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "group_cntr"
+	      SID		      "1083"
 	      Ports		      [1, 1]
 	      Position		      [545, 140, 580, 170]
+	      ZOrder		      -24
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Counter"
 	      SourceType	      "Xilinx Counter Block"
 	      infoedit		      "Hardware notes: Free running counters are the least expensive in hardware.  A count limited co"
@@ -35313,22 +38628,17 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "posedge"
+	      SID		      "1084"
 	      Ports		      [1, 1]
 	      Position		      [300, 481, 335, 499]
+	      ZOrder		      -25
 	      BackgroundColor	      "[0.501961, 1.000000, 0.501961]"
 	      AttributesFormatString  "rising edges\nactive high"
+	      LibraryVersion	      "1.43"
 	      UserDataPersistent      on
 	      UserData		      "DataTag4"
 	      SourceBlock	      "casper_library_misc/edge_detect"
 	      SourceType	      "edge_detect"
-	      ShowPortLabels	      "FromPortIcon"
-	      SystemSampleTime	      "-1"
-	      FunctionWithSeparateData off
-	      RTWMemSecFuncInitTerm   "Inherit from model"
-	      RTWMemSecFuncExecute    "Inherit from model"
-	      RTWMemSecDataConstants  "Inherit from model"
-	      RTWMemSecDataInternal   "Inherit from model"
-	      RTWMemSecDataParameters "Inherit from model"
 	      edge		      "Rising"
 	      polarity		      "Active High"
 	      x_in		      "[0 0.08 0.08 0.16 0.16 0.24 0.24 0.32 0.32 0.4]"
@@ -35339,8 +38649,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "pulse_cntr"
+	      SID		      "1085"
 	      Ports		      [2, 1]
 	      Position		      [650, 323, 685, 352]
+	      ZOrder		      -26
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Counter"
 	      SourceType	      "Xilinx Counter Block"
 	      infoedit		      "Hardware notes: Free running counters are the least expensive in hardware.  A count limited co"
@@ -35381,8 +38694,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "tot_cntr"
+	      SID		      "1086"
 	      Ports		      [2, 1]
 	      Position		      [435, 503, 470, 532]
+	      ZOrder		      -27
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Counter"
 	      SourceType	      "Xilinx Counter Block"
 	      infoedit		      "Hardware notes: Free running counters are the least expensive in hardware.  A count limited co"
@@ -35423,13 +38739,17 @@ Library {
 	    Block {
 	      BlockType		      Outport
 	      Name		      "valid"
+	      SID		      "1087"
 	      Position		      [1005, 523, 1035, 537]
+	      ZOrder		      -28
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "running"
+	      SID		      "1088"
 	      Position		      [980, 663, 1010, 677]
+	      ZOrder		      -29
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
@@ -35727,56 +39047,61 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "group_period"
+	  SID			  "1089"
 	  Tag			  "xps:sw_reg"
 	  Ports			  [1, 1]
 	  Position		  [60, 425, 160, 455]
+	  ZOrder		  -40
 	  BackgroundColor	  "[1.000000, 1.000000, 0.000000]"
+	  AttributesFormatString  "1input"
+	  LibraryVersion	  "1.521"
 	  SourceBlock		  "xps_library/software register"
-	  SourceType		  ""
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
+	  SourceType		  "swreg"
+	  mode			  "one value"
 	  io_dir		  "From Processor"
-	  arith_type		  "Unsigned"
-	  bitwidth		  "32"
-	  bin_pt		  "0"
+	  io_delay		  "0"
 	  sample_period		  "1"
-	  gw_name		  "casper_library_accumulators_vacc_tvg_group_period_user_data_out"
+	  names			  "reg"
+	  bitwidths		  "32"
+	  arith_types		  "0"
+	  bin_pts		  "0"
+	  sim_port		  on
+	  show_format		  off
 	}
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "ins_counter"
+	  SID			  "1090"
 	  Ports			  [4, 3]
 	  Position		  [790, 60, 900, 315]
+	  ZOrder		  -41
 	  AttributesFormatString  "Vector Length: 139264"
 	  MinAlgLoopOccurrences	  off
 	  PropExecContextOutsideSubsystem off
 	  RTWSystemCode		  "Auto"
 	  FunctionWithSeparateData off
 	  Opaque		  off
+	  RequestExecContextInheritance	off
 	  MaskHideContents	  off
-	  MaskPromptString	  "Vector Length?"
-	  MaskStyleString	  "edit"
-	  MaskVariables		  "vec_len=@1;"
-	  MaskTunableValueString  "on"
-	  MaskEnableString	  "on"
-	  MaskVisibilityString	  "on"
-	  MaskToolTipString	  "on"
-	  MaskInitialization	  "fmtstr = sprintf('Vector Length: %d', vec_len);\nset_param(gcb, 'AttributesFormatString', fmt"
-	  "str);\n"
-	  MaskIconFrame		  on
-	  MaskIconOpaque	  on
-	  MaskIconRotate	  "none"
-	  MaskIconUnits		  "autoscale"
-	  MaskValueString	  "len"
+	  Object {
+	    $PropName		    "MaskObject"
+	    $ObjectID		    87
+	    $ClassName		    "Simulink.Mask"
+	    Initialization	    "fmtstr = sprintf('Vector Length: %d', vec_len);\nset_param(gcb, 'AttributesFormatString', fmt"
+	    "str);\n"
+	    Object {
+	      $PropName		      "Parameters"
+	      $ObjectID		      88
+	      $ClassName	      "Simulink.MaskParameter"
+	      Type		      "edit"
+	      Name		      "vec_len"
+	      Prompt		      "Vector Length?"
+	      Value		      "len"
+	    }
+	  }
 	  System {
 	    Name		    "ins_counter"
-	    Location		    [329, 155, 907, 566]
+	    Location		    [295, 45, 921, 691]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -35792,35 +39117,46 @@ Library {
 	    Block {
 	      BlockType		      Inport
 	      Name		      "new_acc_in"
+	      SID		      "1091"
 	      Position		      [15, 178, 45, 192]
+	      ZOrder		      -1
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "din"
+	      SID		      "1092"
 	      Position		      [15, 138, 45, 152]
+	      ZOrder		      -2
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "valid_in"
+	      SID		      "1093"
 	      Position		      [15, 233, 45, 247]
+	      ZOrder		      -3
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "enable"
+	      SID		      "1094"
 	      Position		      [15, 103, 45, 117]
+	      ZOrder		      -4
 	      Port		      "4"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Counter"
+	      SID		      "1095"
 	      Ports		      [2, 1]
 	      Position		      [195, 212, 235, 248]
+	      ZOrder		      -5
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Counter"
 	      SourceType	      "Xilinx Counter Block"
 	      infoedit		      "Hardware notes: Free running counters are the least expensive in hardware.  A count limited co"
@@ -35848,37 +39184,45 @@ Library {
 	      sggui_pos		      "20,20,348,619"
 	      block_type	      "counter"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "40,36,1,1,white,blue,0,46c73e85,right"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 60 60 0 ],[0 0 60 60 ],[0.77 0.82 "
-	      "0.91]);\npatch([14 4 18 4 14 30 34 38 55 42 29 20 35 20 29 42 55 38 34 30 14 ],[6 16 30 44 54 54 50 54 54 41 54"
-	      " 45 30 15 6 19 6 6 10 6 6 ],[0.98 0.96 0.92]);\nplot([0 60 60 0 0 ],[0 0 60 60 0 ]);\nfprintf('','COMMENT: end "
-	      "icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_label('input',1,'rst');\ncolor('"
-	      "black');port_label('input',2,'en');\ncolor('black');port_label('output',1,'out');\nfprintf('','COMMENT: end ico"
-	      "n text');\n"
+	      sg_icon_stat	      "40,36,2,1,white,blue,0,131a2a7a,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 40 40 0 0 ],[0 0 36 36 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 40 40 0 0 ],[0 0 36 36 0 ]);\npatch([8.875 16.1 21.1 26.1 31.1 21.1 13.875 8.875 ],[23.55"
+	      " 23.55 28.55 23.55 28.55 28.55 28.55 23.55 ],[1 1 1 ]);\npatch([13.875 21.1 16.1 8.875 13.875 ],[18.55 18.55 23"
+	      ".55 23.55 18.55 ],[0.931 0.946 0.973 ]);\npatch([8.875 16.1 21.1 13.875 8.875 ],[13.55 13.55 18.55 18.55 13.55 "
+	      "],[1 1 1 ]);\npatch([13.875 31.1 26.1 21.1 16.1 8.875 13.875 ],[8.55 8.55 13.55 8.55 13.55 13.55 8.55 ],[0.931 "
+	      "0.946 0.973 ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('bla"
+	      "ck');port_label('input',1,'rst');\ncolor('black');port_label('input',2,'en');\n\ncolor('black');disp('{\\fontsi"
+	      "ze{14}\\bf\\lceil++\\rceil}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out4"
+	      SID		      "1096"
 	      Ports		      [1, 1]
 	      Position		      [315, 238, 345, 252]
+	      ZOrder		      -6
 	      NamePlacement	      "alternate"
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,14,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "30,14,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 14 14 0 ],[0.88 0"
 	      ".88 0.88 ]);\nplot([0 30 30 0 0 ],[0 0 14 14 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[9"
 	      ".22 9.22 11.22 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[7.22 7.22 9.22"
@@ -35891,26 +39235,32 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out5"
+	      SID		      "1097"
 	      Ports		      [1, 1]
 	      Position		      [315, 253, 345, 267]
+	      ZOrder		      -7
 	      NamePlacement	      "alternate"
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,14,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "30,14,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 14 14 0 ],[0.88 0"
 	      ".88 0.88 ]);\nplot([0 30 30 0 0 ],[0 0 14 14 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[9"
 	      ".22 9.22 11.22 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[7.22 7.22 9.22"
@@ -35923,26 +39273,32 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out6"
+	      SID		      "1098"
 	      Ports		      [1, 1]
 	      Position		      [315, 223, 345, 237]
+	      ZOrder		      -8
 	      NamePlacement	      "alternate"
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,14,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "30,14,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 14 14 0 ],[0.88 0"
 	      ".88 0.88 ]);\nplot([0 30 30 0 0 ],[0 0 14 14 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[9"
 	      ".22 9.22 11.22 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[7.22 7.22 9.22"
@@ -35955,8 +39311,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Mux"
+	      SID		      "1099"
 	      Ports		      [3, 1]
 	      Position		      [265, 97, 290, 163]
+	      ZOrder		      -9
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Mux"
 	      SourceType	      "Xilinx Bus Multiplexer Block"
 	      inputs		      "2"
@@ -35989,8 +39348,10 @@ Library {
 	    Block {
 	      BlockType		      Scope
 	      Name		      "Scope2"
+	      SID		      "1100"
 	      Ports		      [3]
 	      Position		      [370, 218, 405, 272]
+	      ZOrder		      -10
 	      Floating		      off
 	      Location		      [6, 41, 1446, 867]
 	      Open		      off
@@ -36002,6 +39363,7 @@ Library {
 		axes2			"data_out"
 		axes3			"valid_out"
 	      }
+	      ShowLegends	      off
 	      YMin		      "-1~65~0"
 	      YMax		      "1~92.5~1"
 	      SaveName		      "ScopeData35"
@@ -36012,20 +39374,26 @@ Library {
 	    Block {
 	      BlockType		      Outport
 	      Name		      "new_acc_out"
+	      SID		      "1101"
 	      Position		      [115, 178, 145, 192]
+	      ZOrder		      -11
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "dout"
+	      SID		      "1102"
 	      Position		      [335, 123, 365, 137]
+	      ZOrder		      -12
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "valid_out"
+	      SID		      "1103"
 	      Position		      [115, 253, 145, 267]
+	      ZOrder		      -13
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
@@ -36131,80 +39499,85 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "ins_vect_loc"
+	  SID			  "1104"
 	  Tag			  "xps:sw_reg"
 	  Ports			  [1, 1]
 	  Position		  [990, 210, 1090, 240]
+	  ZOrder		  -42
 	  BackgroundColor	  "[1.000000, 1.000000, 0.000000]"
+	  AttributesFormatString  "1input"
+	  LibraryVersion	  "1.521"
 	  SourceBlock		  "xps_library/software register"
-	  SourceType		  ""
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
+	  SourceType		  "swreg"
+	  mode			  "one value"
 	  io_dir		  "From Processor"
-	  arith_type		  "Unsigned"
-	  bitwidth		  "32"
-	  bin_pt		  "0"
+	  io_delay		  "0"
 	  sample_period		  "1"
-	  gw_name		  "casper_library_accumulators_vacc_tvg_ins_vect_loc_user_data_out"
+	  names			  "reg"
+	  bitwidths		  "32"
+	  arith_types		  "0"
+	  bin_pts		  "0"
+	  sim_port		  on
+	  show_format		  off
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "ins_vect_val"
+	  SID			  "1105"
 	  Tag			  "xps:sw_reg"
 	  Ports			  [1, 1]
 	  Position		  [990, 250, 1090, 280]
+	  ZOrder		  -43
 	  BackgroundColor	  "[1.000000, 1.000000, 0.000000]"
+	  AttributesFormatString  "1input"
+	  LibraryVersion	  "1.521"
 	  SourceBlock		  "xps_library/software register"
-	  SourceType		  ""
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
+	  SourceType		  "swreg"
+	  mode			  "one value"
 	  io_dir		  "From Processor"
-	  arith_type		  "Unsigned"
-	  bitwidth		  "32"
-	  bin_pt		  "0"
+	  io_delay		  "0"
 	  sample_period		  "1"
-	  gw_name		  "casper_library_accumulators_vacc_tvg_ins_vect_val_user_data_out"
+	  names			  "reg"
+	  bitwidths		  "32"
+	  arith_types		  "0"
+	  bin_pts		  "0"
+	  sim_port		  on
+	  show_format		  off
 	}
 	Block {
 	  BlockType		  SubSystem
 	  Name			  "ins_vector"
+	  SID			  "1106"
 	  Ports			  [6, 3]
 	  Position		  [1140, 78, 1265, 332]
+	  ZOrder		  -44
 	  AttributesFormatString  "Vector Length: 139264"
 	  MinAlgLoopOccurrences	  off
 	  PropExecContextOutsideSubsystem off
 	  RTWSystemCode		  "Auto"
 	  FunctionWithSeparateData off
 	  Opaque		  off
+	  RequestExecContextInheritance	off
 	  MaskHideContents	  off
-	  MaskPromptString	  "number of vectors"
-	  MaskStyleString	  "edit"
-	  MaskVariables		  "num_vectors=@1;"
-	  MaskTunableValueString  "on"
-	  MaskEnableString	  "on"
-	  MaskVisibilityString	  "on"
-	  MaskToolTipString	  "on"
-	  MaskInitialization	  "fmtstr = sprintf('Vector Length: %d', num_vectors);\nset_param(gcb, 'AttributesFormatString',"
-	  " fmtstr);\n"
-	  MaskIconFrame		  on
-	  MaskIconOpaque	  on
-	  MaskIconRotate	  "none"
-	  MaskIconUnits		  "autoscale"
-	  MaskValueString	  "len"
+	  Object {
+	    $PropName		    "MaskObject"
+	    $ObjectID		    89
+	    $ClassName		    "Simulink.Mask"
+	    Initialization	    "fmtstr = sprintf('Vector Length: %d', num_vectors);\nset_param(gcb, 'AttributesFormatString',"
+	    " fmtstr);\n"
+	    Object {
+	      $PropName		      "Parameters"
+	      $ObjectID		      90
+	      $ClassName	      "Simulink.MaskParameter"
+	      Type		      "edit"
+	      Name		      "num_vectors"
+	      Prompt		      "number of vectors"
+	      Value		      "len"
+	    }
+	  }
 	  System {
 	    Name		    "ins_vector"
-	    Location		    [106, 204, 1479, 939]
+	    Location		    [72, 85, 1493, 1055]
 	    Open		    off
 	    ModelBrowserVisibility  off
 	    ModelBrowserWidth	    200
@@ -36220,50 +39593,65 @@ Library {
 	    Block {
 	      BlockType		      Inport
 	      Name		      "new_acc_in"
+	      SID		      "1107"
 	      Position		      [40, 443, 70, 457]
+	      ZOrder		      -1
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "data_in"
+	      SID		      "1108"
 	      Position		      [40, 348, 70, 362]
+	      ZOrder		      -2
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "valid_in"
+	      SID		      "1109"
 	      Position		      [40, 483, 70, 497]
+	      ZOrder		      -3
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "vector"
+	      SID		      "1110"
 	      Position		      [40, 318, 70, 332]
+	      ZOrder		      -4
 	      Port		      "4"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "value"
+	      SID		      "1111"
 	      Position		      [40, 393, 70, 407]
+	      ZOrder		      -5
 	      Port		      "5"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Inport
 	      Name		      "enable"
+	      SID		      "1112"
 	      Position		      [40, 243, 70, 257]
+	      ZOrder		      -6
 	      Port		      "6"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay1"
+	      SID		      "1113"
 	      Ports		      [1, 1]
 	      Position		      [155, 481, 180, 499]
+	      ZOrder		      -7
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -36292,9 +39680,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay2"
+	      SID		      "1114"
 	      Ports		      [1, 1]
 	      Position		      [250, 481, 275, 499]
+	      ZOrder		      -8
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -36323,9 +39714,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay4"
+	      SID		      "1115"
 	      Ports		      [1, 1]
 	      Position		      [155, 346, 180, 364]
+	      ZOrder		      -9
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -36354,9 +39748,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay5"
+	      SID		      "1116"
 	      Ports		      [1, 1]
 	      Position		      [250, 346, 275, 364]
+	      ZOrder		      -10
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -36385,9 +39782,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay6"
+	      SID		      "1117"
 	      Ports		      [1, 1]
 	      Position		      [155, 391, 180, 409]
+	      ZOrder		      -11
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -36416,9 +39816,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay7"
+	      SID		      "1118"
 	      Ports		      [1, 1]
 	      Position		      [250, 391, 275, 409]
+	      ZOrder		      -12
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -36447,9 +39850,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay8"
+	      SID		      "1119"
 	      Ports		      [1, 1]
 	      Position		      [155, 441, 180, 459]
+	      ZOrder		      -13
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -36478,9 +39884,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Delay9"
+	      SID		      "1120"
 	      Ports		      [1, 1]
 	      Position		      [250, 441, 275, 459]
+	      ZOrder		      -14
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Delay"
 	      SourceType	      "Xilinx Delay Block"
 	      infoedit		      "Hardware notes: A delay line is a chain, each link of which is an SRL16 followed by a flip-flo"
@@ -36509,26 +39918,32 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out1"
+	      SID		      "1121"
 	      Ports		      [1, 1]
 	      Position		      [635, 58, 665, 72]
+	      ZOrder		      -15
 	      NamePlacement	      "alternate"
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,14,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "30,14,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 14 14 0 ],[0.88 0"
 	      ".88 0.88 ]);\nplot([0 30 30 0 0 ],[0 0 14 14 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[9"
 	      ".22 9.22 11.22 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[7.22 7.22 9.22"
@@ -36541,26 +39956,32 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out2"
+	      SID		      "1122"
 	      Ports		      [1, 1]
 	      Position		      [635, 73, 665, 87]
+	      ZOrder		      -16
 	      NamePlacement	      "alternate"
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,14,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "30,14,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 14 14 0 ],[0.88 0"
 	      ".88 0.88 ]);\nplot([0 30 30 0 0 ],[0 0 14 14 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[9"
 	      ".22 9.22 11.22 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[7.22 7.22 9.22"
@@ -36573,26 +39994,32 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out3"
+	      SID		      "1123"
 	      Ports		      [1, 1]
 	      Position		      [635, 88, 665, 102]
+	      ZOrder		      -17
 	      NamePlacement	      "alternate"
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,14,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "30,14,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 14 14 0 ],[0.88 0"
 	      ".88 0.88 ]);\nplot([0 30 30 0 0 ],[0 0 14 14 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[9"
 	      ".22 9.22 11.22 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[7.22 7.22 9.22"
@@ -36605,26 +40032,32 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out4"
+	      SID		      "1124"
 	      Ports		      [1, 1]
 	      Position		      [635, 28, 665, 42]
+	      ZOrder		      -18
 	      NamePlacement	      "alternate"
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,14,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "30,14,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 14 14 0 ],[0.88 0"
 	      ".88 0.88 ]);\nplot([0 30 30 0 0 ],[0 0 14 14 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[9"
 	      ".22 9.22 11.22 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[7.22 7.22 9.22"
@@ -36637,26 +40070,32 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out5"
+	      SID		      "1125"
 	      Ports		      [1, 1]
 	      Position		      [635, 43, 665, 57]
+	      ZOrder		      -19
 	      NamePlacement	      "alternate"
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,14,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "30,14,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 14 14 0 ],[0.88 0"
 	      ".88 0.88 ]);\nplot([0 30 30 0 0 ],[0 0 14 14 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[9"
 	      ".22 9.22 11.22 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[7.22 7.22 9.22"
@@ -36669,26 +40108,32 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out6"
+	      SID		      "1126"
 	      Ports		      [1, 1]
 	      Position		      [635, 13, 665, 27]
+	      ZOrder		      -20
 	      NamePlacement	      "alternate"
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,14,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "30,14,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 14 14 0 ],[0.88 0"
 	      ".88 0.88 ]);\nplot([0 30 30 0 0 ],[0 0 14 14 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[9"
 	      ".22 9.22 11.22 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[7.22 7.22 9.22"
@@ -36701,26 +40146,32 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Gateway Out7"
+	      SID		      "1127"
 	      Ports		      [1, 1]
 	      Position		      [635, 103, 665, 117]
+	      ZOrder		      -21
 	      NamePlacement	      "alternate"
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Gateway Out"
 	      SourceType	      "Xilinx Gateway Out Block"
 	      infoedit		      "Gateway out block.  Converts Xilinx fixed point inputs into ouputs of type Simulink integer, d"
 	      "ouble, or fixed point.<P><P>Hardware notes:  In hardware these blocks become top level output ports or are disc"
 	      "arded, depending on how they are configured."
+	      inherit_from_input      off
 	      hdl_port		      off
 	      timing_constraint	      "None"
 	      locs_specified	      off
 	      LOCs		      "{}"
+	      UseAsDAC		      off
+	      DACChannel	      "'1'"
 	      xl_use_area	      off
 	      xl_area		      "[0, 0, 0, 0, 0, 0, 0]"
 	      has_advanced_control    "0"
 	      sggui_pos		      "-1,-1,-1,-1"
 	      block_type	      "gatewayout"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "30,14,1,1,white,grey,0,632ec840,right,,[ ],[ ]"
+	      sg_icon_stat	      "30,14,1,1,white,grey,1,632ec840,right,,[ ],[ ]"
 	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 30 30 0 0 ],[0 0 14 14 0 ],[0.88 0"
 	      ".88 0.88 ]);\nplot([0 30 30 0 0 ],[0 0 14 14 0 ]);\npatch([10.55 13.44 15.44 17.44 19.44 15.44 12.55 10.55 ],[9"
 	      ".22 9.22 11.22 9.22 11.22 11.22 11.22 9.22 ],[1 1 1 ]);\npatch([12.55 15.44 13.44 10.55 12.55 ],[7.22 7.22 9.22"
@@ -36733,8 +40184,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Logical"
+	      SID		      "1128"
 	      Ports		      [2, 1]
 	      Position		      [325, 299, 360, 321]
+	      ZOrder		      -22
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Logical"
 	      SourceType	      "Xilinx Logical Block Block"
 	      logical_function	      "AND"
@@ -36765,9 +40219,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Mux"
+	      SID		      "1129"
 	      Ports		      [3, 1]
 	      Position		      [400, 289, 425, 421]
+	      ZOrder		      -23
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Mux"
 	      SourceType	      "Xilinx Bus Multiplexer Block"
 	      inputs		      "2"
@@ -36800,9 +40257,12 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "Relational"
+	      SID		      "1130"
 	      Ports		      [2, 1]
 	      Position		      [250, 288, 280, 337]
+	      ZOrder		      -24
 	      ShowName		      off
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Relational"
 	      SourceType	      "Xilinx Arithmetic Relational Operator Block"
 	      mode		      "a=b"
@@ -36829,8 +40289,10 @@ Library {
 	    Block {
 	      BlockType		      Scope
 	      Name		      "Scope2"
+	      SID		      "1131"
 	      Ports		      [7]
 	      Position		      [695, 16, 735, 114]
+	      ZOrder		      -25
 	      Floating		      off
 	      Location		      [5, 34, 1689, 1035]
 	      Open		      off
@@ -36846,6 +40308,7 @@ Library {
 		axes6			"%<SignalLabel>"
 		axes7			"sync_out"
 	      }
+	      ShowLegends	      off
 	      YMin		      "0.95~0~-1~-5~-5~-5~-5"
 	      YMax		      "1.05~1~1~5~5~5~5"
 	      SaveName		      "ScopeData1"
@@ -36856,8 +40319,11 @@ Library {
 	    Block {
 	      BlockType		      Reference
 	      Name		      "tot_cntr"
+	      SID		      "1132"
 	      Ports		      [2, 1]
 	      Position		      [150, 283, 185, 312]
+	      ZOrder		      -26
+	      LibraryVersion	      "1.2"
 	      SourceBlock	      "xbsIndex_r4/Counter"
 	      SourceType	      "Xilinx Counter Block"
 	      infoedit		      "Hardware notes: Free running counters are the least expensive in hardware.  A count limited co"
@@ -36885,33 +40351,39 @@ Library {
 	      sggui_pos		      "20,20,348,618"
 	      block_type	      "counter"
 	      block_version	      "10.1.3"
-	      sg_icon_stat	      "35,31,1,1,white,blue,0,46c73e85,right,,[ ],[ ]"
-	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 35 35 0 0 ],[0 0 31 31 0 ],[0.77 0"
-	      ".82 0.91 ]);\nplot([0 35 35 0 0 ],[0 0 31 31 0 ]);\npatch([8.1 13.88 17.88 21.88 25.88 17.88 12.1 8.1 ],[19.44 "
-	      "19.44 23.44 19.44 23.44 23.44 23.44 19.44 ],[1 1 1 ]);\npatch([12.1 17.88 13.88 8.1 12.1 ],[15.44 15.44 19.44 1"
-	      "9.44 15.44 ],[0.931 0.946 0.973 ]);\npatch([8.1 13.88 17.88 12.1 8.1 ],[11.44 11.44 15.44 15.44 11.44 ],[1 1 1 "
-	      "]);\npatch([12.1 25.88 21.88 17.88 13.88 8.1 12.1 ],[7.44 7.44 11.44 7.44 11.44 11.44 7.44 ],[0.931 0.946 0.973"
+	      sg_icon_stat	      "35,29,2,1,white,blue,0,131a2a7a,right,,[ ],[ ]"
+	      sg_mask_display	      "fprintf('','COMMENT: begin icon graphics');\npatch([0 35 35 0 0 ],[0 0 29 29 0 ],[0.77 0"
+	      ".82 0.91 ]);\nplot([0 35 35 0 0 ],[0 0 29 29 0 ]);\npatch([8.1 13.88 17.88 21.88 25.88 17.88 12.1 8.1 ],[18.44 "
+	      "18.44 22.44 18.44 22.44 22.44 22.44 18.44 ],[1 1 1 ]);\npatch([12.1 17.88 13.88 8.1 12.1 ],[14.44 14.44 18.44 1"
+	      "8.44 14.44 ],[0.931 0.946 0.973 ]);\npatch([8.1 13.88 17.88 12.1 8.1 ],[10.44 10.44 14.44 14.44 10.44 ],[1 1 1 "
+	      "]);\npatch([12.1 25.88 21.88 17.88 13.88 8.1 12.1 ],[6.44 6.44 10.44 6.44 10.44 10.44 6.44 ],[0.931 0.946 0.973"
 	      " ]);\nfprintf('','COMMENT: end icon graphics');\nfprintf('','COMMENT: begin icon text');\ncolor('black');port_l"
-	      "abel('input',1,'rst');\ncolor('black');port_label('input',2,'en');\ncolor('black');port_label('output',1,'out')"
-	      ";\nfprintf('','COMMENT: end icon text');\n"
+	      "abel('input',1,'rst');\ncolor('black');port_label('input',2,'en');\n\ncolor('black');disp('{\\fontsize{14}\\bf\\"
+	      "lceil++\\rceil}','texmode','on');\nfprintf('','COMMENT: end icon text');"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "new_acc_out"
+	      SID		      "1133"
 	      Position		      [525, 443, 555, 457]
+	      ZOrder		      -27
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "data"
+	      SID		      "1134"
 	      Position		      [525, 348, 555, 362]
+	      ZOrder		      -28
 	      Port		      "2"
 	      IconDisplay	      "Port number"
 	    }
 	    Block {
 	      BlockType		      Outport
 	      Name		      "valid_out"
+	      SID		      "1135"
 	      Position		      [525, 483, 555, 497]
+	      ZOrder		      -29
 	      Port		      "3"
 	      IconDisplay	      "Port number"
 	    }
@@ -37141,112 +40613,119 @@ Library {
 	Block {
 	  BlockType		  Constant
 	  Name			  "master_reset_sim1"
+	  SID			  "1136"
 	  Position		  [270, 145, 300, 175]
+	  ZOrder		  -45
 	  ShowName		  off
 	  Value			  "0"
 	}
 	Block {
 	  BlockType		  Constant
 	  Name			  "master_reset_sim10"
+	  SID			  "1137"
 	  Position		  [940, 250, 970, 280]
+	  ZOrder		  -46
 	  ShowName		  off
 	  Value			  "10000"
 	}
 	Block {
 	  BlockType		  Constant
 	  Name			  "master_reset_sim11"
+	  SID			  "1138"
 	  Position		  [940, 210, 970, 240]
+	  ZOrder		  -47
 	  ShowName		  off
 	  Value			  "2"
 	}
 	Block {
 	  BlockType		  Constant
 	  Name			  "master_reset_sim7"
+	  SID			  "1139"
 	  Position		  [15, 320, 45, 350]
+	  ZOrder		  -48
 	  ShowName		  off
 	  Value			  "512000"
 	}
 	Block {
 	  BlockType		  Constant
 	  Name			  "master_reset_sim8"
+	  SID			  "1140"
 	  Position		  [15, 370, 45, 400]
+	  ZOrder		  -49
 	  ShowName		  off
 	  Value			  "16"
 	}
 	Block {
 	  BlockType		  Constant
 	  Name			  "master_reset_sim9"
+	  SID			  "1141"
 	  Position		  [15, 425, 45, 455]
+	  ZOrder		  -50
 	  ShowName		  off
 	  Value			  "128"
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "n_per_group"
+	  SID			  "1142"
 	  Tag			  "xps:sw_reg"
 	  Ports			  [1, 1]
 	  Position		  [60, 370, 160, 400]
+	  ZOrder		  -51
 	  BackgroundColor	  "[1.000000, 1.000000, 0.000000]"
+	  AttributesFormatString  "1input"
+	  LibraryVersion	  "1.521"
 	  SourceBlock		  "xps_library/software register"
-	  SourceType		  ""
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
+	  SourceType		  "swreg"
+	  mode			  "one value"
 	  io_dir		  "From Processor"
-	  arith_type		  "Unsigned"
-	  bitwidth		  "32"
-	  bin_pt		  "0"
+	  io_delay		  "0"
 	  sample_period		  "1"
-	  gw_name		  "casper_library_accumulators_vacc_tvg_n_per_group_user_data_out"
+	  names			  "reg"
+	  bitwidths		  "32"
+	  arith_types		  "0"
+	  bin_pts		  "0"
+	  sim_port		  on
+	  show_format		  off
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "n_pulses"
+	  SID			  "1143"
 	  Tag			  "xps:sw_reg"
 	  Ports			  [1, 1]
 	  Position		  [60, 320, 160, 350]
+	  ZOrder		  -52
 	  BackgroundColor	  "[1.000000, 1.000000, 0.000000]"
+	  AttributesFormatString  "1input"
+	  LibraryVersion	  "1.521"
 	  SourceBlock		  "xps_library/software register"
-	  SourceType		  ""
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
+	  SourceType		  "swreg"
+	  mode			  "one value"
 	  io_dir		  "From Processor"
-	  arith_type		  "Unsigned"
-	  bitwidth		  "32"
-	  bin_pt		  "0"
+	  io_delay		  "0"
 	  sample_period		  "1"
-	  gw_name		  "casper_library_accumulators_vacc_tvg_n_pulses_user_data_out"
+	  names			  "reg"
+	  bitwidths		  "32"
+	  arith_types		  "0"
+	  bin_pts		  "0"
+	  sim_port		  on
+	  show_format		  off
 	}
 	Block {
 	  BlockType		  Reference
 	  Name			  "posedge"
+	  SID			  "1144"
 	  Ports			  [1, 1]
 	  Position		  [380, 71, 415, 89]
+	  ZOrder		  -53
 	  BackgroundColor	  "[0.501961, 1.000000, 0.501961]"
 	  AttributesFormatString  "rising edges\nactive high"
+	  LibraryVersion	  "1.43"
 	  UserDataPersistent	  on
 	  UserData		  "DataTag5"
 	  SourceBlock		  "casper_library_misc/edge_detect"
 	  SourceType		  "edge_detect"
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
 	  edge			  "Rising"
 	  polarity		  "Active High"
 	  x_in			  "[0 0.08 0.08 0.16 0.16 0.24 0.24 0.32 0.32 0.4]"
@@ -37257,44 +40736,50 @@ Library {
 	Block {
 	  BlockType		  Reference
 	  Name			  "write1"
+	  SID			  "1145"
 	  Tag			  "xps:sw_reg"
 	  Ports			  [1, 1]
 	  Position		  [315, 145, 415, 175]
+	  ZOrder		  -54
 	  BackgroundColor	  "[1.000000, 1.000000, 0.000000]"
+	  AttributesFormatString  "1input"
+	  LibraryVersion	  "1.521"
 	  SourceBlock		  "xps_library/software register"
-	  SourceType		  ""
-	  ShowPortLabels	  "FromPortIcon"
-	  SystemSampleTime	  "-1"
-	  FunctionWithSeparateData off
-	  RTWMemSecFuncInitTerm	  "Inherit from model"
-	  RTWMemSecFuncExecute	  "Inherit from model"
-	  RTWMemSecDataConstants  "Inherit from model"
-	  RTWMemSecDataInternal	  "Inherit from model"
-	  RTWMemSecDataParameters "Inherit from model"
+	  SourceType		  "swreg"
+	  mode			  "one value"
 	  io_dir		  "From Processor"
-	  arith_type		  "Unsigned"
-	  bitwidth		  "32"
-	  bin_pt		  "0"
+	  io_delay		  "0"
 	  sample_period		  "1"
-	  gw_name		  "casper_library_accumulators_vacc_tvg_write1_user_data_out"
+	  names			  "reg"
+	  bitwidths		  "32"
+	  arith_types		  "0"
+	  bin_pts		  "0"
+	  sim_port		  on
+	  show_format		  off
 	}
 	Block {
 	  BlockType		  Outport
 	  Name			  "sync_out"
+	  SID			  "1146"
 	  Position		  [1360, 113, 1390, 127]
+	  ZOrder		  -55
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Outport
 	  Name			  "data_out"
+	  SID			  "1147"
 	  Position		  [1360, 198, 1390, 212]
+	  ZOrder		  -56
 	  Port			  "2"
 	  IconDisplay		  "Port number"
 	}
 	Block {
 	  BlockType		  Outport
 	  Name			  "valid_out"
+	  SID			  "1148"
 	  Position		  [1360, 283, 1390, 297]
+	  ZOrder		  -57
 	  Port			  "3"
 	  IconDisplay		  "Port number"
 	}
@@ -37663,57 +41148,46 @@ Library {
 MatData {
   NumRecords		  6
   DataRecord {
-    Tag			    DataTag5
-    Data		    "  %)30     .    L 8   8    (     @         %    \"     $    !     0         %  0 \"P    $    6    <W1A="
-    "&4       !P87)A;65T97)S    #@   #     &    \"     T         !0    @    !     0    $         !@ $ /0)!@(.    ( 8   "
-    "8    (     @         %    \"     $    !     0         %  0 \"0    $    _    9&5F875L=', 961G90      <&]L87)I='D >%"
-    "]I;@      >%]O=70     >5]I;@      >5]O=70       X   \"8 P  !@    @    !          4    (     0    P    !          X"
-    "    P    !@    @    $          4    (     0    0    !         !  ! !E9&=E#@   #@    &    \"     0         !0    @ "
-    "   !    !@    $         $     8   !2:7-I;F<   X    X    !@    @    $          4    (     0    @    !         !    "
-    " (    <&]L87)I='D.    0     8    (    !          %    \"     $    +     0         0    \"P   $%C=&EV92!(:6=H      "
-    " .    ,     8    (    !          %    \"     $    $     0         0  0 >%]I;@X   !@    !@    @    $          4    "
-    "(     0   \"\\    !         !     O    6S L,\"XP.\"PP+C X+# N,38L,\"XQ-BPP+C(T+# N,C0L,\"XS,BPP+C,R+# N-%T #@   #@"
-    "    &    \"     0         !0    @    !    !0    $         $     4   !X7V]U=     X   !@    !@    @    $          4 "
-    "   (     0   \"\\    !         !     O    6S N-BPP+C8X+# N-C@L,\"XW-BPP+C<V+# N.#0L,\"XX-\"PP+CDR+# N.3(L,5T #@   "
-    "#     &    \"     0         !0    @    !    !     $         $  $ 'E?:6X.    4     8    (    !          %    \"    "
-    " $    ?     0         0    'P   %LM,2PM,2PM,2PM,2PM,2PM,2PM,2PM,2PM,2PM,5T #@   #@    &    \"     0         !0    "
-    "@    !    !0    $         $     4   !Y7V]U=     X   !0    !@    @    $          4    (     0   !\\    !         ! "
-    "    ?    6RTQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ70 .    .     8    (    !          %    \"     $    &   "
-    "  0         0    !@   %)I<VEN9P  #@   $     &    \"     0         !0    @    !    \"P    $         $     L   !!8W1"
-    "I=F4@2&EG:       #@   &     &    \"     0         !0    @    !    +P    $         $    \"\\   !;,\" P+C X(# N,#@@,"
-    "\"XQ-B P+C$V(# N,C0@,\"XR-\" P+C,R(# N,S(@,\"XT70 .    8     8    (    !          %    \"     $    O     0        "
-    " 0    +P   %LP+C8@,\"XV.\" P+C8X(# N-S8@,\"XW-B P+C@T(# N.#0@,\"XY,B P+CDR(#%=  X   !0    !@    @    $          4 "
-    "   (     0   !\\    !         !     ?    6RTQ(\"TQ(\" Q(\" Q(\" Q(\" Q(\" Q(\" Q(\" Q(\" Q70 .    4     8    (    "
-    "!          %    \"     $    ?     0         0    'P   %LM,2 M,2 @,2 @,2 M,2 M,2 M,2 M,2 M,2 M,5T "
+    Tag			    DataTag0
+    Data		    "  %)30     .    , (   8    (     @         %    \"     $    !     0         %  0 \"P    $    6    <W1A="
+    "&4       !P87)A;65T97)S    #@   #     &    \"     T         !0    @    !     0    $         !@ $ &1W,@ .    H $   "
+    "8    (     @         %    \"     $    !     0         %  0 \"P    $    W    9&5F875L=',   !V96-?;&5N     &%R:71H7W"
+    "1Y<&4 ;E]B:71S      !B:6Y?<'0        .    *     8    (     0         %    \"                0         .    .     8"
+    "    (    !@         %    \"     $    !     0         )    \"            #! #@   #@    &    \"     0         !0    "
+    "@    !    !@    $         $     8   !3:6=N960   X    X    !@    @    &          4    (     0    $    !          D "
+    "   (            0$ .    .     8    (    !@         %    \"     $    !     0         )    \"               "
   }
   DataRecord {
-    Tag			    DataTag4
-    Data		    "  %)30     .    L 8   8    (     @         %    \"     $    !     0         %  0 \"P    $    6    <W1A="
-    "&4       !P87)A;65T97)S    #@   #     &    \"     T         !0    @    !     0    $         !@ $ /0)!@(.    ( 8   "
-    "8    (     @         %    \"     $    !     0         %  0 \"0    $    _    9&5F875L=', 961G90      <&]L87)I='D >%"
-    "]I;@      >%]O=70     >5]I;@      >5]O=70       X   \"8 P  !@    @    !          4    (     0    P    !          X"
-    "    P    !@    @    $          4    (     0    0    !         !  ! !E9&=E#@   #@    &    \"     0         !0    @ "
-    "   !    !@    $         $     8   !2:7-I;F<   X    X    !@    @    $          4    (     0    @    !         !    "
-    " (    <&]L87)I='D.    0     8    (    !          %    \"     $    +     0         0    \"P   $%C=&EV92!(:6=H      "
-    " .    ,     8    (    !          %    \"     $    $     0         0  0 >%]I;@X   !@    !@    @    $          4    "
-    "(     0   \"\\    !         !     O    6S L,\"XP.\"PP+C X+# N,38L,\"XQ-BPP+C(T+# N,C0L,\"XS,BPP+C,R+# N-%T #@   #@"
-    "    &    \"     0         !0    @    !    !0    $         $     4   !X7V]U=     X   !@    !@    @    $          4 "
-    "   (     0   \"\\    !         !     O    6S N-BPP+C8X+# N-C@L,\"XW-BPP+C<V+# N.#0L,\"XX-\"PP+CDR+# N.3(L,5T #@   "
-    "#     &    \"     0         !0    @    !    !     $         $  $ 'E?:6X.    4     8    (    !          %    \"    "
-    " $    ?     0         0    'P   %LM,2PM,2PM,2PM,2PM,2PM,2PM,2PM,2PM,2PM,5T #@   #@    &    \"     0         !0    "
-    "@    !    !0    $         $     4   !Y7V]U=     X   !0    !@    @    $          4    (     0   !\\    !         ! "
-    "    ?    6RTQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ70 .    .     8    (    !          %    \"     $    &   "
-    "  0         0    !@   %)I<VEN9P  #@   $     &    \"     0         !0    @    !    \"P    $         $     L   !!8W1"
-    "I=F4@2&EG:       #@   &     &    \"     0         !0    @    !    +P    $         $    \"\\   !;,\" P+C X(# N,#@@,"
-    "\"XQ-B P+C$V(# N,C0@,\"XR-\" P+C,R(# N,S(@,\"XT70 .    8     8    (    !          %    \"     $    O     0        "
-    " 0    +P   %LP+C8@,\"XV.\" P+C8X(# N-S8@,\"XW-B P+C@T(# N.#0@,\"XY,B P+CDR(#%=  X   !0    !@    @    $          4 "
-    "   (     0   !\\    !         !     ?    6RTQ(\"TQ(\" Q(\" Q(\" Q(\" Q(\" Q(\" Q(\" Q(\" Q70 .    4     8    (    "
-    "!          %    \"     $    ?     0         0    'P   %LM,2 M,2 @,2 @,2 M,2 M,2 M,2 M,2 M,2 M,5T "
+    Tag			    DataTag1
+    Data		    "  %)30     .    6 0   8    (     @         %    \"     $    !     0         %  0 \"P    $    6    <W1A="
+    "&4       !P87)A;65T97)S    #@   #     &    \"     T         !0    @    !     0    $         !@ $  A!+0$.    R ,   "
+    "8    (     @         %    \"     $    !     0         %  0 \"P    $    W    9&5F875L=',   !V96-?;&5N     &%R:71H7W"
+    "1Y<&4 8FEN7W!T7VEN  !N7V)I='-?;W5T   .    0 (   8    (     0         %    \"     $    (     0         .    .     8"
+    "    (    !          %    \"     $    '     0         0    !P   '9E8U]L96X #@   #@    &    \"     8         !0    @"
+    "    !     0    $         \"0    @            @0 X   !     !@    @    $          4    (     0    H    !         !  "
+    "   *    87)I=&A?='EP90        X    X    !@    @    $          4    (     0    @    !         !     (    56YS:6=N96"
+    "0.    0     8    (    !          %    \"     $    )     0         0    \"0   &)I;E]P=%]I;@         .    .     8   "
+    " (    !@         %    \"     $    !     0         )    \"            #] #@   $     &    \"     0         !0    @  "
+    "  !    \"@    $         $     H   !N7V)I='-?;W5T        #@   #@    &    \"     8         !0    @    !     0    $  "
+    "       \"0    @           ! 0 X    X    !@    @    &          4    (     0    $    !          D    (            ($"
+    " .    2     8    (    !          %    \"     $    2     0         0    $@   %-I9VYE9\" @*#(G<R!C;VUP*0        X   "
+    " X    !@    @    &          4    (     0    $    !          D    (            /T .    .     8    (    !@         %"
+    "    \"     $    !     0         )    \"            $! "
+  }
+  DataRecord {
+    Tag			    DataTag2
+    Data		    "  %)30     .    , (   8    (     @         %    \"     $    !     0         %  0 \"P    $    6    <W1A="
+    "&4       !P87)A;65T97)S    #@   #     &    \"     T         !0    @    !     0    $         !@ $ 'E(LP8.    H $   "
+    "8    (     @         %    \"     $    !     0         %  0 \"P    $    W    9&5F875L=',   !V96-?;&5N     &%R:71H7W"
+    "1Y<&4 ;E]B:71S      !B:6Y?<'0        .    *     8    (     0         %    \"                0         .    .     8"
+    "    (    !@         %    \"     $    !     0         )    \"            \"! #@   #@    &    \"     0         !0   "
+    " @    !    !@    $         $     8   !3:6=N960   X    X    !@    @    &          4    (     0    $    !          D"
+    "    (            0$ .    .     8    (    !@         %    \"     $    !     0         )    \"               "
   }
   DataRecord {
     Tag			    DataTag3
     Data		    "  %)30     .    J 8   8    (     @         %    \"     $    !     0         %  0 \"P    $    6    <W1A="
-    "&4       !P87)A;65T97)S    #@   #     &    \"     T         !0    @    !     0    $         !@ $ +E+\"P,.    & 8  "
+    "&4       !P87)A;65T97)S    #@   #     &    \"     T         !0    @    !     0    $         !@ $ \"NX:@4.    & 8  "
     " 8    (     @         %    \"     $    !     0         %  0 \"0    $    _    9&5F875L=', 961G90      <&]L87)I='D >"
     "%]I;@      >%]O=70     >5]I;@      >5]O=70       X   \"8 P  !@    @    !          4    (     0    P    !          "
     "X    P    !@    @    $          4    (     0    0    !         !  ! !E9&=E#@   #@    &    \"     0         !0    @"
@@ -37735,40 +41209,51 @@ MatData {
     "    !    'P    $         $    !\\   !;+3$@+3$@(#$@(#$@+3$@+3$@(#$@(#$@+3$@+3%=  "
   }
   DataRecord {
-    Tag			    DataTag2
-    Data		    "  %)30     .    , (   8    (     @         %    \"     $    !     0         %  0 \"P    $    6    <W1A="
-    "&4       !P87)A;65T97)S    #@   #     &    \"     T         !0    @    !     0    $         !@ $ (,<6 (.    H $   "
-    "8    (     @         %    \"     $    !     0         %  0 \"P    $    W    9&5F875L=',   !V96-?;&5N     &%R:71H7W"
-    "1Y<&4 ;E]B:71S      !B:6Y?<'0        .    *     8    (     0         %    \"                0         .    .     8"
-    "    (    !@         %    \"     $    !     0         )    \"            \"! #@   #@    &    \"     0         !0   "
-    " @    !    !@    $         $     8   !3:6=N960   X    X    !@    @    &          4    (     0    $    !          D"
-    "    (            0$ .    .     8    (    !@         %    \"     $    !     0         )    \"               "
+    Tag			    DataTag4
+    Data		    "  %)30     .    L 8   8    (     @         %    \"     $    !     0         %  0 \"P    $    6    <W1A="
+    "&4       !P87)A;65T97)S    #@   #     &    \"     T         !0    @    !     0    $         !@ $ )#IO@4.    ( 8   "
+    "8    (     @         %    \"     $    !     0         %  0 \"0    $    _    9&5F875L=', 961G90      <&]L87)I='D >%"
+    "]I;@      >%]O=70     >5]I;@      >5]O=70       X   \"8 P  !@    @    !          4    (     0    P    !          X"
+    "    P    !@    @    $          4    (     0    0    !         !  ! !E9&=E#@   #@    &    \"     0         !0    @ "
+    "   !    !@    $         $     8   !2:7-I;F<   X    X    !@    @    $          4    (     0    @    !         !    "
+    " (    <&]L87)I='D.    0     8    (    !          %    \"     $    +     0         0    \"P   $%C=&EV92!(:6=H      "
+    " .    ,     8    (    !          %    \"     $    $     0         0  0 >%]I;@X   !@    !@    @    $          4    "
+    "(     0   \"\\    !         !     O    6S L,\"XP.\"PP+C X+# N,38L,\"XQ-BPP+C(T+# N,C0L,\"XS,BPP+C,R+# N-%T #@   #@"
+    "    &    \"     0         !0    @    !    !0    $         $     4   !X7V]U=     X   !@    !@    @    $          4 "
+    "   (     0   \"\\    !         !     O    6S N-BPP+C8X+# N-C@L,\"XW-BPP+C<V+# N.#0L,\"XX-\"PP+CDR+# N.3(L,5T #@   "
+    "#     &    \"     0         !0    @    !    !     $         $  $ 'E?:6X.    4     8    (    !          %    \"    "
+    " $    ?     0         0    'P   %LM,2PM,2PM,2PM,2PM,2PM,2PM,2PM,2PM,2PM,5T #@   #@    &    \"     0         !0    "
+    "@    !    !0    $         $     4   !Y7V]U=     X   !0    !@    @    $          4    (     0   !\\    !         ! "
+    "    ?    6RTQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ70 .    .     8    (    !          %    \"     $    &   "
+    "  0         0    !@   %)I<VEN9P  #@   $     &    \"     0         !0    @    !    \"P    $         $     L   !!8W1"
+    "I=F4@2&EG:       #@   &     &    \"     0         !0    @    !    +P    $         $    \"\\   !;,\" P+C X(# N,#@@,"
+    "\"XQ-B P+C$V(# N,C0@,\"XR-\" P+C,R(# N,S(@,\"XT70 .    8     8    (    !          %    \"     $    O     0        "
+    " 0    +P   %LP+C8@,\"XV.\" P+C8X(# N-S8@,\"XW-B P+C@T(# N.#0@,\"XY,B P+CDR(#%=  X   !0    !@    @    $          4 "
+    "   (     0   !\\    !         !     ?    6RTQ(\"TQ(\" Q(\" Q(\" Q(\" Q(\" Q(\" Q(\" Q(\" Q70 .    4     8    (    "
+    "!          %    \"     $    ?     0         0    'P   %LM,2 M,2 @,2 @,2 M,2 M,2 M,2 M,2 M,2 M,5T "
   }
   DataRecord {
-    Tag			    DataTag1
-    Data		    "  %)30     .    6 0   8    (     @         %    \"     $    !     0         %  0 \"P    $    6    <W1A="
-    "&4       !P87)A;65T97)S    #@   #     &    \"     T         !0    @    !     0    $         !@ $ )4[W 4.    R ,   "
-    "8    (     @         %    \"     $    !     0         %  0 \"P    $    W    9&5F875L=',   !V96-?;&5N     &%R:71H7W"
-    "1Y<&4 8FEN7W!T7VEN  !N7V)I='-?;W5T   .    0 (   8    (     0         %    \"     $    (     0         .    .     8"
-    "    (    !          %    \"     $    '     0         0    !P   '9E8U]L96X #@   #@    &    \"     8         !0    @"
-    "    !     0    $         \"0    @            @0 X   !     !@    @    $          4    (     0    H    !         !  "
-    "   *    87)I=&A?='EP90        X    X    !@    @    $          4    (     0    @    !         !     (    56YS:6=N96"
-    "0.    0     8    (    !          %    \"     $    )     0         0    \"0   &)I;E]P=%]I;@         .    .     8   "
-    " (    !@         %    \"     $    !     0         )    \"               #@   $     &    \"     0         !0    @  "
-    "  !    \"@    $         $     H   !N7V)I='-?;W5T        #@   #@    &    \"     8         !0    @    !     0    $  "
-    "       \"0    @           ! 0 X    X    !@    @    &          4    (     0    $    !          D    (            ($"
-    " .    2     8    (    !          %    \"     $    2     0         0    $@   %-I9VYE9\" @*#(G<R!C;VUP*0        X   "
-    " X    !@    @    &          4    (     0    $    !          D    (               .    .     8    (    !@         %"
-    "    \"     $    !     0         )    \"            $! "
-  }
-  DataRecord {
-    Tag			    DataTag0
-    Data		    "  %)30     .    , (   8    (     @         %    \"     $    !     0         %  0 \"P    $    6    <W1A="
-    "&4       !P87)A;65T97)S    #@   #     &    \"     T         !0    @    !     0    $         !@ $ \"H_+0<.    H $  "
-    " 8    (     @         %    \"     $    !     0         %  0 \"P    $    W    9&5F875L=',   !V96-?;&5N     &%R:71H7"
-    "W1Y<&4 ;E]B:71S      !B:6Y?<'0        .    *     8    (     0         %    \"                0         .    .     "
-    "8    (    !@         %    \"     $    !     0         )    \"            #! #@   #@    &    \"     0         !0   "
-    " @    !    !@    $         $     8   !3:6=N960   X    X    !@    @    &          4    (     0    $    !          D"
-    "    (            0$ .    .     8    (    !@         %    \"     $    !     0         )    \"               "
+    Tag			    DataTag5
+    Data		    "  %)30     .    L 8   8    (     @         %    \"     $    !     0         %  0 \"P    $    6    <W1A="
+    "&4       !P87)A;65T97)S    #@   #     &    \"     T         !0    @    !     0    $         !@ $ )#IO@4.    ( 8   "
+    "8    (     @         %    \"     $    !     0         %  0 \"0    $    _    9&5F875L=', 961G90      <&]L87)I='D >%"
+    "]I;@      >%]O=70     >5]I;@      >5]O=70       X   \"8 P  !@    @    !          4    (     0    P    !          X"
+    "    P    !@    @    $          4    (     0    0    !         !  ! !E9&=E#@   #@    &    \"     0         !0    @ "
+    "   !    !@    $         $     8   !2:7-I;F<   X    X    !@    @    $          4    (     0    @    !         !    "
+    " (    <&]L87)I='D.    0     8    (    !          %    \"     $    +     0         0    \"P   $%C=&EV92!(:6=H      "
+    " .    ,     8    (    !          %    \"     $    $     0         0  0 >%]I;@X   !@    !@    @    $          4    "
+    "(     0   \"\\    !         !     O    6S L,\"XP.\"PP+C X+# N,38L,\"XQ-BPP+C(T+# N,C0L,\"XS,BPP+C,R+# N-%T #@   #@"
+    "    &    \"     0         !0    @    !    !0    $         $     4   !X7V]U=     X   !@    !@    @    $          4 "
+    "   (     0   \"\\    !         !     O    6S N-BPP+C8X+# N-C@L,\"XW-BPP+C<V+# N.#0L,\"XX-\"PP+CDR+# N.3(L,5T #@   "
+    "#     &    \"     0         !0    @    !    !     $         $  $ 'E?:6X.    4     8    (    !          %    \"    "
+    " $    ?     0         0    'P   %LM,2PM,2PM,2PM,2PM,2PM,2PM,2PM,2PM,2PM,5T #@   #@    &    \"     0         !0    "
+    "@    !    !0    $         $     4   !Y7V]U=     X   !0    !@    @    $          4    (     0   !\\    !         ! "
+    "    ?    6RTQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ+\"TQ70 .    .     8    (    !          %    \"     $    &   "
+    "  0         0    !@   %)I<VEN9P  #@   $     &    \"     0         !0    @    !    \"P    $         $     L   !!8W1"
+    "I=F4@2&EG:       #@   &     &    \"     0         !0    @    !    +P    $         $    \"\\   !;,\" P+C X(# N,#@@,"
+    "\"XQ-B P+C$V(# N,C0@,\"XR-\" P+C,R(# N,S(@,\"XT70 .    8     8    (    !          %    \"     $    O     0        "
+    " 0    +P   %LP+C8@,\"XV.\" P+C8X(# N-S8@,\"XW-B P+C@T(# N.#0@,\"XY,B P+CDR(#%=  X   !0    !@    @    $          4 "
+    "   (     0   !\\    !         !     ?    6RTQ(\"TQ(\" Q(\" Q(\" Q(\" Q(\" Q(\" Q(\" Q(\" Q70 .    4     8    (    "
+    "!          %    \"     $    ?     0         0    'P   %LM,2 M,2 @,2 @,2 M,2 M,2 M,2 M,2 M,2 M,5T "
   }
 }

--- a/casper_library/cross_multiplier_init.m
+++ b/casper_library/cross_multiplier_init.m
@@ -62,16 +62,18 @@ offset = 0;
 tick=120;
 for input = 0:streams-1,
     %number of multipliers to be used
-    mults = (2*(input+1)-1)*aggregation; 
+    %mults = (2*(input+1)-1)*aggregation
+    mults = (streams - input)*aggregation; 
 
     reuse_block(blk, ['din',num2str(input)], 'built-in/inport', ...
         'Port', [num2str(input+2)], 'Position', [30 100+(offset+mults)*tick 60 115+(offset+mults)*tick]);
 
     % set up uncram block for each stream
-    reuse_block(blk, ['unpack',num2str(input)], 'gavrt_library/uncram', ...
-        'num_slice', 'aggregation', ...
-        'slice_width', 'bit_width_in*2', ... 
-        'bin_pt', '0', 'arith_type', '0', ...
+    reuse_block(blk, ['unpack',num2str(input)], 'casper_library_flow_control/bus_expand', ...
+        'mode', 'divisions of equal size', ...
+        'outputNum', 'aggregation', ...
+        'outputWidth', 'bit_width_in*2', ... 
+        'outputBinaryPt', '0', 'outputArithmeticType', '0', ...
         'Position', [120 100+(offset+mults)*tick 170 100+(offset+mults+aggregation)*tick]);
     add_line(blk, ['din',num2str(input),'/1'],['unpack',num2str(input),'/1']);
 
@@ -85,7 +87,12 @@ for input = 0:streams-1,
             'Position', [200 100+(offset+mults+substream)*tick 250 150+(offset+mults+substream)*tick]);
         add_line(blk, ['unpack',num2str(input),'/',num2str(substream+1)], [sub_name,'/1']);
     end
+end
 
+offset = 0;
+tick=120;
+for input = 0:streams-1,
+    mults = (streams - input)*aggregation; 
     %go through multipliers    
     for mult = 0:(mults/aggregation)-1,
         
@@ -97,14 +104,16 @@ for input = 0:streams-1,
         %C* | AC* BC* CC* DC*
         %D* | AD* BD* CD* DD*
         
-        x_in = min(mult,input);
-        y_in = min(input,mults/aggregation-mult-1);
+        %x_in = min(mult,input)
+        x_in = input
+        %y_in = min(input,mults/aggregation-mult-1)
+        y_in = input+mult;
     
         %to recombine streams
         pack_name = ['pack', num2str(input), '_', num2str(mult)];
-        reuse_block(blk, pack_name, 'gavrt_library/cram', ...
-            'num_slice', 'aggregation', ...
-            'Position', [800 100+(offset+mults+(mult*aggregation))*tick 850 130+(offset+mults+(mult*aggregation))*tick]);
+        reuse_block(blk, pack_name, 'casper_library_flow_control/bus_create', ...
+            'inputNum', 'aggregation', ...
+            'Position', [800 100+(offset+(mult*aggregation))*tick 850 130+(offset+(mult*aggregation))*tick]);
         
         for substream = 0:aggregation-1,
 
@@ -112,34 +121,34 @@ for input = 0:streams-1,
             mult_name = ['cmult', num2str(input), '_', num2str(mult), '_', num2str(substream)];  
             reuse_block(blk, mult_name, 'casper_library_multipliers/cmult_4bit_hdl*', ...
                 'mult_latency', 'mult_latency', 'add_latency', 'add_latency', ...
-                'Position', [550 100+(offset+mults+(mult*aggregation)+substream)*tick 600 195+(offset+mults+(mult*aggregation)+substream)*tick]);
+                'Position', [550 100+(offset+(mult*aggregation)+substream)*tick 600 195+(offset+(mult*aggregation)+substream)*tick]);
 
             %set up delays to remove fanout from c_to_ri blocks
             delay_name = ['delay', num2str(input), '_', num2str(mult), '_', num2str(substream), '_0'];
             reuse_block(blk, delay_name, 'xbsIndex_r4/Delay', ...
                 'latency', '1', ...
-                'Position', [450 100+(offset+mults+(mult*aggregation)+substream)*tick 480 100+(offset+mults+(mult*aggregation)+substream)*tick+15]); 
+                'Position', [450 100+(offset+(mult*aggregation)+substream)*tick 480 100+(offset+(mult*aggregation)+substream)*tick+15]); 
             add_line(blk, ['c_to_ri', num2str(x_in), '_', num2str(substream), '/1'], [delay_name,'/1']);
             add_line(blk, [delay_name,'/1'], [mult_name,'/1']);
 
             delay_name = ['delay', num2str(input), '_', num2str(mult), '_', num2str(substream), '_1'];
             reuse_block(blk, delay_name, 'xbsIndex_r4/Delay', ...
                 'latency', '1', ...
-                'Position', [450 100+(offset+mults+(mult*aggregation)+substream)*tick+30 480 100+(offset+mults+(mult*aggregation)+substream)*tick+45]);    
+                'Position', [450 100+(offset+(mult*aggregation)+substream)*tick+30 480 100+(offset+(mult*aggregation)+substream)*tick+45]);    
             add_line(blk, ['c_to_ri', num2str(x_in), '_', num2str(substream), '/2'], [delay_name,'/1']);
             add_line(blk, [delay_name,'/1'], [mult_name,'/2']);
             
             delay_name = ['delay', num2str(input), '_', num2str(mult), '_', num2str(substream), '_2'];
             reuse_block(blk, delay_name, 'xbsIndex_r4/Delay', ...
                 'latency', '1', ...
-                'Position', [450 100+(offset+mults+(mult*aggregation)+substream)*tick+60 480 100+(offset+mults+(mult*aggregation)+substream)*tick+75]);    
+                'Position', [450 100+(offset+(mult*aggregation)+substream)*tick+60 480 100+(offset+(mult*aggregation)+substream)*tick+75]);    
             add_line(blk, ['c_to_ri', num2str(y_in), '_', num2str(substream), '/1'], [delay_name,'/1']);
             add_line(blk, [delay_name,'/1'], [mult_name,'/3']);
 
             delay_name = ['delay', num2str(input), '_', num2str(mult), '_', num2str(substream), '_3'];
             reuse_block(blk, delay_name, 'xbsIndex_r4/Delay', ...
                 'latency', '1', ...
-                'Position', [450 100+(offset+mults+(mult*aggregation)+substream)*tick+90 480 100+(offset+mults+(mult*aggregation)+substream)*tick+105]);    
+                'Position', [450 100+(offset+(mult*aggregation)+substream)*tick+90 480 100+(offset+(mult*aggregation)+substream)*tick+105]);    
             add_line(blk, ['c_to_ri', num2str(y_in), '_', num2str(substream), '/2'], [delay_name,'/1']);
             add_line(blk, [delay_name,'/1'], [mult_name,'/4']);
 
@@ -150,12 +159,12 @@ for input = 0:streams-1,
 	    	'bit_width_i', tostring(bit_width_in*2+1), 'binary_point_i', tostring(binary_point_in*2), ...
 	    	'bit_width_o', tostring(bit_width_out), 'binary_point_o', tostring(binary_point_out), ...
 		'overflow', tostring(overflow), 'quantization', tostring(quantisation), 'latency', tostring(conv_latency), ...
-                'Position', [625 100+(offset+mults+(mult*aggregation)+substream)*tick 675 130+(offset+mults+(mult*aggregation)+substream)*tick]);
+                'Position', [625 100+(offset+(mult*aggregation)+substream)*tick 675 130+(offset+(mult*aggregation)+substream)*tick]);
             reuse_block(blk, [cvrt_name, '_imag'], 'casper_library_misc/convert_of', ...
 	    	'bit_width_i', tostring(bit_width_in*2+1), 'binary_point_i', tostring(binary_point_in*2), ...
 	    	'bit_width_o', tostring(bit_width_out), 'binary_point_o', tostring(binary_point_out), ...
 		'overflow', tostring(overflow), 'quantization', tostring(quantisation), 'latency', tostring(conv_latency), ... 
-                'Position', [625 150+(offset+mults+(mult*aggregation)+substream)*tick 675 180+(offset+mults+(mult*aggregation)+substream)*tick]);
+                'Position', [625 150+(offset+(mult*aggregation)+substream)*tick 675 180+(offset+(mult*aggregation)+substream)*tick]);
             
 	    add_line(blk, [mult_name,'/1'], [cvrt_name,'_real/1']);
             add_line(blk, [mult_name,'/2'], [cvrt_name,'_imag/1']);
@@ -163,7 +172,7 @@ for input = 0:streams-1,
             %join results into complex output
             ri2c_name = ['ri_to_c', num2str(input), '_', num2str(mult), '_', num2str(substream)];
             reuse_block(blk, ri2c_name, 'casper_library_misc/ri_to_c', ...
-                'Position', [725 100+(offset+mults+(mult*aggregation)+substream)*tick 775 130+(offset+mults+(mult*aggregation)+substream)*tick]);
+                'Position', [725 100+(offset+(mult*aggregation)+substream)*tick 775 130+(offset+(mult*aggregation)+substream)*tick]);
 
             add_line(blk, [cvrt_name,'_real/1'], [ri2c_name,'/1']);
             add_line(blk, [cvrt_name,'_imag/1'], [ri2c_name,'/2']);
@@ -175,7 +184,7 @@ for input = 0:streams-1,
         %create output port
         out_name = ['din', num2str(x_in), '_x_din', num2str(y_in), '*']; 
         reuse_block(blk, out_name, 'built-in/outport', 'Port', num2str((offset/aggregation)+mult+2), ...
-            'Position', [950 100+(offset+mults+(mult*aggregation))*tick 980 115+(offset+mults+(mult*aggregation))*tick])
+            'Position', [950 100+(offset+(mult*aggregation))*tick 980 115+(offset+(mult*aggregation))*tick])
         add_line(blk, [pack_name,'/1'], [out_name,'/1']);
 
     end

--- a/casper_library/cross_multiplier_init.m
+++ b/casper_library/cross_multiplier_init.m
@@ -46,12 +46,13 @@ add_latency = get_var('add_latency', 'defaults', defaults, varargin{:});
 overflow = get_var('overflow', 'defaults', defaults, varargin{:});
 quantisation = get_var('quantisation', 'defaults', defaults, varargin{:});
 conv_latency = get_var('conv_latency', 'defaults', defaults, varargin{:});
+fanout_latency = get_var('fanout_latency', 'defaults', defaults, varargin{:});
 
 %delay infrastructure
 reuse_block(blk, 'sync_in', 'built-in/inport', ...
     'Port', '1', 'Position', [30 30 60 45]);
 reuse_block(blk, 'sync_delay', 'xbsIndex_r4/Delay', ...
-    'latency', 'mult_latency+add_latency+1+conv_latency', ...
+    'latency', 'mult_latency+add_latency+conv_latency+fanout_latency', ...
     'Position', [410 25 460 50]) 
 add_line(blk, 'sync_in/1', 'sync_delay/1');
 reuse_block(blk, 'sync_out', 'built-in/outport', ...
@@ -105,7 +106,7 @@ for input = 0:streams-1,
         %D* | AD* BD* CD* DD*
         
         %x_in = min(mult,input)
-        x_in = input
+        x_in = input;
         %y_in = min(input,mults/aggregation-mult-1)
         y_in = input+mult;
     
@@ -124,31 +125,31 @@ for input = 0:streams-1,
                 'Position', [550 100+(offset+(mult*aggregation)+substream)*tick 600 195+(offset+(mult*aggregation)+substream)*tick]);
 
             %set up delays to remove fanout from c_to_ri blocks
-            delay_name = ['delay', num2str(input), '_', num2str(mult), '_', num2str(substream), '_0'];
-            reuse_block(blk, delay_name, 'xbsIndex_r4/Delay', ...
-                'latency', '1', ...
-                'Position', [450 100+(offset+(mult*aggregation)+substream)*tick 480 100+(offset+(mult*aggregation)+substream)*tick+15]); 
+            delay_name = ['pipeline', num2str(input), '_', num2str(mult), '_', num2str(substream), '_0'];
+            reuse_block(blk, delay_name, 'casper_library_delays/pipeline', ...
+                'latency', 'fanout_latency', ...
+                'Position', [420 100+(offset+(mult*aggregation)+substream)*tick 480 100+(offset+(mult*aggregation)+substream)*tick+15]); 
             add_line(blk, ['c_to_ri', num2str(x_in), '_', num2str(substream), '/1'], [delay_name,'/1']);
             add_line(blk, [delay_name,'/1'], [mult_name,'/1']);
 
-            delay_name = ['delay', num2str(input), '_', num2str(mult), '_', num2str(substream), '_1'];
-            reuse_block(blk, delay_name, 'xbsIndex_r4/Delay', ...
-                'latency', '1', ...
-                'Position', [450 100+(offset+(mult*aggregation)+substream)*tick+30 480 100+(offset+(mult*aggregation)+substream)*tick+45]);    
+            delay_name = ['pipeline', num2str(input), '_', num2str(mult), '_', num2str(substream), '_1'];
+            reuse_block(blk, delay_name, 'casper_library_delays/pipeline', ...
+                'latency', 'fanout_latency', ...
+                'Position', [420 100+(offset+(mult*aggregation)+substream)*tick+30 480 100+(offset+(mult*aggregation)+substream)*tick+45]);    
             add_line(blk, ['c_to_ri', num2str(x_in), '_', num2str(substream), '/2'], [delay_name,'/1']);
             add_line(blk, [delay_name,'/1'], [mult_name,'/2']);
             
-            delay_name = ['delay', num2str(input), '_', num2str(mult), '_', num2str(substream), '_2'];
-            reuse_block(blk, delay_name, 'xbsIndex_r4/Delay', ...
-                'latency', '1', ...
-                'Position', [450 100+(offset+(mult*aggregation)+substream)*tick+60 480 100+(offset+(mult*aggregation)+substream)*tick+75]);    
+            delay_name = ['pipeline', num2str(input), '_', num2str(mult), '_', num2str(substream), '_2'];
+            reuse_block(blk, delay_name, 'casper_library_delays/pipeline', ...
+                'latency', 'fanout_latency', ...
+                'Position', [420 100+(offset+(mult*aggregation)+substream)*tick+60 480 100+(offset+(mult*aggregation)+substream)*tick+75]);    
             add_line(blk, ['c_to_ri', num2str(y_in), '_', num2str(substream), '/1'], [delay_name,'/1']);
             add_line(blk, [delay_name,'/1'], [mult_name,'/3']);
 
-            delay_name = ['delay', num2str(input), '_', num2str(mult), '_', num2str(substream), '_3'];
-            reuse_block(blk, delay_name, 'xbsIndex_r4/Delay', ...
-                'latency', '1', ...
-                'Position', [450 100+(offset+(mult*aggregation)+substream)*tick+90 480 100+(offset+(mult*aggregation)+substream)*tick+105]);    
+            delay_name = ['pipeline', num2str(input), '_', num2str(mult), '_', num2str(substream), '_3'];
+            reuse_block(blk, delay_name, 'casper_library_delays/pipeline', ...
+                'latency', 'fanout_latency', ...
+                'Position', [420 100+(offset+(mult*aggregation)+substream)*tick+90 480 100+(offset+(mult*aggregation)+substream)*tick+105]);    
             add_line(blk, ['c_to_ri', num2str(y_in), '_', num2str(substream), '/2'], [delay_name,'/1']);
             add_line(blk, [delay_name,'/1'], [mult_name,'/4']);
 

--- a/casper_library/dsp48e_bram_vacc_init.m
+++ b/casper_library/dsp48e_bram_vacc_init.m
@@ -38,7 +38,7 @@ function dsp48e_bram_vacc_init (blk, varargin)
 defaults = { ...
   'vec_len', 8, ...
   'arith_type', 'Unsigned', ...
-  'bin_pt_in', 0, ...
+  'bin_pt_in', 31, ...
   'n_bits_out', 32, ...
 };
 
@@ -71,24 +71,18 @@ if (bin_pt_in < 0),
   return
 end
 
-if (bin_pt_in > n_bits_out),
-  errordlg([blk, ': Input binary point cannot exceed output bit width.']);
-  return
-end
-
 if (n_bits_out < 1),
   errordlg([blk, ': Bit width must be greater than 0.']);
   return
 end
 
-if (n_bits_out > 32),
-  errordlg([blk, ': Bit width cannot exceed 32.']);
+if (n_bits_out > 48),
+  errordlg([blk, ': Output bit width cannot exceed 48.']);
   return
 end
 
 % Update sub-block parameters.
-
-set_param([blk, '/Reinterpret'], 'arith_type', arith_type)
+set_param([blk, '/Reinterpret'], 'arith_type', arith_type);
 
 % Save block state to stop repeated init script runs.
 save_state(blk, 'defaults', defaults, varargin{:});

--- a/casper_library/dsp48e_bram_vacc_init.m
+++ b/casper_library/dsp48e_bram_vacc_init.m
@@ -82,7 +82,12 @@ if (n_bits_out > 48),
 end
 
 % Update sub-block parameters.
-set_param([blk, '/Reinterpret'], 'arith_type', arith_type);
+set_param([blk, '/convert'], 'bin_pt_in', num2str(bin_pt_in));
+set_param([blk, '/convert'], 'n_bits_out', num2str(n_bits_out));
+set_param([blk, '/convert'], 'bin_pt_out', num2str( bin_pt_in - (48 - n_bits_out) ));
+set_param([blk, '/convert'], 'quantization', 'Round  (biased: Up)');
+set_param([blk, '/convert'], 'overflow', 'Wrap');
+set_param([blk, '/convert'], 'latency', '2');
 
 % Save block state to stop repeated init script runs.
 save_state(blk, 'defaults', defaults, varargin{:});


### PR DESCRIPTION
- clean out cross_mutliplier block as init script draws it.
- add configurable fanout latency to cross_multiplier
- change DSP48E bram vacc to accumulate full 48 bits, and use a convert block when slicing off upper bits