### PR TITLE
bugfix: PFB FIR coefficients not symmetric

### DIFF
--- a/casper_library/pfb_coeff_gen_calc.m
+++ b/casper_library/pfb_coeff_gen_calc.m
@@ -63,13 +63,13 @@ else
         end
     end
     try
-        total_coeffs = windowval .* sinc(fwidth * ([0:alltaps-1]/(2^PFBSize)-TotalTaps/2));
+        total_coeffs = windowval .* sinc(fwidth * ([0.5:1:alltaps-0.5]/(2^PFBSize)-TotalTaps/2));
     catch err
         switch err.identifier
             case 'MATLAB:UndefinedFunction'
                 warning('sinc function undefined in MATLAB. Attempting to use python variant')
                 try
-                    total_coeffs = windowval .* cellfun(@double, cell(py.window.sinc(py.list(fwidth * ([0:alltaps-1]/(2^PFBSize)-TotalTaps/2)))));
+                    total_coeffs = windowval .* cellfun(@double, cell(py.window.sinc(py.list(fwidth * ([0.5:alltaps-0.5]/(2^PFBSize)-TotalTaps/2)))));
                 catch
                     error('Python call to sinc() failed!')
                 end

--- a/casper_library/pfb_fir_coeff_gen_init.m
+++ b/casper_library/pfb_fir_coeff_gen_init.m
@@ -108,10 +108,10 @@ function pfb_fir_coeff_gen_init(blk, varargin)
   %%%%%%%%%%%%%%%%%
 
   reuse_block(blk, 'sync', 'built-in/Inport', 'Port', '1', 'Position', [15 23 45 37]);
-  reuse_block(blk, 'sync_delay', 'xbsIndex_r4/Delay', 'reg_retiming', 'on', ...
-    'latency', num2str(fan_latency+bram_latency+1), 'Position', [255 22 1035 38]);
+  reuse_block(blk, 'sync_delay', 'xbsIndex_r4/Delay', 'reg_retiming', 'on', ...	  
+    'latency', num2str(fan_latency+bram_latency), 'Position', [255 22 670 38]);
   add_line(blk,'sync/1', 'sync_delay/1');
-  reuse_block(blk, 'sync_out', 'built-in/Outport', 'Port', '1', 'Position', [1185 23 1215 37]);
+  reuse_block(blk, 'sync_out', 'built-in/Outport', 'Port', '1', 'Position', [755 23 785 37]);
   add_line(blk,'sync_delay/1', 'sync_out/1');
  
   %%%%%%%%%%%%%%%%
@@ -120,9 +120,9 @@ function pfb_fir_coeff_gen_init(blk, varargin)
 
   reuse_block(blk, 'din', 'built-in/Inport', 'Port', '2', 'Position', [15 68 45 82]);
   reuse_block(blk, 'din_delay', 'xbsIndex_r4/Delay', 'reg_retiming', 'on',...
-    'latency', num2str(fan_latency+bram_latency+1), 'Position', [255 67 1035 83]);
+    'latency', num2str(fan_latency+bram_latency), 'Position', [255 67 670 83]);
   add_line(blk, 'din/1', 'din_delay/1');
-  reuse_block(blk, 'dout', 'built-in/Outport', 'Port', '2', 'Position', [1185 68 1215 82]);
+  reuse_block(blk, 'dout', 'built-in/Outport', 'Port', '2', 'Position', [755 68 785 82]);
   add_line(blk,'din_delay/1', 'dout/1');
 
   %%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -191,122 +191,28 @@ function pfb_fir_coeff_gen_init(blk, varargin)
   add_line(blk, 'rom_we/1', 'rom/6');
 
   % logic for second half of taps 
-  % Coefficients are not quite symmetrical, they are off by one, and do not overlap by one
-  % e.g with T taps and fft size of N: tap T-1, sample 0 is not the same as tap 0, sample N-1
-  % instead it is unique and not included in the coefficients for Tap 0
-
-  reuse_block(blk, 'zero', 'xbsIndex_r4/Constant', ...
-        'const', '0', 'arith_type', 'Unsigned', ...
-        'n_bits', num2str(pfb_size-n_inputs), 'bin_pt', '0', ...
-        'explicit_period', 'on', 'period', '1', ...
-        'Position', [185 122 205 138]);
-  
-  reuse_block(blk, 'first', 'xbsIndex_r4/Relational' , ...
-        'latency', num2str(fan_latency), 'mode', 'a=b', 'Position', [255 114 285 176]);
-  add_line(blk, 'counter/1', 'first/2');
-  add_line(blk, 'zero/1', 'first/1');
-  
-  reuse_block(blk, 'dfirst', 'xbsIndex_r4/Delay', 'reg_retiming', 'on', ...
-    'latency', num2str(bram_latency), 'Position', [385 136 925 154] );
-  add_line(blk, 'first/1', 'dfirst/1');
 
   % reorder output of port B 
-  order = zeros(1, n_taps/2 * 2^n_inputs);
-  for tap_index = 0:n_taps/2-1,
-    for input_index = 0:2^n_inputs-1,
-      offset = ((n_taps/2)-tap_index-1) * (2^n_inputs);
-      if input_index == 0, index = offset;
-      else, index = offset + (2^n_inputs - input_index);
-      end
-    
-      order(tap_index*(2^n_inputs) + input_index + 1) = index;
-    end %for
-  end %for
-
+  order = [2^n_inputs*n_taps/2-1:-1:0];	
+  
   reuse_block(blk, 'munge', 'casper_library_flow_control/munge', ...
     'divisions', num2str(outputs_required), ...
     'div_size', mat2str(repmat(n_bits_coeff, 1, outputs_required)), ...
     'order', mat2str(order), 'arith_type_out', 'Unsigned', 'bin_pt_out', '0', ... 
     'Position', [435 377 475 403] );
   add_line(blk, 'rom/2', 'munge/1');
-  
-  % coefficient extraction
-  reuse_block(blk, 'a_expand', 'casper_library_flow_control/bus_expand', ...
-    'mode', 'divisions of equal size', 'outputNum', num2str(outputs_required), ...
-    'outputWidth', num2str(n_bits_coeff), 'outputBinaryPt', '0', 'outputArithmeticType', '0', ...
-    'Position', [620 yoff 670 yoff+(outputs_required*yinc)]);
-  add_line(blk, 'rom/1', 'a_expand/1');
-  
-  reuse_block(blk, 'b_expand', 'casper_library_flow_control/bus_expand', ...
-    'mode', 'divisions of equal size', 'outputNum', num2str(outputs_required), ...
-    'outputWidth', num2str(n_bits_coeff), 'outputBinaryPt', '0', 'outputArithmeticType', '0', ...
-    'Position', [515 yoff+(outputs_required*yinc) 565 yoff+(outputs_required*yinc*2)]);
-  add_line(blk, 'munge/1', 'b_expand/1');
 
   reuse_block(blk, 'coeffs', 'built-in/Outport', 'Port', '3', ...
-    'Position', [1185 yoff+outputs_required*yinc-7 1215 yoff+outputs_required*yinc+7]);
+    'Position', [755 323 785 337]);
 
   % concat a and b busses together
   reuse_block(blk, 'concat', 'xbsIndex_r4/Concat', ...
-    'num_inputs', num2str(outputs_required*2), ...
-    'Position', [1095 yoff 1120 yoff+(outputs_required*2*yinc)]); 
+    'num_inputs', '2', ...
+    'Position', [645 210 670 450]); 
   add_line(blk, 'concat/1', 'coeffs/1');
 
-  % delays for each output
-  for d_index = 0:outputs_required*2-1,
-    src_port = mod(d_index, outputs_required) + 1;
-    d_name = ['d',num2str(d_index)];
-
-    if ((d_index/outputs_required) < 1),
-      reuse_block(blk, d_name, 'xbsIndex_r4/Delay', ...
-        'latency', '1', 'reg_retiming', 'on', ...
-        'Position', [980 yoff+d_index*yinc 1035 yoff+d_index*yinc+18]);
-
-      src_blk = 'a_expand';
-      add_line(blk, [src_blk, '/', num2str(src_port)], [d_name, '/1']);
-    else,
-      %if first element of coefficients for tap, need to choose a special first value
-      if mod(d_index, 2^n_inputs) == 0,
-        reuse_block(blk, d_name, 'xbsIndex_r4/Delay', ...
-          'latency', '1', 'reg_retiming', 'on', 'en', async, ...
-          'Position', [745 yoff+d_index*yinc 800 yoff+d_index*yinc+18]);
-
-        add_line(blk, ['b_expand/', num2str(src_port)], [d_name, '/1']);
-
-        offset = d_index - outputs_required;
-        vector = pfb_coeff_gen_calc(pfb_size, n_taps, WindowType, n_inputs, 0, fwidth, n_taps/2+1+offset/(2^n_inputs), false);
-        m_name = ['mux', num2str(offset/2^n_inputs)];
-        c_name = ['const',num2str(offset/2^n_inputs)];
-        r_name = ['reinterpret',num2str(offset/2^n_inputs)];
-        reuse_block(blk, c_name, 'xbsIndex_r4/Constant', ...
-          'const', num2str(vector(1)), 'explicit_period', 'on', 'period', '1', ...
-          'arith_type', 'Signed (2''s comp)', 'n_bits', num2str(n_bits_coeff), 'bin_pt', num2str(n_bits_coeff-1), ...
-          'Position', [620 yoff+(d_index*yinc)+20 740 yoff+(d_index*yinc)+40]);
-        reuse_block(blk, r_name, 'xbsIndex_r4/Reinterpret', ...
-          'force_arith_type', 'on', 'arith_type', 'Unsigned', ...
-          'force_bin_pt', 'on', 'bin_pt', '0', ...
-          'Position', [840 yoff+(d_index*yinc)+20 890 yoff+(d_index*yinc)+40]);
-        reuse_block(blk, m_name, 'xbsIndex_r4/Mux', ...
-          'latency', '1', 'inputs', '2', ...
-          'Position', [980 yoff+(d_index*yinc)-10 1035 yoff+(d_index*yinc)+25]);
-	add_line(blk, [c_name,'/1'], [r_name, '/1']);
-	add_line(blk, [r_name,'/1'], [m_name, '/3']);
-    	add_line(blk, 'dfirst/1', [m_name,'/1']);    
-        add_line(blk, [d_name, '/1'], [m_name, '/2']);
-        
-	d_name = m_name;
-      else,
-        reuse_block(blk, d_name, 'xbsIndex_r4/Delay', ...
-          'latency', '1', 'reg_retiming', 'on', ...
-          'Position', [980 yoff+d_index*yinc 1035 yoff+d_index*yinc+18]);
-
-        src_blk = 'b_expand';
-        add_line(blk, [src_blk, '/', num2str(src_port)], [d_name, '/1']);
-      end
-    end
-    add_line(blk, [d_name,'/1'], ['concat/',num2str(d_index+1)]);    
-
-  end %for 
+  add_line(blk, 'rom/1', 'concat/1');
+  add_line(blk, 'munge/1', 'concat/2');
   
   % asynchronous pipeline
   if strcmp(async, 'on'),
@@ -318,22 +224,12 @@ function pfb_fir_coeff_gen_init(blk, varargin)
  
     reuse_block(blk, 'den0', 'xbsIndex_r4/Delay', 'reg_retiming', 'on', ...
       'latency', num2str(fan_latency+bram_latency), ...
-      'Position', [255 yoff+(outputs_required*2+2)*yinc 670 yoff+(outputs_required*2+2)*yinc+18]);
+      'Position', [255 546 670 564]);
     add_line(blk, 'en/1', 'den0/1');
-          
-    for n = n_taps/2:n_taps-1,
-      add_line(blk, 'den0/1', ['d', num2str(n*2^n_inputs), '/2']);
-    end
-    
-    reuse_block(blk, 'den1', 'xbsIndex_r4/Delay', 'reg_retiming', 'on', ...
-      'latency', '1', ...
-      'Position', [980 yoff+(outputs_required*2+2)*yinc 1035 yoff+(outputs_required*2+2)*yinc+18]);
-    add_line(blk, 'den0/1', 'den1/1');
     
     reuse_block(blk, 'dvalid', 'built-in/Outport', 'Port', '4', ...
-      'Position', [1185 yoff+(outputs_required*2+2)*yinc+2 1215 yoff+(outputs_required*2+2)*yinc+16]);
-    add_line(blk, 'den1/1', 'dvalid/1');
-
+      'Position', [755 548 785 562]);
+    add_line(blk, 'den0/1', 'dvalid/1');
   end %if async
 
   clean_blocks(blk);


### PR DESCRIPTION
The window coefficients for the PFB FIR were not quite symmetric and were off by half.

This was previously thought to be intentional, and extra logic was required to allow only half the coefficients to be stored, but for them to be output asymmetrically.

This has been fixed so that coefficients are now symmetric. This required removal of this extra logic (that should improve timing andreduce resource use), and a change in the generation logic so that the coefficients are symmetric (this should improve PFB channel response in a small way).

This change should be backwards compatible i.e no changes to existing designs should be required.