### PR TITLE
Adding the raw axi4lite interface

### DIFF
--- a/jasper_library/memory.py
+++ b/jasper_library/memory.py
@@ -1,6 +1,6 @@
 class Register(object):
     def __init__(self, name, nbytes=4, offset=0, mode='r',
-                default_val=0, ram=False, ram_size=-1, data_width=32):
+                default_val=0, ram=False, ram_size=-1, data_width=32, axi4lite_mode=''):
         """
         A class to encapsulate a register's parameters. This is used when
         instantiating a device with a large address space, but it is desirable
@@ -54,3 +54,4 @@ class Register(object):
         # - Placing here for now because toolflow.py:generate_xml_memory_map
         #   has access to the memory.Register object in the XML generation
         self.data_width = data_width
+        self.axi4lite_mode = axi4lite_mode

--- a/jasper_library/toolflow.py
+++ b/jasper_library/toolflow.py
@@ -809,6 +809,7 @@ class Toolflow(object):
                 node.set('mask', hex(0xFFFFFFFF))
                 # node.set('size', str(reg.nbytes))
                 node.set('permission', reg.mode)               
+                node.set('axi4lite_mode', reg.axi4lite_mode)
                 if reg.mode == 'r':
                     if reg.default_val != 0:
                        # Populate defaults of sys_block version registers

--- a/jasper_library/yellow_blocks/axi4lite_interconnect.py
+++ b/jasper_library/yellow_blocks/axi4lite_interconnect.py
@@ -51,26 +51,52 @@ class axi4lite_interconnect(YellowBlock):
         inst.add_port('s_axi4lite_rready',  'M_AXI_rready',  dir='out', width=1,  parent_sig=False)
         inst.add_port('s_axi4lite_bready',  'M_AXI_bready',  dir='out', width=1,  parent_sig=False)
 
+        for key, val in list(self.memory_map.items()):
+            for reg in val["memory_map"]:
+                if reg.axi4lite_mode=='raw':
+
+                   # raw axi4l miso signals
+                   inst.add_port('m_axi4lite_%s_awready' %reg.name,  'm_axi4lite_%s_awready' %reg.name, dir='in', width=1,  parent_sig=False)
+                   inst.add_port('m_axi4lite_%s_wready' %reg.name,   'm_axi4lite_%s_wready' %reg.name, dir='in', width=1,  parent_sig=False)
+                   inst.add_port('m_axi4lite_%s_bresp' %reg.name,    'm_axi4lite_%s_bresp'  %reg.name, dir='in', width=2,  parent_sig=False)
+                   inst.add_port('m_axi4lite_%s_bvalid' %reg.name,   'm_axi4lite_%s_bvalid' %reg.name, dir='in', width=1,  parent_sig=False)
+                   inst.add_port('m_axi4lite_%s_arready' %reg.name,  'm_axi4lite_%s_arready'%reg.name, dir='in', width=1,  parent_sig=False)
+                   inst.add_port('m_axi4lite_%s_rresp' %reg.name,    'm_axi4lite_%s_rresp'  %reg.name, dir='in', width=2,  parent_sig=False)
+                   inst.add_port('m_axi4lite_%s_rdata'  %reg.name,   'm_axi4lite_%s_rdata'  %reg.name, dir='in', width=32, parent_sig=False)
+                   inst.add_port('m_axi4lite_%s_rvalid' %reg.name,   'm_axi4lite_%s_rvalid' %reg.name, dir='in', width=1,  parent_sig=False)
+
+                   # raw axi4l mosi signals
+                   inst.add_port('m_axi4lite_%s_awaddr' %reg.name,  'm_axi4lite_%s_awaddr' %reg.name,  dir='in',  width=32, parent_sig=False)
+                   inst.add_port('m_axi4lite_%s_awvalid' %reg.name, 'm_axi4lite_%s_awvalid' %reg.name, dir='in',  width=1,  parent_sig=False)
+                   inst.add_port('m_axi4lite_%s_wdata' %reg.name,   'm_axi4lite_%s_wdata' %reg.name,   dir='in',  width=32, parent_sig=False)
+                   inst.add_port('m_axi4lite_%s_wvalid' %reg.name,  'm_axi4lite_%s_wvalid' %reg.name,  dir='in',  width=1,  parent_sig=False)
+                   inst.add_port('m_axi4lite_%s_wstrb' %reg.name,   'm_axi4lite_%s_wstrb' %reg.name,   dir='in',  width=4,  parent_sig=False)
+                   inst.add_port('m_axi4lite_%s_araddr' %reg.name,  'm_axi4lite_%s_araddr' %reg.name,  dir='in',  width=32, parent_sig=False)
+                   inst.add_port('m_axi4lite_%s_arvalid' %reg.name, 'm_axi4lite_%s_arvalid' %reg.name, dir='in',  width=1,  parent_sig=False)
+                   inst.add_port('m_axi4lite_%s_rready' %reg.name,  'm_axi4lite_%s_rready' %reg.name,  dir='in',  width=1,  parent_sig=False)
+                   inst.add_port('m_axi4lite_%s_bready' %reg.name,  'm_axi4lite_%s_bready' %reg.name,  dir='in',  width=1,  parent_sig=False)
+
         #self.design_name = self.fullname[:-1].strip(self.name)
         self.design_name = self.fullname.replace("_axi4lite_interconnect","")
         #self.design_name = "test_red_pitaya"
 
         for key, val in list(self.memory_map.items()):
             for reg in val["memory_map"]:
-                if reg.ram == True:
-                    inst.add_port('axi4lite_%s_%s_add'      %(key, reg.name), '%s_%s_addr'     %(self.design_name, reg.name), dir='in',  width=int(math.log2((reg.nbytes * 8)/reg.data_width)), parent_sig=True)
-                    inst.add_port('axi4lite_%s_%s_data_in'  %(key, reg.name), '%s_%s_data_in'  %(self.design_name, reg.name), dir='in',  width=reg.data_width,           parent_sig=True)
-                    inst.add_port('axi4lite_%s_%s_data_out' %(key, reg.name), '%s_%s_data_out' %(self.design_name, reg.name), dir='out', width=reg.data_width,           parent_sig=True)
-                    inst.add_port('axi4lite_%s_%s_we'       %(key, reg.name), '%s_%s_we'       %(self.design_name, reg.name), dir='in',  width=1,                        parent_sig=True)
-                    inst.add_port('axi4lite_%s_%s_en'       %(key, reg.name), '1\'b1'                                       , dir='in',  width=1,                        parent_sig=False, parent_port=False)
-                    inst.add_port('axi4lite_%s_%s_clk'      %(key, reg.name), 'user_clk'                                    , dir='in',  width=1,                        parent_sig=False, parent_port=False)
-                else:
-                    if (reg.mode == "r"):
-                        inst.add_port('axi4lite_%s_%s_in'     %(key, reg.name), '%s_%s_in'     %(self.design_name, reg.name), dir='out', width=32, parent_sig=True)
-                        inst.add_port('axi4lite_%s_%s_in_we'  %(key, reg.name), '%s_%s_in_we'  %(self.design_name, reg.name), dir='out', width=1)
-                    if (reg.mode == "rw"):
-                        inst.add_port('axi4lite_%s_%s_out'    %(key, reg.name), '%s_%s_out'    %(self.design_name, reg.name), dir='in', width=32, parent_sig=True)
-                        inst.add_port('axi4lite_%s_%s_out_we' %(key, reg.name), '%s_%s_out_we' %(self.design_name, reg.name), dir='in', width=1)
+                if reg.axi4lite_mode != 'raw':
+                   if reg.ram == True:
+                      inst.add_port('axi4lite_%s_%s_add'      %(key, reg.name), '%s_%s_addr'     %(self.design_name, reg.name), dir='in',  width=int(math.log2((reg.nbytes * 8)/reg.data_width)), parent_sig=True)
+                      inst.add_port('axi4lite_%s_%s_data_in'  %(key, reg.name), '%s_%s_data_in'  %(self.design_name, reg.name), dir='in',  width=reg.data_width,           parent_sig=True)
+                      inst.add_port('axi4lite_%s_%s_data_out' %(key, reg.name), '%s_%s_data_out' %(self.design_name, reg.name), dir='out', width=reg.data_width,           parent_sig=True)
+                      inst.add_port('axi4lite_%s_%s_we'       %(key, reg.name), '%s_%s_we'       %(self.design_name, reg.name), dir='in',  width=1,                        parent_sig=True)
+                      inst.add_port('axi4lite_%s_%s_en'       %(key, reg.name), '1\'b1'                                       , dir='in',  width=1,                        parent_sig=False, parent_port=False)
+                      inst.add_port('axi4lite_%s_%s_clk'      %(key, reg.name), 'user_clk'                                    , dir='in',  width=1,                        parent_sig=False, parent_port=False)
+                   else:
+                      if (reg.mode == "r"):
+                         inst.add_port('axi4lite_%s_%s_in'     %(key, reg.name), '%s_%s_in'     %(self.design_name, reg.name), dir='out', width=32, parent_sig=True)
+                         inst.add_port('axi4lite_%s_%s_in_we'  %(key, reg.name), '%s_%s_in_we'  %(self.design_name, reg.name), dir='out', width=1)
+                      if (reg.mode == "rw"):
+                         inst.add_port('axi4lite_%s_%s_out'    %(key, reg.name), '%s_%s_out'    %(self.design_name, reg.name), dir='in', width=32, parent_sig=True)
+                         inst.add_port('axi4lite_%s_%s_out_we' %(key, reg.name), '%s_%s_out_we' %(self.design_name, reg.name), dir='in', width=1)
            
 
     def gen_tcl_cmds(self):
@@ -126,34 +152,59 @@ class axi4lite_interconnect(YellowBlock):
         axi4lite_wrapper.add_port('s_axi4lite_rready',  'M_AXI_rready',  dir='in',  width=1,  parent_sig=False)
         axi4lite_wrapper.add_port('s_axi4lite_bready',  'M_AXI_bready',  dir='in',  width=1,  parent_sig=False)
 
+        for key, val in list(self.memory_map.items()):
+            for reg in val["memory_map"]:
+                if reg.axi4lite_mode=='raw':
+                   # raw axi4l miso signals
+                   axi4lite_wrapper.add_port('m_axi4lite_%s_awready'%reg.name, 'm_axi4lite_%s_awready' %reg.name, dir='in', width=1,  parent_sig=False)
+                   axi4lite_wrapper.add_port('m_axi4lite_%s_wready' %reg.name, 'm_axi4lite_%s_wready' %reg.name, dir='in', width=1,  parent_sig=False)
+                   axi4lite_wrapper.add_port('m_axi4lite_%s_bresp' %reg.name,  'm_axi4lite_%s_bresp'  %reg.name, dir='in', width=2,  parent_sig=False)
+                   axi4lite_wrapper.add_port('m_axi4lite_%s_bvalid' %reg.name, 'm_axi4lite_%s_bvalid' %reg.name, dir='in', width=1,  parent_sig=False)
+                   axi4lite_wrapper.add_port('m_axi4lite_%s_arready' %reg.name,'m_axi4lite_%s_arready' %reg.name, dir='in', width=1,  parent_sig=False)
+                   axi4lite_wrapper.add_port('m_axi4lite_%s_rresp' %reg.name,  'm_axi4lite_%s_rresp'  %reg.name, dir='in', width=2,  parent_sig=False)
+                   axi4lite_wrapper.add_port('m_axi4lite_%s_rdata' %reg.name,  'm_axi4lite_%s_rdata'  %reg.name, dir='in', width=32, parent_sig=False)
+                   axi4lite_wrapper.add_port('m_axi4lite_%s_rvalid'%reg.name,  'm_axi4lite_%s_rvalid' %reg.name, dir='in', width=1,  parent_sig=False)              
+
+                   # raw axi4l mosi signals
+                   axi4lite_wrapper.add_port('m_axi4lite_%s_awaddr' %reg.name,  'm_axi4lite_%s_awaddr' %reg.name, dir='out',  width=32, parent_sig=False)
+                   axi4lite_wrapper.add_port('m_axi4lite_%s_awvalid' %reg.name, 'm_axi4lite_%s_awvalid' %reg.name, dir='out',  width=1,  parent_sig=False)
+                   axi4lite_wrapper.add_port('m_axi4lite_%s_wdata' %reg.name,   'm_axi4lite_%s_wdata' %reg.name,   dir='out',  width=32, parent_sig=False)
+                   axi4lite_wrapper.add_port('m_axi4lite_%s_wvalid' %reg.name,  'm_axi4lite_%s_wvalid' %reg.name,  dir='out',  width=1,  parent_sig=False)
+                   axi4lite_wrapper.add_port('m_axi4lite_%s_wstrb' %reg.name,   'm_axi4lite_%s_wstrb' %reg.name,   dir='out',  width=4,  parent_sig=False)
+                   axi4lite_wrapper.add_port('m_axi4lite_%s_araddr' %reg.name,  'm_axi4lite_%s_araddr' %reg.name,  dir='out',  width=32, parent_sig=False)
+                   axi4lite_wrapper.add_port('m_axi4lite_%s_arvalid' %reg.name, 'm_axi4lite_%s_arvalid' %reg.name, dir='out',  width=1,  parent_sig=False)
+                   axi4lite_wrapper.add_port('m_axi4lite_%s_rready' %reg.name,  'm_axi4lite_%s_rready' %reg.name,  dir='out',  width=1,  parent_sig=False)
+                   axi4lite_wrapper.add_port('m_axi4lite_%s_bready' %reg.name,  'm_axi4lite_%s_bready' %reg.name,  dir='out',  width=1,  parent_sig=False)
+
         # breakout ports for the registers from the records
         for key, val in list(self.memory_map.items()):
             for reg in val["memory_map"]:
-                if reg.ram==True:
-                    # axi4lite_wrapper.add_port('axi4lite_%s_%s_add'      %(key, reg.name), '%s_%s_add'     %(self.design_name, reg.name), dir='in',  width=int(math.log10(reg.nbytes/4)/math.log10(2)), parent_sig=True)
-                    axi4lite_wrapper.add_port('axi4lite_%s_%s_add'      %(key, reg.name), '%s_%s_add'      %(self.design_name, reg.name), dir='in',  width=int(math.log2((reg.nbytes * 8)/reg.data_width)), parent_sig=True)
-                    axi4lite_wrapper.add_port('axi4lite_%s_%s_data_in'  %(key, reg.name), '%s_%s_data_in'  %(self.design_name, reg.name), dir='in',  width=reg.data_width,           parent_sig=True)
-                    axi4lite_wrapper.add_port('axi4lite_%s_%s_data_out' %(key, reg.name), '%s_%s_data_out' %(self.design_name, reg.name), dir='out', width=reg.data_width,           parent_sig=True)
-                    axi4lite_wrapper.add_port('axi4lite_%s_%s_we'       %(key, reg.name), '%s_%s_we'       %(self.design_name, reg.name), dir='in',  width=1,            parent_sig=True)
-                    axi4lite_wrapper.add_port('axi4lite_%s_%s_en'       %(key, reg.name), '1\'b1'                                       , dir='in',  width=1,            parent_sig=False, parent_port=False)
-                    axi4lite_wrapper.add_port('axi4lite_%s_%s_clk'      %(key, reg.name), 'user_clk'                                    , dir='in',  width=1,            parent_sig=False, parent_port=False)
-                    pass
+                if reg.axi4lite_mode != 'raw':
+                   if reg.ram==True:
+                      # axi4lite_wrapper.add_port('axi4lite_%s_%s_add'      %(key, reg.name), '%s_%s_add'     %(self.design_name, reg.name), dir='in',  width=int(math.log10(reg.nbytes/4)/math.log10(2)), parent_sig=True)
+                      axi4lite_wrapper.add_port('axi4lite_%s_%s_add'      %(key, reg.name), '%s_%s_add'      %(self.design_name, reg.name), dir='in',  width=int(math.log2((reg.nbytes * 8)/reg.data_width)), parent_sig=True)
+                      axi4lite_wrapper.add_port('axi4lite_%s_%s_data_in'  %(key, reg.name), '%s_%s_data_in'  %(self.design_name, reg.name), dir='in',  width=reg.data_width,           parent_sig=True)
+                      axi4lite_wrapper.add_port('axi4lite_%s_%s_data_out' %(key, reg.name), '%s_%s_data_out' %(self.design_name, reg.name), dir='out', width=reg.data_width,           parent_sig=True)
+                      axi4lite_wrapper.add_port('axi4lite_%s_%s_we'       %(key, reg.name), '%s_%s_we'       %(self.design_name, reg.name), dir='in',  width=1,            parent_sig=True)
+                      axi4lite_wrapper.add_port('axi4lite_%s_%s_en'       %(key, reg.name), '1\'b1'                                       , dir='in',  width=1,            parent_sig=False, parent_port=False)
+                      axi4lite_wrapper.add_port('axi4lite_%s_%s_clk'      %(key, reg.name), 'user_clk'                                    , dir='in',  width=1,            parent_sig=False, parent_port=False)
+                      pass
 
-                else:
-                    if (reg.mode == "rw"):
-                        # add ports
-                        axi4lite_wrapper.add_port('axi4lite_%s_%s_out'      %(key, reg.name), '%s_out_%s_user_data_in'    %(self.design_name, reg.name), dir='out', width=32, parent_sig=True)
-                        axi4lite_wrapper.add_port('axi4lite_%s_%s_out_we'   %(key, reg.name), '%s_out_we_%s'              %(self.design_name, reg.name), dir='out',   width=1)
-                        # add signals
-                        axi4lite_wrapper.add_assign('axi4lite_%s_%s_out'    %(key, reg.name), 'axi4lite_%s_out.%s'    %(key, reg.name))
-                        axi4lite_wrapper.add_assign('axi4lite_%s_%s_out_we' %(key, reg.name), 'axi4lite_%s_out_we.%s' %(key, reg.name))
-                    if (reg.mode == "r"):
-                        # add ports
-                        axi4lite_wrapper.add_port('axi4lite_%s_%s_in'       %(key, reg.name), '%s_in_%s_user_data_in'    %(self.design_name, reg.name), dir='in', width=32, parent_sig=True)
-                        axi4lite_wrapper.add_port('axi4lite_%s_%s_in_we'    %(key, reg.name), '%s_in_we_%s'              %(self.design_name, reg.name), dir='in',  width=1)
-                        # add signals
-                        axi4lite_wrapper.add_assign('axi4lite_%s_in.%s'     %(key, reg.name), 'axi4lite_%s_%s_in'     %(key, reg.name))
-                        axi4lite_wrapper.add_assign('axi4lite_%s_in_we.%s'  %(key, reg.name), 'axi4lite_%s_%s_in_we'  %(key, reg.name))
+                   else:
+                      if (reg.mode == "rw"):
+                         # add ports
+                         axi4lite_wrapper.add_port('axi4lite_%s_%s_out'      %(key, reg.name), '%s_out_%s_user_data_in'    %(self.design_name, reg.name), dir='out', width=32, parent_sig=True)
+                         axi4lite_wrapper.add_port('axi4lite_%s_%s_out_we'   %(key, reg.name), '%s_out_we_%s'              %(self.design_name, reg.name), dir='out',   width=1)
+                         # add signals
+                         axi4lite_wrapper.add_assign('axi4lite_%s_%s_out'    %(key, reg.name), 'axi4lite_%s_out.%s'    %(key, reg.name))
+                         axi4lite_wrapper.add_assign('axi4lite_%s_%s_out_we' %(key, reg.name), 'axi4lite_%s_out_we.%s' %(key, reg.name))
+                      if (reg.mode == "r"):
+                         # add ports
+                         axi4lite_wrapper.add_port('axi4lite_%s_%s_in'       %(key, reg.name), '%s_in_%s_user_data_in'    %(self.design_name, reg.name), dir='in', width=32, parent_sig=True)
+                         axi4lite_wrapper.add_port('axi4lite_%s_%s_in_we'    %(key, reg.name), '%s_in_we_%s'              %(self.design_name, reg.name), dir='in',  width=1)
+                         # add signals
+                         axi4lite_wrapper.add_assign('axi4lite_%s_in.%s'     %(key, reg.name), 'axi4lite_%s_%s_in'     %(key, reg.name))
+                         axi4lite_wrapper.add_assign('axi4lite_%s_in_we.%s'  %(key, reg.name), 'axi4lite_%s_%s_in_we'  %(key, reg.name))
 
         # add signals for the axi4lite interfaces
         axi4lite_wrapper.add_signal('axi4lite_mosi_arr', 't_axi4lite_mosi_arr(0 to c_axi4lite_mmap_nof_slave-1)')
@@ -164,13 +215,14 @@ class axi4lite_interconnect(YellowBlock):
         for key, val in list(self.memory_map.items()):
             # for reg in val["memory_map"]:
             #     if reg.ram==True:
-            if val['memory_map'][-1].ram==True:
-                pass
-            else:
-                axi4lite_wrapper.add_signal('axi4lite_%s_in_we'  %key, 't_axi4lite_%s_decoded' %key)
-                axi4lite_wrapper.add_signal('axi4lite_%s_in'     %key, 't_axi4lite_%s'         %key)
-                axi4lite_wrapper.add_signal('axi4lite_%s_out_we' %key, 't_axi4lite_%s_decoded' %key)
-                axi4lite_wrapper.add_signal('axi4lite_%s_out'    %key, 't_axi4lite_%s'         %key)
+            if val['memory_map'][-1].axi4lite_mode != 'raw':
+               if val['memory_map'][-1].ram==True:
+                  pass
+               else:
+                  axi4lite_wrapper.add_signal('axi4lite_%s_in_we'  %key, 't_axi4lite_%s_decoded' %key)
+                  axi4lite_wrapper.add_signal('axi4lite_%s_in'     %key, 't_axi4lite_%s'         %key)
+                  axi4lite_wrapper.add_signal('axi4lite_%s_out_we' %key, 't_axi4lite_%s_decoded' %key)
+                  axi4lite_wrapper.add_signal('axi4lite_%s_out'    %key, 't_axi4lite_%s'         %key)
 
         # ports for interconnect instance
         self.ic_ports = []
@@ -187,34 +239,35 @@ class axi4lite_interconnect(YellowBlock):
         # ports for devices
         for key, val in list(self.memory_map.items()):
             #if reg.ram==True:
-            if val['memory_map'][-1].ram==True:
-                self.ic_ports = []
-                self.ic_ports.append(Port('axi4lite_aclk',             'axi4lite_aclk'))
-                self.ic_ports.append(Port('axi4lite_aresetn',          'axi4lite_aresetn'))
-                self.ic_ports.append(Port('axi4lite_mosi',             'axi4lite_mosi_arr(axi4lite_mmap_get_id(id_%s))' %key))
-                self.ic_ports.append(Port('axi4lite_miso',             'axi4lite_miso_arr(axi4lite_mmap_get_id(id_%s))' %key))
-                self.ic_ports.append(Port('%s_%s_add'  %(key, key), 'axi4lite_%s_%s_add'                                %(key, key)))
-                self.ic_ports.append(Port('%s_%s_wdat' %(key, key), 'axi4lite_%s_%s_data_in'                            %(key, key)))
-                self.ic_ports.append(Port('%s_%s_rdat' %(key, key), 'axi4lite_%s_%s_data_out'                           %(key, key)))
-                self.ic_ports.append(Port('%s_%s_clk'  %(key, key), 'axi4lite_%s_%s_clk'                                %(key, key)))
-                self.ic_ports.append(Port('%s_%s_en'   %(key, key), 'axi4lite_%s_%s_en'                                 %(key, key)))
-                self.ic_ports.append(Port('%s_%s_we'   %(key, key), 'axi4lite_%s_%s_we'                                 %(key, key)))
+            if val['memory_map'][-1].axi4lite_mode !='raw':
+               if val['memory_map'][-1].ram==True:
+                  self.ic_ports = []
+                  self.ic_ports.append(Port('axi4lite_aclk',             'axi4lite_aclk'))
+                  self.ic_ports.append(Port('axi4lite_aresetn',          'axi4lite_aresetn'))
+                  self.ic_ports.append(Port('axi4lite_mosi',             'axi4lite_mosi_arr(axi4lite_mmap_get_id(id_%s))' %key))
+                  self.ic_ports.append(Port('axi4lite_miso',             'axi4lite_miso_arr(axi4lite_mmap_get_id(id_%s))' %key))
+                  self.ic_ports.append(Port('%s_%s_add'  %(key, key), 'axi4lite_%s_%s_add'                                %(key, key)))
+                  self.ic_ports.append(Port('%s_%s_wdat' %(key, key), 'axi4lite_%s_%s_data_in'                            %(key, key)))
+                  self.ic_ports.append(Port('%s_%s_rdat' %(key, key), 'axi4lite_%s_%s_data_out'                           %(key, key)))
+                  self.ic_ports.append(Port('%s_%s_clk'  %(key, key), 'axi4lite_%s_%s_clk'                                %(key, key)))
+                  self.ic_ports.append(Port('%s_%s_en'   %(key, key), 'axi4lite_%s_%s_en'               %(key, key)))
+                  self.ic_ports.append(Port('%s_%s_we'   %(key, key), 'axi4lite_%s_%s_we'                                 %(key, key)))
 
-                # add interconnect instance
-                axi4lite_wrapper.add_instance('axi4lite_%s_inst'%key, 'entity xil_defaultlib.axi4lite_%s'%key, self.ic_ports)
-            else:
-                self.ic_ports = []
-                self.ic_ports.append(Port('axi4lite_aclk', 'axi4lite_aclk'))
-                self.ic_ports.append(Port('axi4lite_aresetn', 'axi4lite_aresetn'))
-                self.ic_ports.append(Port('axi4lite_mosi', 'axi4lite_mosi_arr(axi4lite_mmap_get_id(id_%s))'%key))
-                self.ic_ports.append(Port('axi4lite_miso', 'axi4lite_miso_arr(axi4lite_mmap_get_id(id_%s))'%key))
-                self.ic_ports.append(Port('axi4lite_%s_in_we'%key,  'axi4lite_%s_in_we'%key))
-                self.ic_ports.append(Port('axi4lite_%s_in'%key,     'axi4lite_%s_in'%key))
-                self.ic_ports.append(Port('axi4lite_%s_out_we'%key, 'axi4lite_%s_out_we'%key))
-                self.ic_ports.append(Port('axi4lite_%s_out'%key,    'axi4lite_%s_out'%key))
+                  # add interconnect instance
+                  axi4lite_wrapper.add_instance('axi4lite_%s_inst'%key, 'entity xil_defaultlib.axi4lite_%s'%key, self.ic_ports)
+               else:
+                  self.ic_ports = []
+                  self.ic_ports.append(Port('axi4lite_aclk', 'axi4lite_aclk'))
+                  self.ic_ports.append(Port('axi4lite_aresetn', 'axi4lite_aresetn'))
+                  self.ic_ports.append(Port('axi4lite_mosi', 'axi4lite_mosi_arr(axi4lite_mmap_get_id(id_%s))'%key))
+                  self.ic_ports.append(Port('axi4lite_miso', 'axi4lite_miso_arr(axi4lite_mmap_get_id(id_%s))'%key))
+                  self.ic_ports.append(Port('axi4lite_%s_in_we'%key,  'axi4lite_%s_in_we'%key))
+                  self.ic_ports.append(Port('axi4lite_%s_in'%key,     'axi4lite_%s_in'%key))
+                  self.ic_ports.append(Port('axi4lite_%s_out_we'%key, 'axi4lite_%s_out_we'%key))
+                  self.ic_ports.append(Port('axi4lite_%s_out'%key,    'axi4lite_%s_out'%key))
 
-                # add interconnect instance
-                axi4lite_wrapper.add_instance('axi4lite_%s_inst'%key, 'entity xil_defaultlib.axi4lite_%s'%key, self.ic_ports)
+                  # add interconnect instance
+                  axi4lite_wrapper.add_instance('axi4lite_%s_inst'%key, 'entity xil_defaultlib.axi4lite_%s'%key, self.ic_ports)
 
         # TODO: only generate signals for in or out not both 
         # This should depend on the r/wr values of the registers
@@ -224,8 +277,7 @@ class axi4lite_interconnect(YellowBlock):
 
 
         # add assignments
-        axi4lite_wrapper.add_assign('s_axi4lite_arready',  'axi4lite_miso.arready')
-        axi4lite_wrapper.add_assign('s_axi4lite_arready', 'axi4lite_miso.arready')
+        axi4lite_wrapper.add_assign('s_axi4lite_arready',  'axi4lite_miso.arready')      
         axi4lite_wrapper.add_assign('s_axi4lite_awready', 'axi4lite_miso.awready')
         axi4lite_wrapper.add_assign('s_axi4lite_bresp', 'axi4lite_miso.bresp')
         axi4lite_wrapper.add_assign('s_axi4lite_bvalid', 'axi4lite_miso.bvalid')
@@ -242,7 +294,29 @@ class axi4lite_interconnect(YellowBlock):
         axi4lite_wrapper.add_assign('axi4lite_mosi.rready', 's_axi4lite_rready') 
         axi4lite_wrapper.add_assign('axi4lite_mosi.wdata', 's_axi4lite_wdata')
         axi4lite_wrapper.add_assign('axi4lite_mosi.wstrb', 's_axi4lite_wstrb')  
-        axi4lite_wrapper.add_assign('axi4lite_mosi.wvalid', 's_axi4lite_wvalid')  
+        axi4lite_wrapper.add_assign('axi4lite_mosi.wvalid', 's_axi4lite_wvalid') 
+        # add raw axi assignments
+        for key, val in list(self.memory_map.items()):
+            for reg in val["memory_map"]:
+                if reg.axi4lite_mode=='raw':
+                   axi4lite_wrapper.add_assign('axi4lite_miso_arr(axi4lite_mmap_get_id(id_%s)).arready' %reg.name, 'm_axi4lite_%s_arready' %reg.name)
+                   axi4lite_wrapper.add_assign('axi4lite_miso_arr(axi4lite_mmap_get_id(id_%s)).awready' %reg.name, 'm_axi4lite_%s_awready' %reg.name)
+                   axi4lite_wrapper.add_assign('axi4lite_miso_arr(axi4lite_mmap_get_id(id_%s)).bresp' %reg.name, 'm_axi4lite_%s_bresp' %reg.name)
+                   axi4lite_wrapper.add_assign('axi4lite_miso_arr(axi4lite_mmap_get_id(id_%s)).bvalid' %reg.name, 'm_axi4lite_%s_bvalid' %reg.name)
+                   axi4lite_wrapper.add_assign('axi4lite_miso_arr(axi4lite_mmap_get_id(id_%s)).rdata' %reg.name, 'm_axi4lite_%s_rdata' %reg.name)
+                   axi4lite_wrapper.add_assign('axi4lite_miso_arr(axi4lite_mmap_get_id(id_%s)).rresp' %reg.name, 'm_axi4lite_%s_rresp' %reg.name)
+                   axi4lite_wrapper.add_assign('axi4lite_miso_arr(axi4lite_mmap_get_id(id_%s)).rvalid' %reg.name, 'm_axi4lite_%s_rvalid' %reg.name)
+                   axi4lite_wrapper.add_assign('axi4lite_miso_arr(axi4lite_mmap_get_id(id_%s)).wready' %reg.name, 'm_axi4lite_%s_wready' %reg.name) 
+
+                   axi4lite_wrapper.add_assign('m_axi4lite_%s_araddr' %reg.name, 'axi4lite_mosi_arr(axi4lite_mmap_get_id(id_%s)).araddr' %reg.name)
+                   axi4lite_wrapper.add_assign('m_axi4lite_%s_arvalid' %reg.name, 'axi4lite_mosi_arr(axi4lite_mmap_get_id(id_%s)).arvalid' %reg.name)
+                   axi4lite_wrapper.add_assign('m_axi4lite_%s_awaddr' %reg.name, 'axi4lite_mosi_arr(axi4lite_mmap_get_id(id_%s)).awaddr' %reg.name)
+                   axi4lite_wrapper.add_assign('m_axi4lite_%s_awvalid' %reg.name, 'axi4lite_mosi_arr(axi4lite_mmap_get_id(id_%s)).awvalid' %reg.name)
+                   axi4lite_wrapper.add_assign('m_axi4lite_%s_bready' %reg.name, 'axi4lite_mosi_arr(axi4lite_mmap_get_id(id_%s)).bready' %reg.name)
+                   axi4lite_wrapper.add_assign('m_axi4lite_%s_rready' %reg.name, 'axi4lite_mosi_arr(axi4lite_mmap_get_id(id_%s)).rready' %reg.name)
+                   axi4lite_wrapper.add_assign('m_axi4lite_%s_wdata' %reg.name, 'axi4lite_mosi_arr(axi4lite_mmap_get_id(id_%s)).wdata' %reg.name)
+                   axi4lite_wrapper.add_assign('m_axi4lite_%s_wstrb' %reg.name, 'axi4lite_mosi_arr(axi4lite_mmap_get_id(id_%s)).wstrb' %reg.name)
+                   axi4lite_wrapper.add_assign('m_axi4lite_%s_wvalid' %reg.name, 'axi4lite_mosi_arr(axi4lite_mmap_get_id(id_%s)).wvalid' %reg.name) 
         return {'axi4lite_ic_wrapper.vhdl': axi4lite_wrapper.gen_code()}
         # instantiate wrapper and add relevant ports
         # expose AXI4-Lite interface to connected to processor


### PR DESCRIPTION
A memory map attribute, axi4lite_mode = 'raw' is introduced for raw axi4lite
devices. Committed files are updated to create the raw axi4lite interface.